### PR TITLE
Picker + account settings awareness of HA-linked profiles

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -561,6 +561,7 @@ def get_account_users(
             full_name=user.full_name,
             has_pin=bool(user.pin_hash),
             requires_full_password=user.needs_full_password(),
+            ha_linked=bool(user.ha_user_id),
             roles=[{"id": r.id, "name": r.name, "display_name": r.display_name} for r in user.roles]
         )
         for user in users

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -76,6 +76,10 @@ class AccountUserItem(BaseModel):
     full_name: str
     has_pin: bool
     requires_full_password: bool
+    # Linked to a Home Assistant login — signs in automatically via ingress.
+    # The picker uses this to explain (rather than dead-end) profiles that may
+    # have no human-known password.
+    ha_linked: bool = False
     roles: List[dict] = []
 
 

--- a/frontend/src/pages/UserSelectionPage.jsx
+++ b/frontend/src/pages/UserSelectionPage.jsx
@@ -179,6 +179,7 @@ export default function UserSelectionPage() {
                       <div className="user-name">{user.full_name || user.username}</div>
                       <div className="user-roles">
                         {user.roles?.map(r => r.display_name || r.name).join(', ') || 'User'}
+                        {user.ha_linked ? ' · Signs in with Home Assistant' : ''}
                       </div>
                     </div>
                   </button>
@@ -215,6 +216,14 @@ export default function UserSelectionPage() {
                     autoFocus
                     required
                   />
+                  {selectedUser.ha_linked && !selectedUser.has_pin && (
+                    <small className="form-hint">
+                      This profile normally signs in automatically from the Home
+                      Assistant sidebar. To use it here, enter its app password —
+                      if it was never given one, an administrator can set one (or
+                      a PIN) under Configuration → Users.
+                    </small>
+                  )}
                 </div>
               ) : (
                 <div className="form-group">

--- a/frontend/src/pages/admin-v2/AdminV2AccountSettings.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2AccountSettings.jsx
@@ -131,7 +131,7 @@ export default function AdminV2AccountSettings() {
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({
-          current_password: currentPassword,
+          current_password: currentPassword || null,
           new_password: newPassword
         })
       });
@@ -146,6 +146,7 @@ export default function AdminV2AccountSettings() {
       setNewPassword('');
       setConfirmPassword('');
       setShowPasswordForm(false);
+      fetchAccountDetails(); // refresh password_unset so the notice clears
     } catch (err) {
       setPasswordError(err.message);
     } finally {
@@ -279,11 +280,19 @@ export default function AdminV2AccountSettings() {
             <CardContent>
               {!showPasswordForm ? (
                 <div className="flex flex-col items-start gap-4">
+                  {accountData?.password_unset && (
+                    <Alert>
+                      No account password has been set yet (setup was completed
+                      through Home Assistant). Shared and LAN devices stay in
+                      add-only mode until one is set — you can set it now without
+                      a current password.
+                    </Alert>
+                  )}
                   <p className="text-sm text-muted-foreground">
                     The account password is used to log in at the account level before selecting a user profile.
                   </p>
                   <Button variant="secondary" onClick={() => setShowPasswordForm(true)}>
-                    Change Password
+                    {accountData?.password_unset ? 'Set Password' : 'Change Password'}
                   </Button>
                 </div>
               ) : (
@@ -291,15 +300,19 @@ export default function AdminV2AccountSettings() {
                   {passwordError && <Alert variant="destructive">{passwordError}</Alert>}
                   {passwordSuccess && <Alert variant="success">{passwordSuccess}</Alert>}
 
-                  <Field label="Current Password" htmlFor="currentPassword">
-                    <Input
-                      type="password"
-                      id="currentPassword"
-                      value={currentPassword}
-                      onChange={(e) => setCurrentPassword(e.target.value)}
-                      required
-                    />
-                  </Field>
+                  {/* First human-set password after an HA-ingress setup: the
+                      stored password is random, so there's nothing to verify. */}
+                  {!accountData?.password_unset && (
+                    <Field label="Current Password" htmlFor="currentPassword">
+                      <Input
+                        type="password"
+                        id="currentPassword"
+                        value={currentPassword}
+                        onChange={(e) => setCurrentPassword(e.target.value)}
+                        required
+                      />
+                    </Field>
+                  )}
 
                   <Field label="New Password" htmlFor="newPassword" hint="Minimum 8 characters">
                     <Input


### PR DESCRIPTION
Follow-up to #79 (one commit that landed after the merge, moved to its own branch).

- `/api/auth/account/users` now reports `ha_linked`; the user picker labels those profiles ("Signs in with Home Assistant") and, when one has no PIN, explains how to use it outside HA instead of dead-ending on a password nobody knows.
- Account Settings shows the "no account password set" notice after an HA-ingress first-run and offers **Set Password** with no current-password field (uses the one-time backend bypass from #79), refreshing the flag after the change.
- Verified `/ws/sensors` through real ingress on the dev HA while testing: 101 upgrade + immediate state broadcast.

Backend auth suites and the full frontend suite (309) are green; ESLint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Djmoqd4QNDTRWMYF8QT2SK