### PR TITLE
Test suites + Home Assistant embedding fixes

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -344,6 +344,35 @@ html, body, #root {
   background-color: rgba(255, 140, 0, 0.1);
 }
 
+/* Tight desktop screens (e.g. iPad landscape, Home Assistant embedded iframe):
+   drop the "Smart Home Health" wordmark to just the logo icon, and let the menu
+   icon row flow into the full width between the logo and the clock instead of
+   being boxed into the rigid centre 50%. Below 769px the mobile header (with the
+   hamburger) takes over, so this only targets the cramped desktop range. */
+@media (min-width: 769px) and (max-width: 1150px) {
+  .logo-text {
+    display: none;
+  }
+  .logo-container {
+    width: auto;
+    flex: 0 0 auto;
+    justify-content: flex-start;
+    padding-left: 12px;
+  }
+  .datetime-container {
+    width: auto;
+    flex: 0 0 auto;
+    padding: 0 12px;
+  }
+  .menu-container {
+    position: static;
+    left: auto;
+    right: auto;
+    flex: 1 1 auto;
+    gap: clamp(8px, 2vw, 25px);
+  }
+}
+
 .icon-wrapper {
   position: relative;
   display: flex;
@@ -837,6 +866,20 @@ html, body, #root {
 .perfusion .unit,
 .perfusion .value-stats {
   color: #EF6C00; /* Orange for Perfusion */
+}
+
+/* Tight desktop screens (iPad landscape / embedded iframe): scale the large
+   vital readouts down so they don't overflow the card or collide with the
+   rotated title. Placed AFTER the base .value/.unit rules above so it wins on
+   source order (same specificity). */
+@media (min-width: 769px) and (max-width: 1150px) {
+  .value {
+    font-size: 3.5rem;
+  }
+  .unit {
+    font-size: 1.1rem;
+    margin-top: 8px;
+  }
 }
 
 /* Update ClockCard to work in the header */

--- a/frontend/src/components/DynamicVitalsCard.jsx
+++ b/frontend/src/components/DynamicVitalsCard.jsx
@@ -311,24 +311,8 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
         }}
         onClick={() => setIsFlipped(true)}
         >
-          {/* Quick-add button (skip if no patient context) */}
-          {patientId && (
-            <button
-              type="button"
-              onClick={(e) => { e.stopPropagation(); setQuickAddOpen(true); }}
-              title={`Add ${displayTitle}`}
-              aria-label={`Add ${displayTitle}`}
-              style={{
-                position: 'absolute', top: 6, right: 6, zIndex: 5,
-                width: 28, height: 28, borderRadius: '50%',
-                border: '1px solid rgba(255,255,255,0.18)',
-                background: 'rgba(0,0,0,0.45)',
-                color: '#fff', cursor: 'pointer',
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                fontSize: 18, lineHeight: 1, fontWeight: 600,
-              }}
-            >+</button>
-          )}
+          {/* Quick-add lives on the flipped (details) side, not here — keeps the
+              chart view clean. See the back side below. */}
           <h3 style={{
             color: vitalType === 'bathroom' && primaryGroup ?
               getChartColor(vitalType, primaryGroup) :
@@ -537,7 +521,29 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
               </tbody>
             </table>
           </div>
-          
+
+          {/* Quick-add button — only on the details side, at the bottom.
+              backfaceVisibility:hidden keeps it from bleeding onto the front. */}
+          {patientId && (
+            <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 4 }}>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); setQuickAddOpen(true); }}
+                title={`Add ${displayTitle}`}
+                aria-label={`Add ${displayTitle}`}
+                style={{
+                  backfaceVisibility: 'hidden',
+                  width: 30, height: 30, borderRadius: '50%',
+                  border: '1px solid rgba(255,255,255,0.18)',
+                  background: 'rgba(0,0,0,0.45)',
+                  color: '#fff', cursor: 'pointer',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 18, lineHeight: 1, fontWeight: 600,
+                }}
+              >+</button>
+            </div>
+          )}
+
           {/* Click hint */}
           <div style={{
             textAlign: 'center',

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1367,7 +1367,7 @@ export default function Dashboard() {
                 <DynamicVitalsCard
                   vitalType={dashboardChart1.vital_type}
                   data={dashboardChart1.data}
-                  title={`Chart 1: ${formatVitalDisplayName(dashboardChart1.vital_type)} History`}
+                  title={formatVitalDisplayName(dashboardChart1.vital_type)}
                   patientId={selectedPatient?.id}
                   chrome={chartChrome}
                   onSaved={() => fetchChartData(dashboardChart1.vital_type, 1)}
@@ -1378,7 +1378,7 @@ export default function Dashboard() {
                 <DynamicVitalsCard
                   vitalType={dashboardChart2.vital_type}
                   data={dashboardChart2.data}
-                  title={`Chart 2: ${formatVitalDisplayName(dashboardChart2.vital_type)} History`}
+                  title={formatVitalDisplayName(dashboardChart2.vital_type)}
                   patientId={selectedPatient?.id}
                   chrome={chartChrome}
                   onSaved={() => fetchChartData(dashboardChart2.vital_type, 2)}

--- a/frontend/src/pages/admin-v2/AdminV2.css
+++ b/frontend/src/pages/admin-v2/AdminV2.css
@@ -1066,6 +1066,45 @@
   color: var(--muted-foreground);
 }
 
+/* Tablet / embedded iPad (above the 768px mobile cutoff but still tight): the
+   full-size summary cards wrap into two rows and eat vertical space above the
+   patient list. Condense them into a single compact row of four (icon + value
+   stacked, smaller label kept). The ≤768px mobile block below handles phones. */
+@media (min-width: 769px) and (max-width: 1150px) {
+  .admin-v2-dashboard .admin-v2-summary-stats {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  .admin-v2-dashboard .admin-v2-summary-stats .admin-v2-stat-card {
+    padding: 0.6rem 0.4rem;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.3rem;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+  .admin-v2-dashboard .admin-v2-summary-stats .admin-v2-stat-icon {
+    width: 36px;
+    height: 36px;
+  }
+  .admin-v2-dashboard .admin-v2-summary-stats .admin-v2-stat-icon svg {
+    width: 20px;
+    height: 20px;
+  }
+  .admin-v2-dashboard .admin-v2-summary-stats .admin-v2-stat-info h4 {
+    margin: 0;
+    font-size: 1.2rem;
+    line-height: 1.1;
+  }
+  .admin-v2-dashboard .admin-v2-summary-stats .admin-v2-stat-info p {
+    margin: 0.1rem 0 0 0;
+    font-size: 0.7rem;
+    line-height: 1.1;
+  }
+}
+
 /* Section Header */
 .admin-v2-section-header {
   display: flex;
@@ -4502,6 +4541,56 @@
   max-height: 600px;
   overflow-y: auto;
   overflow-x: hidden;
+}
+
+/* ============================================================
+   App shell (tablet + desktop, >=769px): make .admin-v2-content the SINGLE
+   scroll area so the document itself never scrolls. This keeps the fixed
+   sidebar and any sticky page header pinned in place instead of sliding off the
+   top — the "top nav scrolls away on iPad" problem. Mobile (<769px) keeps its
+   existing document-scroll + sticky date-nav behavior untouched. */
+@media (min-width: 769px) {
+  .admin-v2-main {
+    /* Bound the height (was only min-height) so the child content scrolls
+       instead of the whole page growing. overflow:hidden stops .admin-v2-main
+       itself from becoming a second scroller (its overflow-x:hidden would
+       otherwise compute overflow-y to auto). */
+    height: calc(100vh - var(--vkb-height, 0px));
+    height: calc(100dvh - var(--vkb-height, 0px));
+    overflow: hidden;
+  }
+  .admin-v2-content {
+    min-height: 0; /* allow the flex child to shrink so its overflow engages */
+  }
+
+  /* Schedule: pin the date/nav bar to the top of the scroll area. The stat
+     cards deliberately scroll away (kept off the pinned bar to preserve
+     timeline height on short landscape screens). Collapsing the timeline's
+     inner scroll keeps .admin-v2-content the one and only scroller. */
+  .admin-v2-schedule-nav {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: var(--card);
+    /* No transparent gap under the opaque bar — otherwise rows scrolling past
+       show through the margin. Full-bleed over the content's 1.5rem padding and
+       square off the corners so nothing peeks around the edges. */
+    margin: 0 -1.5rem;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    border-top: none;
+    padding: 1rem 1.5rem;
+  }
+  /* The timeline column header is sticky top:0 too, which pinned it *behind*
+     the date bar (the "TIME / MEDICATIONS / NUTRITION" bleed). Let it scroll
+     with the rows so only the date bar stays pinned. */
+  .admin-v2-schedule-header {
+    position: static;
+  }
+  .admin-v2-schedule-body {
+    max-height: none;
+  }
 }
 
 /* Schedule Row */

--- a/frontend/src/utils/authInterceptor.js
+++ b/frontend/src/utils/authInterceptor.js
@@ -43,6 +43,12 @@ const RECOVERY_DEBOUNCE_MS = 1000;
 
 let installed = false;
 
+// Detect a cross-origin iframe (e.g. Home Assistant embedding). Same idiom as
+// config.js (_isIframe) and AuthContext (isIframe). Computed once at load.
+const isIframe = (() => {
+  try { return window.self !== window.top; } catch { return true; }
+})();
+
 // Pull the path out of whatever the first fetch() arg is (string, URL, Request).
 function getRequestPath(input) {
   try {
@@ -51,6 +57,53 @@ function getRequestPath(input) {
   } catch {
     return '';
   }
+}
+
+// True only for same-origin requests, so we never attach the auth token to an
+// external host.
+function isSameOrigin(input) {
+  try {
+    const url = typeof input === 'string' ? input : input?.url ?? String(input);
+    return new URL(url, window.location.origin).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+// True if the caller already set an Authorization header (authFetch/apiFetch do),
+// so we don't clobber it. Handles plain-object and Headers-instance init.headers.
+function hasAuthHeader(init) {
+  const headers = init?.headers;
+  if (!headers) return false;
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    return headers.has('Authorization');
+  }
+  return Object.keys(headers).some((k) => k.toLowerCase() === 'authorization');
+}
+
+// In a cross-origin iframe the SameSite session cookies are blocked, so attach
+// the stored JWT as a Bearer header for same-origin requests. Returns possibly
+// new fetch args; leaves args untouched outside the iframe (cookie auth path).
+// Note: only the (url|URL, init) form is handled — Request inputs (which carry
+// their own headers) are not used by this app's data fetches and pass through.
+function withIframeAuth(args) {
+  if (!isIframe) return args;
+  const [input, init] = args;
+  if (input instanceof Request) return args;
+  if (!isSameOrigin(input) || hasAuthHeader(init)) return args;
+
+  const token = sessionStorage.getItem('auth_token');
+  if (!token) return args;
+
+  const nextInit = { ...(init || {}) };
+  if (typeof Headers !== 'undefined' && nextInit.headers instanceof Headers) {
+    const merged = new Headers(nextInit.headers);
+    merged.set('Authorization', `Bearer ${token}`);
+    nextInit.headers = merged;
+  } else {
+    nextInit.headers = { ...nextInit.headers, Authorization: `Bearer ${token}` };
+  }
+  return [input, nextInit];
 }
 
 // Only the AuthenticationMiddleware's rejection carries `requires_auth: true`.
@@ -86,7 +139,9 @@ export function installAuthInterceptor({ getAuthLevel, onStale }) {
   };
 
   window.fetch = async (...args) => {
-    const response = await originalFetch(...args);
+    // Attach the Bearer header when embedded so raw fetch() data calls (which
+    // rely on cookies) still authenticate in a cross-origin iframe.
+    const response = await originalFetch(...withIframeAuth(args));
 
     const path = getRequestPath(args[0]);
     // Never react to the auth endpoints themselves (recovery + public probes).

--- a/frontend/src/utils/authInterceptor.test.js
+++ b/frontend/src/utils/authInterceptor.test.js
@@ -33,15 +33,35 @@ beforeEach(() => {
 
 afterEach(() => {
   window.fetch = originalFetch;
+  sessionStorage.clear();
+  // Restore non-iframe state (some tests redefine window.top).
+  Object.defineProperty(window, 'top', { value: window, configurable: true });
 });
 
 // Install a fresh interceptor on top of a base fetch mock that returns `response`.
-async function install({ response, getAuthLevel, onStale }) {
+// `iframe: true` makes the module detect a cross-origin embedding (window.top
+// differs from window.self) — must be set before the dynamic import since the
+// module reads `isIframe` at load.
+async function install({ response, getAuthLevel, onStale, iframe = false }) {
+  if (iframe) {
+    Object.defineProperty(window, 'top', { value: {}, configurable: true });
+  }
   const base = vi.fn().mockResolvedValue(response);
   window.fetch = base;
   const { installAuthInterceptor } = await import('./authInterceptor');
   installAuthInterceptor({ getAuthLevel, onStale });
   return base;
+}
+
+// Authorization header sent to the base fetch for a given mock call (0-indexed).
+function authHeaderOf(base, callIndex = 0) {
+  const init = base.mock.calls[callIndex]?.[1];
+  const headers = init?.headers;
+  if (!headers) return undefined;
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    return headers.get('Authorization') ?? undefined;
+  }
+  return headers.Authorization;
 }
 
 describe('installAuthInterceptor', () => {
@@ -108,5 +128,73 @@ describe('installAuthInterceptor', () => {
     await install({ response, getAuthLevel: () => 'full', onStale: vi.fn() });
     const out = await window.fetch('http://localhost/api/x');
     expect(out).toBe(response);
+  });
+
+  describe('iframe Bearer injection', () => {
+    it('attaches the stored token for same-origin requests when embedded', async () => {
+      sessionStorage.setItem('auth_token', 'tok123');
+      const base = await install({
+        response: res(200), getAuthLevel: () => 'full', onStale: vi.fn(), iframe: true,
+      });
+
+      await window.fetch(`${window.location.origin}/api/dashboard/summary`);
+      expect(authHeaderOf(base)).toBe('Bearer tok123');
+    });
+
+    it('does NOT attach the token when not in an iframe', async () => {
+      sessionStorage.setItem('auth_token', 'tok123');
+      const base = await install({
+        response: res(200), getAuthLevel: () => 'full', onStale: vi.fn(), iframe: false,
+      });
+
+      await window.fetch(`${window.location.origin}/api/dashboard/summary`);
+      expect(authHeaderOf(base)).toBeUndefined();
+    });
+
+    it('does NOT attach the token when none is stored', async () => {
+      const base = await install({
+        response: res(200), getAuthLevel: () => 'full', onStale: vi.fn(), iframe: true,
+      });
+
+      await window.fetch(`${window.location.origin}/api/dashboard/summary`);
+      expect(authHeaderOf(base)).toBeUndefined();
+    });
+
+    it('does NOT attach the token to cross-origin requests', async () => {
+      sessionStorage.setItem('auth_token', 'tok123');
+      const base = await install({
+        response: res(200), getAuthLevel: () => 'full', onStale: vi.fn(), iframe: true,
+      });
+
+      await window.fetch('https://evil.example.com/steal');
+      expect(authHeaderOf(base)).toBeUndefined();
+    });
+
+    it('does NOT clobber a caller-supplied Authorization header', async () => {
+      sessionStorage.setItem('auth_token', 'tok123');
+      const base = await install({
+        response: res(200), getAuthLevel: () => 'full', onStale: vi.fn(), iframe: true,
+      });
+
+      await window.fetch(`${window.location.origin}/api/x`, {
+        headers: { Authorization: 'Bearer existing' },
+      });
+      expect(authHeaderOf(base)).toBe('Bearer existing');
+    });
+
+    it('merges into an existing init without dropping other options', async () => {
+      sessionStorage.setItem('auth_token', 'tok123');
+      const base = await install({
+        response: res(200), getAuthLevel: () => 'full', onStale: vi.fn(), iframe: true,
+      });
+
+      await window.fetch(`${window.location.origin}/api/x`, {
+        method: 'POST', credentials: 'include',
+      });
+      const init = base.mock.calls[0][1];
+      expect(init.method).toBe('POST');
+      expect(init.credentials).toBe('include');
+      expect(authHeaderOf(base)).toBe('Bearer tok123');
+    });
   });
 });


### PR DESCRIPTION
## Summary
Merges the `dev/tests` branch into `dev/main`. Two main bodies of work:

### Test suites
- Backend pytest suite (Waves 0–6) and frontend Vitest/RTL suite, plus `scripts/run_tests.sh` and GitHub Actions CI.

### Home Assistant embedding fixes (latest commit)
- **iframe auth:** global `window.fetch` interceptor now injects the `Authorization: Bearer` token (from `sessionStorage`) for same-origin requests when embedded in a cross-origin HA iframe — fixes "Failed to fetch dashboard data" / empty patient list. (+6 tests)
- **Responsive live-dashboard header:** drops the wordmark and lets the icon row use full width on tight screens.
- **Vital number scaling** on tight screens (fixed a CSS source-order bug where the override never applied).
- **Side-chart titles** cleaned up (no "Chart 1:" prefix, no duplicated "History").
- **Quick-add `+`** moved to the flipped (details) side of the vitals cards.
- **Admin dashboard** summary cards condensed into one compact row on tablet/iPad.
- **Admin app-shell:** content is now the single scroll area (≥769px) and the schedule date bar is pinned, opaque, with no content bleed-through.

## Test plan
- `cd frontend && npm test` — green (137 tests / 16 files).
- Backend: `scripts/run_tests.sh`.
- Verified the HA fixes live in the embedded iPad/Home Assistant view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)