### PR TITLE
Remove live-camera scanning; keep photo capture and wedge scanner

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -44,9 +44,8 @@ browser over WebSockets and bridges to MQTT / home‑automation systems.
 - **Modern responsive web UI**, accessible from a phone or other LAN device
 - **Home Assistant friendly** — runs behind HA ingress, works embedded in an iframe,
   and publishes state to MQTT. **Accessing the app through HA ingress is the
-  preferred setup**: HA's own HTTPS gives the app a real trusted certificate, so
-  camera features (barcode scanning, packing-slip capture) work on phones with no
-  certificate warnings
+  preferred setup**: HA's own HTTPS gives the app a real trusted certificate with
+  no certificate warnings
 
 ## Integrations
 
@@ -104,16 +103,14 @@ On first launch you'll be guided through admin **first‑run setup**. It also wo
 from a phone or other LAN device (e.g. `http://192.168.1.184:8000`). For publishing
 and deployment details, see [`docs/unified-image.md`](docs/unified-image.md).
 
-> **Want phone camera features (barcode / packing‑slip scanning)? Set up HTTPS.**
-> iOS only exposes the live camera to pages served over HTTPS, so the app ships
-> with a guided setup under **Configuration → Security** (also offered at the end
-> of first‑run). The recommended path gets you a free `*.duckdns.org` name and an
+> **Want an encrypted connection? Set up HTTPS.** The app ships with a guided
+> setup under **Configuration → Security** (also offered at the end of
+> first‑run). The recommended path gets you a free `*.duckdns.org` name and an
 > auto‑renewing Let's Encrypt certificate in ~5 minutes, with no port forwarding;
 > there are also paths for an existing reverse proxy (Traefik/nginx/Caddy) or your
 > own certificate. See [`docs/installation/https-setup.md`](docs/installation/https-setup.md).
 > Home Assistant ingress works too and needs no setup at all. Plain‑HTTP LAN
-> access keeps working for everything except the live camera (photo capture is
-> the automatic fallback).
+> access keeps working either way.
 
 ## Develop it (hot reload)
 
@@ -128,18 +125,9 @@ On startup the stack creates the database, runs Alembic migrations
 (`alembic upgrade head`), and starts both dev servers.
 
 **Access the application:**
-- **Web interface**: https://localhost:5173
+- **Web interface**: http://localhost:5173
 - **API**: http://localhost:8000
 - **API docs (Swagger)**: http://localhost:8000/docs
-
-> **The dev server uses a self‑signed HTTPS certificate — your browser WILL
-> complain. That's expected; it's fine.** Click through the warning
-> ("Advanced → Proceed" / on iOS "Show Details → visit this website") once per
-> device and move on. HTTPS is required because iOS only exposes the live camera
-> (barcode scanning, slip capture) to secure origins, and a self‑signed cert is
-> the zero‑setup way to get there on a LAN. Production installs get warning‑free
-> HTTPS via **Configuration → Security** (DuckDNS + Let's Encrypt, reverse proxy,
-> or your own certificate) — see [`docs/installation/https-setup.md`](docs/installation/https-setup.md).
 
 The web UI works from a phone or other LAN device too (e.g.
 `https://192.168.1.184:5173` — note **https**); it reaches the backend on the same
@@ -164,7 +152,7 @@ docker compose exec backend alembic upgrade head
 ### Initial setup
 
 1. Open the web app (http://localhost:8000 for the single‑image run, or
-   https://localhost:5173 in dev) and sign in (or create the first user).
+   http://localhost:5173 in dev) and sign in (or create the first user).
 2. Add a patient and configure alert thresholds under Settings.
 3. Start recording vitals manually, or connect a device/integration.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,14 +66,10 @@ services:
       - ./frontend:/app
       - /app/node_modules
     # Leave VITE_API_URL unset so the frontend uses same-origin (works from
-    # phone/LAN at e.g. https://192.168.1.184:5173). Vite proxies /api + /ws to
+    # phone/LAN at e.g. http://192.168.1.184:5173). Vite proxies /api + /ws to
     # the backend container (see vite.config.js).
-    # VITE_HTTPS serves dev over self-signed HTTPS — required for the live
-    # camera (barcode viewfinder / slip scanning) on iOS, which only exposes
-    # getUserMedia on secure origins. Accept the cert warning once per device.
     environment:
       VITE_PROXY_TARGET: http://backend:8000
-      VITE_HTTPS: "1"
     depends_on:
       - backend
     networks:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,7 +45,6 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
-        "@vitejs/plugin-basic-ssl": "^2.3.0",
         "@vitejs/plugin-react": "^4.4.1",
         "@vitest/coverage-v8": "^3.2.6",
         "eslint": "^9.25.0",
@@ -3010,19 +3009,6 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
-    },
-    "node_modules/@vitejs/plugin-basic-ssl": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.3.0.tgz",
-      "integrity": "sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,6 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
-    "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-react": "^4.4.1",
     "@vitest/coverage-v8": "^3.2.6",
     "eslint": "^9.25.0",

--- a/frontend/src/components/FirstRunSetup.jsx
+++ b/frontend/src/components/FirstRunSetup.jsx
@@ -139,7 +139,7 @@ export default function FirstRunSetup() {
           <div className="first-run-card">
             <div className="first-run-header">
               <h1>Secure this install</h1>
-              <p>Optional — enables camera scanning on phones and tablets</p>
+              <p>Optional — encrypts connections from phones, tablets, and other devices</p>
             </div>
             <SecuritySetupWizard onFinished={handleContinue} />
             <button

--- a/frontend/src/components/SecuritySetupWizard.jsx
+++ b/frontend/src/components/SecuritySetupWizard.jsx
@@ -121,8 +121,8 @@ const SuccessCard = ({ url, onDone, doneLabel }) => (
         <div className="text-xs uppercase tracking-wide text-muted-foreground">Secure address</div>
         <a href={url} target="_blank" rel="noreferrer" className="text-lg font-semibold text-primary break-all">{url}</a>
         <p className="mt-2 text-sm text-muted-foreground">
-          Use this address on phones and tablets — the camera features need it.
-          You can keep using the regular address for everything else.
+          Use this address anywhere you want the connection encrypted — phones,
+          tablets, or away from home. The regular address keeps working too.
         </p>
       </div>
     )}
@@ -308,9 +308,9 @@ const SecuritySetupWizard = ({ onFinished }) => {
       {step === 'choose' && (
         <div className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            A secure (HTTPS) address lets phones and tablets use the camera for
-            barcode and document scanning, and keeps your connection encrypted.
-            Pick the option that fits:
+            A secure (HTTPS) address keeps your connection encrypted, so health
+            data never crosses the network in the clear. Pick the option that
+            fits:
           </p>
           <PathCard
             icon={ShieldIcon}

--- a/frontend/src/lib/slipScanner.js
+++ b/frontend/src/lib/slipScanner.js
@@ -132,11 +132,10 @@ export function attachLineImages(items, ocrLines, canvas) {
 
 function toCanvas(source) {
   if (source instanceof HTMLCanvasElement) return source;
-  // Video frame or image element -> draw onto a canvas so every decoder
-  // gets the same input (ZXing has no one-shot video API).
+  // Image element -> draw onto a canvas so every decoder gets the same input.
   const canvas = document.createElement('canvas');
-  canvas.width = source.videoWidth || source.naturalWidth || source.width;
-  canvas.height = source.videoHeight || source.naturalHeight || source.height;
+  canvas.width = source.naturalWidth || source.width;
+  canvas.height = source.naturalHeight || source.height;
   canvas.getContext('2d').drawImage(source, 0, 0, canvas.width, canvas.height);
   return canvas;
 }
@@ -190,7 +189,7 @@ async function zxingDecodeAll(canvas, formats = SLIP_BARCODE_FORMATS) {
 }
 
 /**
- * Decode all barcodes visible in a canvas / video frame / image element.
+ * Decode all barcodes visible in a canvas / image element.
  * Prefers the native BarcodeDetector API (multi-barcode, fast, Android/Chrome);
  * falls back to ZXing strip-scanning elsewhere (iOS Safari).
  * Returns an array of raw barcode strings (deduped).

--- a/frontend/src/pages/admin-v2/AdminV2Security.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Security.jsx
@@ -146,7 +146,7 @@ const AdminV2Security = () => {
                   <div className="flex flex-col gap-0.5">
                     <CardTitle>HTTPS / Secure access</CardTitle>
                     <p className="text-sm text-muted-foreground">
-                      A secure address enables camera scanning on phones and encrypts your connection.
+                      A secure address encrypts your connection so health data never crosses the network in the clear.
                     </p>
                   </div>
                 </div>
@@ -178,7 +178,7 @@ const AdminV2Security = () => {
                       <Stat
                         label="Secure address"
                         value={httpsUrl || '—'}
-                        hint={status.https_error ? undefined : 'Use this on phones/tablets for camera features'}
+                        hint={status.https_error ? undefined : 'Use this anywhere you want the connection encrypted'}
                       />
                     )}
                     {certActive && (

--- a/frontend/src/pages/admin-v2/components/BarcodeScanDialog.jsx
+++ b/frontend/src/pages/admin-v2/components/BarcodeScanDialog.jsx
@@ -15,10 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-// Single-barcode scanner: point the camera at the barcode on the item's own
-// box (retail UPC/EAN or Code 128) and hand the first read back to the
-// caller. Live camera where available; photo fallback everywhere (iOS over
-// LAN HTTP has no camera API — same constraint as PackingSlipCapture).
+// Single-barcode scanner: photograph the barcode on the item's own box
+// (retail UPC/EAN or Code 128) and hand the first read back to the caller.
 import React, { useEffect, useRef, useState } from 'react';
 import {
   Dialog,
@@ -30,17 +28,11 @@ import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { CameraIcon } from '../../../components/Icons';
 
-const SCAN_INTERVAL_MS = 500;
-
 export default function BarcodeScanDialog({ open, onClose, onFound, title = 'Scan the item barcode' }) {
-  const videoRef = useRef(null);
-  const streamRef = useRef(null);
-  const timerRef = useRef(null);
   const foundRef = useRef(false); // stop after the first read
   const takePhotoInputRef = useRef(null);
   const cameraRollInputRef = useRef(null);
 
-  const [cameraError, setCameraError] = useState(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
 
@@ -52,60 +44,9 @@ export default function BarcodeScanDialog({ open, onClose, onFound, title = 'Sca
   };
 
   useEffect(() => {
-    if (!open) return undefined;
+    if (!open) return;
     foundRef.current = false;
     setError(null);
-    let cancelled = false;
-
-    (async () => {
-      try {
-        if (!navigator.mediaDevices?.getUserMedia) throw new Error('camera-unavailable');
-        const stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: 'environment' },
-          audio: false,
-        });
-        if (cancelled) {
-          stream.getTracks().forEach((t) => t.stop());
-          return;
-        }
-        streamRef.current = stream;
-        if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          await videoRef.current.play().catch(() => {});
-        }
-        timerRef.current = setInterval(async () => {
-          const video = videoRef.current;
-          if (!video || video.readyState < 2 || foundRef.current) return;
-          try {
-            const { detectBarcodes, PRODUCT_BARCODE_FORMATS } = await import('../../../lib/slipScanner');
-            const found = await detectBarcodes(video, PRODUCT_BARCODE_FORMATS);
-            if (found.length) report(found[0]);
-          } catch { /* keep scanning */ }
-        }, SCAN_INTERVAL_MS);
-      } catch {
-        setCameraError(
-          window.isSecureContext
-            ? 'The live camera view isn’t available here — no problem. ' +
-              'Take a photo of the barcode below and we’ll read it the same way.'
-            : 'The live camera needs the secure (HTTPS) address — an administrator ' +
-              'can set one up under Configuration → Security. Meanwhile, take a ' +
-              'photo of the barcode below and we’ll read it the same way.'
-        );
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      if (timerRef.current) {
-        clearInterval(timerRef.current);
-        timerRef.current = null;
-      }
-      if (streamRef.current) {
-        streamRef.current.getTracks().forEach((t) => t.stop());
-        streamRef.current = null;
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const handleFileChosen = async (e) => {
@@ -152,23 +93,14 @@ export default function BarcodeScanDialog({ open, onClose, onFound, title = 'Sca
 
         {error && <Alert variant="destructive"><AlertDescription>{error}</AlertDescription></Alert>}
 
-        {cameraError ? (
-          <Alert><AlertDescription>{cameraError}</AlertDescription></Alert>
-        ) : (
-          <div className="relative overflow-hidden rounded-lg border border-border bg-black">
-            <video ref={videoRef} playsInline muted className="w-full" />
-            <div className="absolute inset-x-0 bottom-0 bg-black/60 p-2 text-center text-sm text-white">
-              Hold the barcode on the box in view — it reads on its own.
-            </div>
-          </div>
-        )}
+        <p className="text-sm text-muted-foreground">
+          Take a photo of the barcode on the box — get close and keep it flat.
+        </p>
 
         <div className="flex flex-col gap-2">
-          {cameraError && (
-            <Button size="lg" onClick={() => takePhotoInputRef.current?.click()} disabled={busy}>
-              <CameraIcon size={16} /> {busy ? 'Reading…' : 'Take a photo of the barcode'}
-            </Button>
-          )}
+          <Button size="lg" onClick={() => takePhotoInputRef.current?.click()} disabled={busy}>
+            <CameraIcon size={16} /> {busy ? 'Reading…' : 'Take a photo of the barcode'}
+          </Button>
           <Button variant="secondary" onClick={() => cameraRollInputRef.current?.click()} disabled={busy}>
             Choose from your camera roll
           </Button>

--- a/frontend/src/pages/admin-v2/components/PackingSlipCapture.jsx
+++ b/frontend/src/pages/admin-v2/components/PackingSlipCapture.jsx
@@ -34,8 +34,6 @@ import { CameraIcon, CheckIcon } from '../../../components/Icons';
 import { shipmentService } from '../../../services/shipments';
 import { sessionGet, sessionSet } from '../../../lib/sessionState';
 
-const SCAN_INTERVAL_MS = 600; // live barcode polling cadence
-
 // Session key for scan accumulation — survives the tab being discarded while
 // the user hops to Photos and back (which reloads the SPA on mobile).
 const scanKey = (shipmentId) => `scan:${shipmentId}`;
@@ -49,15 +47,11 @@ export default function PackingSlipCapture({
   open, onClose, shipmentId = null, expectedItems = [], onComplete, mode = 'confirm',
   sessionKey = null, title = null,
 }) {
-  const videoRef = useRef(null);
-  const streamRef = useRef(null);
-  const scanTimerRef = useRef(null);
   const takePhotoInputRef = useRef(null); // capture="environment": opens the camera
   const cameraRollInputRef = useRef(null); // no capture attr: opens the photo picker
 
   const storageKey = sessionKey || scanKey(shipmentId);
 
-  const [cameraError, setCameraError] = useState(null);
   // Scan accumulation is checkpointed to sessionStorage so a mid-import trip
   // to Photos (which can reload the whole SPA) doesn't lose collected pages.
   const [barcodes, setBarcodes] = useState(() => sessionGet(storageKey)?.barcodes || []);
@@ -111,80 +105,6 @@ export default function PackingSlipCapture({
     })();
     return () => { cancelled = true; };
   }, [barcodes, ocrItems, expectedItems, foundItemNumbers, mode]);
-
-  // --- Camera lifecycle ---
-  useEffect(() => {
-    if (!open) return undefined;
-    let cancelled = false;
-
-    (async () => {
-      try {
-        // iOS/Safari only exposes the live camera on secure origins (HTTPS or
-        // localhost) — over plain LAN HTTP mediaDevices is undefined. Photos
-        // via the inputs below work everywhere and are read the same way.
-        if (!navigator.mediaDevices?.getUserMedia) {
-          throw new Error('camera-unavailable');
-        }
-        const stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: 'environment' },
-          audio: false,
-        });
-        if (cancelled) {
-          stream.getTracks().forEach((t) => t.stop());
-          return;
-        }
-        streamRef.current = stream;
-        if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          await videoRef.current.play().catch(() => {});
-        }
-        startLiveScan();
-      } catch {
-        setCameraError(
-          window.isSecureContext
-            ? 'The live camera view isn’t available here — no problem. ' +
-              'Take a photo of each page below and we’ll read it the same way.'
-            : 'The live camera needs the secure (HTTPS) address — an administrator ' +
-              'can set one up under Configuration → Security. Meanwhile, take a ' +
-              'photo of each page below and we’ll read it the same way.'
-        );
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      stopLiveScan();
-      if (streamRef.current) {
-        streamRef.current.getTracks().forEach((t) => t.stop());
-        streamRef.current = null;
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
-
-  // Continuously look for line-item barcodes in the live picture, so slowly
-  // panning the phone down the slip collects every line without any typing.
-  const startLiveScan = () => {
-    stopLiveScan();
-    scanTimerRef.current = setInterval(async () => {
-      const video = videoRef.current;
-      if (!video || video.readyState < 2) return;
-      try {
-        const { detectBarcodes } = await import('../../../lib/slipScanner');
-        const found = await detectBarcodes(video);
-        if (found.length) {
-          setBarcodes((prev) => [...new Set([...prev, ...found])]);
-        }
-      } catch { /* keep scanning */ }
-    }, SCAN_INTERVAL_MS);
-  };
-
-  const stopLiveScan = () => {
-    if (scanTimerRef.current) {
-      clearInterval(scanTimerRef.current);
-      scanTimerRef.current = null;
-    }
-  };
 
   // --- Page capture (still photo -> barcode + OCR + upload) ---
   // Page numbers via a ref: a multi-photo batch runs inside one closure, so
@@ -243,17 +163,6 @@ export default function PackingSlipCapture({
     } finally {
       setBusy(null);
     }
-  };
-
-  const capturePage = async () => {
-    const video = videoRef.current;
-    if (!video || video.readyState < 2) return;
-    const canvas = document.createElement('canvas');
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-    canvas.getContext('2d').drawImage(video, 0, 0);
-    setError(null);
-    await processCanvas(canvas);
   };
 
   const fileToCanvas = async (file) => {
@@ -324,18 +233,11 @@ export default function PackingSlipCapture({
 
         {error && <Alert variant="destructive"><AlertDescription>{error}</AlertDescription></Alert>}
 
-        {cameraError ? (
-          <Alert><AlertDescription>{cameraError}</AlertDescription></Alert>
-        ) : (
-          <div className="relative overflow-hidden rounded-lg border border-border bg-black">
-            <video ref={videoRef} playsInline muted className="w-full" />
-            <div className="absolute inset-x-0 bottom-0 bg-black/60 p-2 text-center text-sm text-white">
-              {mode === 'import'
-                ? 'Hold the phone over the sheet — each little barcode adds that item for you.'
-                : 'Hold the phone over the slip — the little barcodes check items off automatically.'}
-            </div>
-          </div>
-        )}
+        <p className="text-sm text-muted-foreground">
+          {mode === 'import'
+            ? 'Take a photo of each page of the sheet — each little barcode adds that item for you.'
+            : 'Take a photo of each page of the slip — the little barcodes check items off automatically.'}
+        </p>
 
         {/* Progress: friendly, glanceable */}
         <div className="flex flex-wrap items-center gap-2 text-sm">
@@ -360,15 +262,9 @@ export default function PackingSlipCapture({
         </div>
 
         <div className="flex flex-col gap-2">
-          {!cameraError ? (
-            <Button size="lg" onClick={capturePage} disabled={!!busy || !!batch}>
-              <CameraIcon size={16} /> Save this page
-            </Button>
-          ) : (
-            <Button size="lg" onClick={() => takePhotoInputRef.current?.click()} disabled={!!busy || !!batch}>
-              <CameraIcon size={16} /> Take a photo of the page
-            </Button>
-          )}
+          <Button size="lg" onClick={() => takePhotoInputRef.current?.click()} disabled={!!busy || !!batch}>
+            <CameraIcon size={16} /> Take a photo of the page
+          </Button>
           <Button variant="secondary" onClick={() => cameraRollInputRef.current?.click()} disabled={!!busy || !!batch}>
             Choose from your camera roll
           </Button>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,7 +3,6 @@ import { fileURLToPath, URL } from 'node:url';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
-import basicSsl from '@vitejs/plugin-basic-ssl';
 
 export default defineConfig(({ command }) => ({
   // Production build uses relative asset URLs ('./assets/...') so the injected
@@ -13,12 +12,6 @@ export default defineConfig(({ command }) => ({
   plugins: [
     react(),
     tailwindcss(),
-    // Dev HTTPS (self-signed) when VITE_HTTPS is set — iOS Safari only
-    // exposes the live camera (getUserMedia) on secure origins, so barcode
-    // viewfinders and live slip scanning over LAN need https://. All API/WS
-    // traffic rides the same-origin Vite proxy, so nothing else changes.
-    // Accept the certificate warning once per device.
-    ...(process.env.VITE_HTTPS ? [basicSsl()] : []),
     viteStaticCopy({
       targets: [
         {


### PR DESCRIPTION
The live getUserMedia viewfinder wasn't reliable enough to compete with a Bluetooth wedge scanner, and it was the sole reason the dev stack ran behind a self-signed HTTPS cert. This backs the live camera out while keeping everything that works:

- **PackingSlipCapture / BarcodeScanDialog**: live video branches removed (`getUserMedia`, polling loops, `<video>` elements, `isSecureContext` messaging). "Take a photo" is now the primary button; camera-roll multi-select, OCR, barcode decode, session persistence, and page upload are unchanged.
- **ScannerChoiceDialog / ExternalScanDialog**: untouched — "Use the camera" still accurately describes the photo path.
- **Dev HTTPS requirement dropped**: `VITE_HTTPS` removed from docker-compose.yml, `@vitejs/plugin-basic-ssl` uninstalled, dev is plain `http://localhost:5173` again (no more browser cert warning).
- **HTTPS wizard kept**: DuckDNS/LE, reverse-proxy, and BYO-cert paths all stay; the "enables camera scanning" copy in the wizard, Security page, first-run step, ReadMe, and https-setup doc is reworded around connection encryption.
- Frigate live-camera viewing (CameraLiveModal etc.) is a separate feature and untouched.

Verified: `npm test` green (300 tests / 30 files), ESLint clean on all touched files, dev stack recreated and serving over HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
