### PR TITLE
HA user directory: see every HA user, import as profile or patient

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2.0
 
+- **Home Assistant user directory.** Configuration → Users now lists *every*
+  HA user (via the Supervisor API), not just those who have opened the app.
+  Link them to existing profiles, **create a profile for them in one step**
+  (no password — their HA login signs them in), or add them as a patient.
 - **Sign in with Home Assistant.** When the app is opened through ingress (the
   sidebar panel), it now knows which HA user is at the keyboard. Link an HA user
   to an app profile under **Configuration → Users → Home Assistant users** and
@@ -17,11 +21,13 @@
 - New option `ha_identity_login` (default `true`) to turn identity login off.
 - Add-on icon and logo.
 
-> **⚠️ Upgrade note:** the new LAN port requires a full **uninstall + reinstall**
-> of the add-on to take effect (Home Assistant only applies port changes on
-> install). Your data survives — it lives on the add-on's persistent `/data` —
-> but export a backup first anyway. A plain update gets you identity login
-> through ingress; the LAN port stays closed until you reinstall.
+> **⚠️ Upgrade note:** the new LAN port and Supervisor API permissions require
+> a full **uninstall + reinstall** of the add-on to take effect (Home Assistant
+> only applies port/permission changes on install). **Uninstalling deletes the
+> add-on's `/data` — take a Home Assistant backup of the add-on first and
+> restore it after reinstalling.** A plain update gets you identity login
+> through ingress; the LAN port and the user directory stay off until you
+> reinstall.
 
 ## 0.1.0
 

--- a/addon/DOCS.md
+++ b/addon/DOCS.md
@@ -66,6 +66,24 @@ the Supervisor's ingress proxy (`172.30.32.2`). Requests on the LAN port that
 carry forged identity headers are rejected. Requires Home Assistant Core
 ≥ 2023.9 (older versions simply fall back to the picker flow).
 
+### Home Assistant user directory
+
+**Configuration → Users → Home Assistant users** lists everyone with an HA
+login (fetched through the Supervisor API), each marked *Linked*, *Opened the
+app*, or *Never opened the app*. For anyone not yet linked you can:
+
+- **Link** them to an existing app profile,
+- **Create profile** — a one-step import: pick roles (and patients); no
+  password is set because their HA login signs them in. A password or PIN can
+  be added later for shared devices.
+- **Add as patient** — creates a patient record with the name prefilled.
+
+Running outside Home Assistant (Docker Compose), the Supervisor API isn't
+available; the list falls back to HA users who have opened the app at least
+once. The directory needs the `hassio_api`/`homeassistant_api` permissions in
+this add-on's manifest — on upgrades from 0.1.0 they only take effect after a
+full uninstall + reinstall (back up `/data` first).
+
 ### `skip_account_password`
 
 When enabled, the app skips the account-password screen and goes straight to user

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -41,6 +41,15 @@ ports:
 ports_description:
   8000/tcp: "Direct LAN access for shared-device iframes — always shows the user picker; HA auto-login is ingress-only"
 
+# Supervisor/Core API access: hassio_api makes the Supervisor inject
+# SUPERVISOR_TOKEN into the container env; homeassistant_api opens the
+# ws://supervisor/core/websocket proxy the HA user directory uses
+# (config/auth/list — so admins can link/import household members before
+# they ever open the panel). NOTE: like ports, API-permission changes only
+# apply on a full uninstall + reinstall of the add-on.
+hassio_api: true
+homeassistant_api: true
+
 # Auto-discover HA's Mosquitto broker (optional; the app's MQTT settings still
 # live in its own DB, but this lets us seed the broker host on first run).
 services:

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -45,6 +45,9 @@ else
 fi
 export SHH_INGRESS_TRUSTED_PEERS="${SHH_INGRESS_TRUSTED_PEERS:-172.30.32.2}"
 
+# The app reads SUPERVISOR_TOKEN straight from the container env (injected by
+# the Supervisor; used for the HA user directory). Never unset or override it.
+
 export MIN_SPO2="$(opt min_spo2)"
 export MAX_SPO2="$(opt max_spo2)"
 export MIN_BPM="$(opt min_bpm)"

--- a/backend/alembic/versions/038_patient_ha_identity.py
+++ b/backend/alembic/versions/038_patient_ha_identity.py
@@ -1,0 +1,45 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Patient <- HA user provenance
+
+Revision ID: 038_patient_ha_identity
+Revises: 037_ha_identity
+Create Date: 2026-08-14
+
+patients.ha_user_id records which Home Assistant login a patient record was
+created from, so the HA user directory can offer "Add as patient" at most
+once per HA login (and show which patient it produced). Unique — one patient
+per HA user.
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '038_patient_ha_identity'
+down_revision: Union[str, None] = '037_ha_identity'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('patients', sa.Column('ha_user_id', sa.String(length=32), nullable=True))
+    op.create_index('ix_patients_ha_user_id', 'patients', ['ha_user_id'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_patients_ha_user_id', table_name='patients')
+    op.drop_column('patients', 'ha_user_id')

--- a/backend/crud/patients.py
+++ b/backend/crud/patients.py
@@ -77,6 +77,7 @@ def create_patient(db: Session, patient_data: dict) -> Patient:
         # invisible to every account-filtered consumer (backup, MQTT, integrations).
         account_id=patient_data.get("account_id"),
         owner_user_id=patient_data.get("owner_user_id"),
+        ha_user_id=patient_data.get("ha_user_id"),
         created_at=datetime.utcnow(),
         updated_at=datetime.utcnow()
     )

--- a/backend/crud/patients.py
+++ b/backend/crud/patients.py
@@ -73,6 +73,10 @@ def create_patient(db: Session, patient_data: dict) -> Patient:
         medical_record_number=patient_data.get("medical_record_number"),
         is_active=patient_data.get("is_active", True),
         notes=patient_data.get("notes"),
+        # The route supplies account_id; dropping it here made new patients
+        # invisible to every account-filtered consumer (backup, MQTT, integrations).
+        account_id=patient_data.get("account_id"),
+        owner_user_id=patient_data.get("owner_user_id"),
         created_at=datetime.utcnow(),
         updated_at=datetime.utcnow()
     )

--- a/backend/models/patients.py
+++ b/backend/models/patients.py
@@ -26,6 +26,9 @@ class PatientBase(BaseModel):
     medical_record_number: Optional[str] = Field(None, max_length=50)
     is_active: bool = True
     notes: Optional[str] = None
+    # HA login this record represents (32-hex HA user id). Set when creating
+    # a patient from the HA user directory; one patient per HA login.
+    ha_user_id: Optional[str] = Field(None, min_length=32, max_length=32)
 
 
 class PatientCreate(PatientBase):
@@ -39,6 +42,7 @@ class PatientUpdate(BaseModel):
     medical_record_number: Optional[str] = Field(None, max_length=50)
     is_active: Optional[bool] = None
     notes: Optional[str] = None
+    ha_user_id: Optional[str] = Field(None, min_length=32, max_length=32)
 
 
 class PatientResponse(PatientBase):

--- a/backend/routes/ha_auth.py
+++ b/backend/routes/ha_auth.py
@@ -46,14 +46,18 @@ from routes.auth import (
     create_access_token,
 )
 from schemas.ha_auth import (
+    HADirectoryResponse,
+    HADirectoryUserItem,
     HAIdentityInfo,
     HAIdentityItem,
+    HAImportRequest,
     HALinkRequest,
     HALoginResponse,
     HAStatusResponse,
 )
+from utils import ha_core
 from utils.client_ip import get_client_ip
-from utils.ha_ingress import ingress_identity, is_valid_ha_user_id, trusted_ingress_peer
+from utils.ha_ingress import HAIdentity, ingress_identity, is_valid_ha_user_id, trusted_ingress_peer
 
 logger = logging.getLogger(__name__)
 
@@ -233,6 +237,137 @@ def list_identities(
         )
         for row in rows
     ]
+
+
+@router.get("/directory", response_model=HADirectoryResponse)
+async def ha_directory(
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_system_admin),
+):
+    """The merged HA user directory: everyone in Home Assistant (when running
+    as the add-on with Supervisor access) ∪ identities seen on ingress ∪
+    mapped app users. Always 200 — outside the add-on `available` is False and
+    the list degrades to seen/mapped rows only."""
+    try:
+        directory = await ha_core.list_ha_users()
+        available = True
+    except ha_core.HACoreError as e:
+        if ha_core.ha_core_available():
+            logger.warning(f"HA user directory unavailable: {e}")
+        directory, available = [], False
+
+    seen_by_id = {row.ha_user_id: row for row in db.query(HASeenIdentity).all()}
+    users_by_ha_id = {
+        u.ha_user_id: u
+        for u in db.query(User).filter(User.ha_user_id.isnot(None)).all()
+    }
+
+    items = []
+    all_ids = {d.ha_user_id for d in directory} | set(seen_by_id) | set(users_by_ha_id)
+    dir_by_id = {d.ha_user_id: d for d in directory}
+    for ha_user_id in all_ids:
+        d = dir_by_id.get(ha_user_id)
+        seen = seen_by_id.get(ha_user_id)
+        mapped = users_by_ha_id.get(ha_user_id)
+        items.append(HADirectoryUserItem(
+            ha_user_id=ha_user_id,
+            name=(d.name if d else None) or (seen.display_name if seen else None),
+            username=(d.username if d else None) or (seen.username if seen else None),
+            status="linked" if mapped else ("seen" if seen else "never_opened"),
+            # Only meaningful when the directory loaded; treat everything as
+            # in-directory in fallback mode so the UI doesn't flag stale rows.
+            in_directory=bool(d) or not available,
+            ha_is_owner=bool(d and d.is_owner),
+            ha_is_admin=bool(d and d.is_admin),
+            ha_is_active=d.is_active if d else True,
+            first_seen=seen.first_seen if seen else None,
+            last_seen=seen.last_seen if seen else None,
+            mapped_user=(
+                {"id": mapped.id, "username": mapped.username, "full_name": mapped.full_name}
+                if mapped else None
+            ),
+        ))
+
+    status_rank = {"linked": 0, "seen": 1, "never_opened": 2}
+    items.sort(key=lambda i: (
+        status_rank[i.status],
+        -(i.last_seen.timestamp() if i.last_seen else 0),
+        (i.name or i.username or i.ha_user_id).lower(),
+    ))
+    return HADirectoryResponse(available=available, users=items)
+
+
+@router.post("/import", status_code=status.HTTP_201_CREATED)
+def import_ha_user(
+    body: HAImportRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    admin: User = Depends(require_system_admin),
+):
+    """Create an app user pre-linked to an HA identity. Passwordless by
+    design: a random throwaway hash is stored (the HA login IS the credential;
+    a password/PIN can be set later for non-HA access) and no forced reset —
+    that screen would trap a user who has no password to type."""
+    if not is_valid_ha_user_id(body.ha_user_id):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid HA user id")
+
+    existing = db.query(User).filter(User.ha_user_id == body.ha_user_id).first()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"This Home Assistant user is already linked to {existing.full_name}. Unlink it first.",
+        )
+
+    from crud.users import create_user, get_user_by_username
+    if get_user_by_username(db, body.username):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Username already taken")
+
+    from models.users import Role
+    if body.role_ids:
+        found = {r.id for r in db.query(Role.id).filter(Role.id.in_(body.role_ids)).all()}
+        missing = set(body.role_ids) - found
+        if missing:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unknown role id")
+
+    import secrets as _secrets
+    user = create_user(
+        db,
+        username=body.username,
+        password=_secrets.token_urlsafe(24),
+        full_name=body.full_name,
+        role_ids=body.role_ids or None,
+        force_password_reset=False,
+    )
+    user.ha_user_id = body.ha_user_id
+    if not user.account_id:
+        user.account_id = admin.account_id
+    _upsert_seen_identity(db, HAIdentity(
+        ha_user_id=body.ha_user_id,
+        username=body.username,
+        display_name=body.full_name,
+    ))
+    create_audit_log(
+        db,
+        user_id=admin.id,
+        action="ha.identity.import",
+        details=json.dumps({
+            "ha_user_id": body.ha_user_id,
+            "created_user_id": user.id,
+            "role_ids": body.role_ids,
+        }),
+        ip_address=get_client_ip(request),
+        user_agent=request.headers.get("User-Agent"),
+    )
+    db.commit()
+    db.refresh(user)
+    logger.info(f"Imported HA user as app profile: {user.username}")
+    return {
+        "id": user.id,
+        "username": user.username,
+        "full_name": user.full_name,
+        "ha_user_id": user.ha_user_id,
+        "roles": [{"id": r.id, "name": r.name, "display_name": r.display_name} for r in user.roles],
+    }
 
 
 @router.put("/identities/{ha_user_id}/link")

--- a/backend/routes/ha_auth.py
+++ b/backend/routes/ha_auth.py
@@ -256,19 +256,28 @@ async def ha_directory(
             logger.warning(f"HA user directory unavailable: {e}")
         directory, available = [], False
 
+    from schemas.patient import Patient
     seen_by_id = {row.ha_user_id: row for row in db.query(HASeenIdentity).all()}
     users_by_ha_id = {
         u.ha_user_id: u
         for u in db.query(User).filter(User.ha_user_id.isnot(None)).all()
     }
+    patients_by_ha_id = {
+        p.ha_user_id: p
+        for p in db.query(Patient).filter(Patient.ha_user_id.isnot(None)).all()
+    }
 
     items = []
-    all_ids = {d.ha_user_id for d in directory} | set(seen_by_id) | set(users_by_ha_id)
+    all_ids = (
+        {d.ha_user_id for d in directory}
+        | set(seen_by_id) | set(users_by_ha_id) | set(patients_by_ha_id)
+    )
     dir_by_id = {d.ha_user_id: d for d in directory}
     for ha_user_id in all_ids:
         d = dir_by_id.get(ha_user_id)
         seen = seen_by_id.get(ha_user_id)
         mapped = users_by_ha_id.get(ha_user_id)
+        patient = patients_by_ha_id.get(ha_user_id)
         items.append(HADirectoryUserItem(
             ha_user_id=ha_user_id,
             name=(d.name if d else None) or (seen.display_name if seen else None),
@@ -285,6 +294,10 @@ async def ha_directory(
             mapped_user=(
                 {"id": mapped.id, "username": mapped.username, "full_name": mapped.full_name}
                 if mapped else None
+            ),
+            patient=(
+                {"id": patient.id, "first_name": patient.first_name, "last_name": patient.last_name}
+                if patient else None
             ),
         ))
 

--- a/backend/routes/patients.py
+++ b/backend/routes/patients.py
@@ -78,6 +78,22 @@ def get_current_or_default_patient(db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="No patients found")
     return patient
 
+def _validate_patient_ha_user_id(db: Session, ha_user_id, exclude_patient_id: int = None):
+    """One patient per HA login: valid 32-hex id, not already used."""
+    if not ha_user_id:
+        return
+    from utils.ha_ingress import is_valid_ha_user_id
+    if not is_valid_ha_user_id(ha_user_id):
+        raise HTTPException(status_code=400, detail="Invalid HA user id")
+    from schemas.patient import Patient as PatientORM
+    existing = db.query(PatientORM).filter(PatientORM.ha_user_id == ha_user_id).first()
+    if existing and existing.id != exclude_patient_id:
+        raise HTTPException(
+            status_code=409,
+            detail=f"That Home Assistant user is already the patient {existing.first_name} {existing.last_name}.",
+        )
+
+
 @router.post("", response_model=PatientResponse)
 def create_new_patient(
     patient: PatientCreate,
@@ -94,6 +110,8 @@ def create_new_patient(
                 status_code=400,
                 detail="Medical record number already exists"
             )
+
+    _validate_patient_ha_user_id(db, patient.ha_user_id)
 
     patient_data = patient.model_dump()
     patient_data["account_id"] = account_id
@@ -129,9 +147,11 @@ def update_patient_by_id(
                 detail="Medical record number already exists"
             )
     
+    _validate_patient_ha_user_id(db, patient_update.ha_user_id, exclude_patient_id=patient_id)
+
     # Filter out None values
     update_data = {k: v for k, v in patient_update.model_dump().items() if v is not None}
-    
+
     updated_patient = update_patient(db, patient_id, update_data)
     if not updated_patient:
         raise HTTPException(status_code=404, detail="Patient not found")

--- a/backend/schemas/ha_auth.py
+++ b/backend/schemas/ha_auth.py
@@ -17,7 +17,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class HAIdentityInfo(BaseModel):
@@ -88,8 +88,11 @@ class HADirectoryResponse(BaseModel):
 
 
 class HAImportRequest(BaseModel):
-    """Create a passwordless app user pre-linked to an HA identity."""
+    """Create a passwordless app user pre-linked to an HA identity.
+
+    Length bounds mirror the users table (username 50, full_name 100) so bad
+    input fails validation instead of surfacing as a DB error."""
     ha_user_id: str
-    username: str
-    full_name: str
+    username: str = Field(..., min_length=3, max_length=50)
+    full_name: str = Field(..., min_length=1, max_length=100)
     role_ids: list[int] = []

--- a/backend/schemas/ha_auth.py
+++ b/backend/schemas/ha_auth.py
@@ -63,3 +63,32 @@ class HAIdentityItem(BaseModel):
 class HALinkRequest(BaseModel):
     """Link an HA identity to an app user."""
     user_id: int
+
+
+class HADirectoryUserItem(BaseModel):
+    """One HA user in the merged directory view."""
+    ha_user_id: str
+    name: Optional[str] = None       # HA display name (directory wins over seen)
+    username: Optional[str] = None
+    status: str                      # "linked" | "seen" | "never_opened"
+    in_directory: bool               # False = seen/mapped row no longer in HA (or fallback mode)
+    ha_is_owner: bool = False
+    ha_is_admin: bool = False
+    ha_is_active: bool = True
+    first_seen: Optional[datetime] = None
+    last_seen: Optional[datetime] = None
+    mapped_user: Optional[dict] = None  # {id, username, full_name} | None
+
+
+class HADirectoryResponse(BaseModel):
+    """GET /api/auth/ha/directory. available=False → seen-only fallback data."""
+    available: bool
+    users: list[HADirectoryUserItem] = []
+
+
+class HAImportRequest(BaseModel):
+    """Create a passwordless app user pre-linked to an HA identity."""
+    ha_user_id: str
+    username: str
+    full_name: str
+    role_ids: list[int] = []

--- a/backend/schemas/ha_auth.py
+++ b/backend/schemas/ha_auth.py
@@ -78,6 +78,7 @@ class HADirectoryUserItem(BaseModel):
     first_seen: Optional[datetime] = None
     last_seen: Optional[datetime] = None
     mapped_user: Optional[dict] = None  # {id, username, full_name} | None
+    patient: Optional[dict] = None      # {id, first_name, last_name} | None — created from this HA login
 
 
 class HADirectoryResponse(BaseModel):

--- a/backend/schemas/patient.py
+++ b/backend/schemas/patient.py
@@ -37,6 +37,9 @@ class Patient(Base):
     medical_record_number = Column(String, nullable=True, unique=True)
     is_active = Column(Boolean, default=True, nullable=False)
     notes = Column(Text, nullable=True)
+    # HA user this patient record was created from (uuid4().hex) — provenance
+    # so the HA-user directory offers "Add as patient" at most once per login.
+    ha_user_id = Column(String(32), unique=True, nullable=True, index=True)
     created_at = Column(TIMESTAMP(timezone=True), nullable=False)
     updated_at = Column(TIMESTAMP(timezone=True), nullable=False)
     

--- a/backend/tests/test_ha_directory.py
+++ b/backend/tests/test_ha_directory.py
@@ -1,0 +1,208 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+HA user directory (config/auth/list via Supervisor) + import-as-app-user.
+
+The Core WS client is monkeypatched at the module attribute the route calls
+(routes.ha_auth -> utils.ha_core.list_ha_users), so no socket is involved.
+"""
+import pytest
+
+from utils import ha_core
+from utils.ha_core import HACoreError, HADirectoryUser, _users_from_result
+
+HA_OWNER = "a" * 32
+HA_NEW = "b" * 32
+HA_GONE = "c" * 32  # seen on ingress once, since deleted from HA
+
+
+def _dir_user(ha_user_id, name, username=None, **kw):
+    return HADirectoryUser(
+        ha_user_id=ha_user_id, name=name, username=username,
+        is_owner=kw.get("is_owner", False), is_active=kw.get("is_active", True),
+        local_only=kw.get("local_only", False), is_admin=kw.get("is_admin", False),
+    )
+
+
+@pytest.fixture
+def fake_directory(monkeypatch):
+    """Patch the directory fetch; returns a dict you can mutate per-test."""
+    state = {"users": [], "error": None}
+
+    async def fake_list(timeout: float = 5.0):
+        if state["error"]:
+            raise state["error"]
+        return state["users"]
+
+    monkeypatch.setattr(ha_core, "list_ha_users", fake_list)
+    return state
+
+
+# ---------------------------------------------------------------- parsing unit
+
+def test_users_from_result_filters_and_maps():
+    result = [
+        {"id": HA_OWNER, "name": "John", "username": "john", "is_owner": True,
+         "is_active": True, "group_ids": ["system-admin"]},
+        {"id": "d" * 32, "name": "Supervisor", "system_generated": True},
+        {"id": HA_NEW, "name": "Nurse Nancy", "group_ids": ["system-users"]},
+        {"no_id": True},
+    ]
+    users = _users_from_result(result)
+    assert [u.ha_user_id for u in users] == [HA_OWNER, HA_NEW]
+    assert users[0].is_admin is True and users[0].is_owner is True
+    assert users[1].is_admin is False
+
+
+def test_list_ha_users_requires_token(monkeypatch):
+    import asyncio
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    with pytest.raises(HACoreError):
+        asyncio.run(ha_core.list_ha_users())
+
+
+# ---------------------------------------------------------------- directory route
+
+def test_directory_requires_auth(client, account):
+    assert client.get("/api/auth/ha/directory").status_code == 401
+
+
+def test_directory_forbidden_for_non_admin(limited_client, account):
+    assert limited_client.get("/api/auth/ha/directory").status_code == 403
+
+
+def test_directory_merges_statuses(admin_client, admin_user, account, db_session, fake_directory):
+    from models.ha_identity import HASeenIdentity
+    fake_directory["users"] = [
+        _dir_user(HA_OWNER, "John", "john", is_owner=True, is_admin=True),
+        _dir_user(HA_NEW, "Nurse Nancy"),
+    ]
+    # Owner is linked + seen; Nancy never opened the panel.
+    admin_user.ha_user_id = HA_OWNER
+    db_session.add(HASeenIdentity(ha_user_id=HA_OWNER, username="john", display_name="John"))
+    db_session.commit()
+
+    body = admin_client.get("/api/auth/ha/directory").json()
+    assert body["available"] is True
+    by_id = {u["ha_user_id"]: u for u in body["users"]}
+    assert by_id[HA_OWNER]["status"] == "linked"
+    assert by_id[HA_OWNER]["mapped_user"]["id"] == admin_user.id
+    assert by_id[HA_OWNER]["ha_is_owner"] is True
+    assert by_id[HA_NEW]["status"] == "never_opened"
+    assert by_id[HA_NEW]["name"] == "Nurse Nancy"
+    assert by_id[HA_NEW]["in_directory"] is True
+    # Linked sorts first.
+    assert body["users"][0]["ha_user_id"] == HA_OWNER
+
+
+def test_directory_flags_stale_seen_rows(admin_client, account, db_session, fake_directory):
+    from models.ha_identity import HASeenIdentity
+    fake_directory["users"] = [_dir_user(HA_OWNER, "John")]
+    db_session.add(HASeenIdentity(ha_user_id=HA_GONE, display_name="Old Phone User"))
+    db_session.commit()
+    body = admin_client.get("/api/auth/ha/directory").json()
+    by_id = {u["ha_user_id"]: u for u in body["users"]}
+    assert by_id[HA_GONE]["in_directory"] is False
+    assert by_id[HA_GONE]["status"] == "seen"
+
+
+def test_directory_unavailable_falls_back_to_seen(admin_client, account, db_session, fake_directory):
+    from models.ha_identity import HASeenIdentity
+    fake_directory["error"] = HACoreError("no supervisor")
+    db_session.add(HASeenIdentity(ha_user_id=HA_OWNER, display_name="John"))
+    db_session.commit()
+    r = admin_client.get("/api/auth/ha/directory")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert [u["ha_user_id"] for u in body["users"]] == [HA_OWNER]
+    # Fallback mode never flags rows as stale.
+    assert body["users"][0]["in_directory"] is True
+
+
+def test_directory_includes_mapped_but_never_seen(admin_client, admin_user, account, db_session, fake_directory):
+    fake_directory["error"] = HACoreError("no supervisor")
+    admin_user.ha_user_id = HA_OWNER
+    db_session.commit()
+    body = admin_client.get("/api/auth/ha/directory").json()
+    by_id = {u["ha_user_id"]: u for u in body["users"]}
+    assert by_id[HA_OWNER]["status"] == "linked"
+
+
+# ---------------------------------------------------------------- import route
+
+def _import(client, **overrides):
+    payload = {"ha_user_id": HA_NEW, "username": "nancy", "full_name": "Nurse Nancy", "role_ids": []}
+    payload.update(overrides)
+    return client.post("/api/auth/ha/import", json=payload)
+
+
+def test_import_creates_passwordless_linked_user(admin_client, admin_user, account, db_session):
+    from crud.users import get_role_by_name
+    role = get_role_by_name(db_session, "caregiver")
+    r = _import(admin_client, role_ids=[role.id])
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["ha_user_id"] == HA_NEW
+    assert [x["name"] for x in body["roles"]] == ["caregiver"]
+
+    from models.users import User, AuditLog
+    user = db_session.query(User).filter_by(username="nancy").one()
+    assert user.ha_user_id == HA_NEW
+    assert user.force_password_reset is False
+    assert user.account_id == admin_user.account_id
+    from models.ha_identity import HASeenIdentity
+    assert db_session.query(HASeenIdentity).filter_by(ha_user_id=HA_NEW).count() == 1
+    assert db_session.query(AuditLog).filter_by(action="ha.identity.import").count() == 1
+
+
+def test_import_then_ingress_login_is_full_session(admin_client, client, account, db_session, monkeypatch):
+    monkeypatch.setenv("SHH_INGRESS", "1")
+    monkeypatch.setenv("SHH_INGRESS_TRUSTED_PEERS", "testclient")
+    assert _import(admin_client).status_code == 201
+    client.cookies.clear()
+    client.headers.pop("Authorization", None)
+    r = client.post("/api/auth/ha/login", headers={"X-Remote-User-Id": HA_NEW})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mapped"] is True
+    assert body["auth_level"] == "full"
+    assert body["user"]["username"] == "nancy"
+
+
+def test_import_validations(admin_client, admin_user, limited_user, account, db_session):
+    assert _import(admin_client, ha_user_id="nope").status_code == 400
+    limited_user.ha_user_id = HA_NEW
+    db_session.commit()
+    assert _import(admin_client).status_code == 409
+    limited_user.ha_user_id = None
+    db_session.commit()
+    assert _import(admin_client, username="limited_test").status_code == 400  # taken
+    assert _import(admin_client, role_ids=[999999]).status_code == 400
+
+
+def test_import_requires_admin(limited_client, account):
+    assert _import(limited_client).status_code == 403
+
+
+# ---------------------------------------------------------------- patients account_id fix
+
+def test_created_patient_gets_account_id(admin_client, account, db_session):
+    r = admin_client.post("/api/patients", json={"first_name": "Nancy", "last_name": "Ward"})
+    assert r.status_code in (200, 201), r.text
+    from schemas.patient import Patient
+    row = db_session.query(Patient).filter_by(first_name="Nancy", last_name="Ward").one()
+    assert row.account_id == account.id

--- a/backend/tests/test_ha_directory.py
+++ b/backend/tests/test_ha_directory.py
@@ -198,6 +198,14 @@ def test_import_requires_admin(limited_client, account):
     assert _import(limited_client).status_code == 403
 
 
+def test_import_rejects_out_of_bounds_lengths(admin_client, account):
+    """Bounds mirror the users table so bad input never reaches the DB."""
+    assert _import(admin_client, username="ab").status_code == 422
+    assert _import(admin_client, username="x" * 51).status_code == 422
+    assert _import(admin_client, full_name="").status_code == 422
+    assert _import(admin_client, full_name="y" * 101).status_code == 422
+
+
 # ---------------------------------------------------------------- patients account_id fix
 
 def test_created_patient_gets_account_id(admin_client, account, db_session):

--- a/backend/tests/test_ha_directory.py
+++ b/backend/tests/test_ha_directory.py
@@ -206,3 +206,43 @@ def test_created_patient_gets_account_id(admin_client, account, db_session):
     from schemas.patient import Patient
     row = db_session.query(Patient).filter_by(first_name="Nancy", last_name="Ward").one()
     assert row.account_id == account.id
+
+
+# ---------------------------------------------------------------- patient <- HA login provenance
+
+def test_add_patient_from_ha_login_is_once_only(admin_client, account, db_session, fake_directory):
+    fake_directory["error"] = HACoreError("fallback is fine here")
+    r = admin_client.post("/api/patients", json={
+        "first_name": "Eli", "last_name": "Carty", "ha_user_id": HA_NEW,
+    })
+    assert r.status_code in (200, 201), r.text
+    from schemas.patient import Patient
+    row = db_session.query(Patient).filter_by(ha_user_id=HA_NEW).one()
+    assert row.first_name == "Eli"
+
+    # Same HA login again -> 409, whether creating or retargeting another patient.
+    r = admin_client.post("/api/patients", json={
+        "first_name": "Eli", "last_name": "Again", "ha_user_id": HA_NEW,
+    })
+    assert r.status_code == 409
+
+    # The directory surfaces the patient so the UI can hide the button.
+    body = admin_client.get("/api/auth/ha/directory").json()
+    by_id = {u["ha_user_id"]: u for u in body["users"]}
+    assert by_id[HA_NEW]["patient"] == {"id": row.id, "first_name": "Eli", "last_name": "Carty"}
+
+
+def test_patient_ha_user_id_must_be_valid(admin_client, account):
+    r = admin_client.post("/api/patients", json={
+        "first_name": "Bad", "last_name": "Id", "ha_user_id": "Z" * 32,
+    })
+    assert r.status_code == 400
+
+
+def test_existing_patient_can_be_retro_linked(admin_client, account, db_session):
+    r = admin_client.post("/api/patients", json={"first_name": "Old", "last_name": "Record"})
+    pid = r.json()["id"]
+    r = admin_client.put(f"/api/patients/{pid}", json={"ha_user_id": HA_NEW})
+    assert r.status_code == 200, r.text
+    from schemas.patient import Patient
+    assert db_session.query(Patient).get(pid).ha_user_id == HA_NEW

--- a/backend/utils/ha_core.py
+++ b/backend/utils/ha_core.py
@@ -1,0 +1,115 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Home Assistant Core API access from inside the add-on.
+
+The Supervisor proxies an admin-privileged Core WebSocket at
+ws://supervisor/core/websocket for add-ons with ``homeassistant_api: true``,
+authenticated with the SUPERVISOR_TOKEN it injects into the container env.
+We use it for exactly one thing: ``config/auth/list``, the HA user directory,
+so admins can link/import household members before they ever open the panel.
+
+Outside the add-on (Compose/unified image) there is no token — every call
+raises HACoreError and callers degrade to the "seen on ingress" fallback.
+"""
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_SUPERVISOR_WS_URL = "ws://supervisor/core/websocket"
+
+
+class HACoreError(Exception):
+    """Core WS unavailable, auth failed, timed out, or replied unexpectedly."""
+
+
+@dataclass(frozen=True)
+class HADirectoryUser:
+    """One Home Assistant user from config/auth/list."""
+    ha_user_id: str
+    name: Optional[str]
+    username: Optional[str]
+    is_owner: bool
+    is_active: bool
+    local_only: bool
+    is_admin: bool
+
+
+def ha_core_available() -> bool:
+    """True when running as the HA add-on (Supervisor injected its token)."""
+    return bool(os.environ.get("SUPERVISOR_TOKEN"))
+
+
+def _users_from_result(result) -> list[HADirectoryUser]:
+    """Parse the config/auth/list result, skipping HA-internal system users."""
+    users = []
+    for entry in result or []:
+        if not isinstance(entry, dict) or entry.get("system_generated"):
+            continue
+        ha_user_id = entry.get("id")
+        if not ha_user_id:
+            continue
+        group_ids = entry.get("group_ids") or []
+        users.append(HADirectoryUser(
+            ha_user_id=ha_user_id,
+            name=entry.get("name"),
+            username=entry.get("username"),
+            is_owner=bool(entry.get("is_owner")),
+            is_active=bool(entry.get("is_active", True)),
+            local_only=bool(entry.get("local_only")),
+            is_admin=entry.get("is_owner") or "system-admin" in group_ids,
+        ))
+    return users
+
+
+async def list_ha_users(timeout: float = 5.0) -> list[HADirectoryUser]:
+    """The full HA user directory, or HACoreError on any failure."""
+    token = os.environ.get("SUPERVISOR_TOKEN")
+    if not token:
+        raise HACoreError("Supervisor API not available (not running as the HA add-on)")
+
+    # websockets>=13 client API; the pin in requirements.txt is 15.x.
+    from websockets.asyncio.client import connect
+
+    try:
+        async with asyncio.timeout(timeout):
+            async with connect(_SUPERVISOR_WS_URL, open_timeout=timeout) as ws:
+                msg = json.loads(await ws.recv())
+                if msg.get("type") != "auth_required":
+                    raise HACoreError(f"Unexpected greeting: {msg.get('type')}")
+                await ws.send(json.dumps({"type": "auth", "access_token": token}))
+                msg = json.loads(await ws.recv())
+                if msg.get("type") != "auth_ok":
+                    raise HACoreError(f"Core WS auth failed: {msg.get('type')}")
+
+                await ws.send(json.dumps({"id": 1, "type": "config/auth/list"}))
+                while True:
+                    msg = json.loads(await ws.recv())
+                    if msg.get("id") == 1 and msg.get("type") == "result":
+                        break
+                if not msg.get("success"):
+                    raise HACoreError(f"config/auth/list failed: {msg.get('error')}")
+                return _users_from_result(msg.get("result"))
+    except HACoreError:
+        raise
+    except Exception as e:  # timeout, DNS, connection refused, bad JSON, ...
+        logger.debug(f"HA core directory fetch failed: {e}")
+        raise HACoreError(str(e)) from e

--- a/frontend/src/pages/admin-v2/AdminV2Users.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Users.jsx
@@ -359,7 +359,13 @@ const AdminV2Users = () => {
           )}
 
           {/* HA identity mapping (system admins; hides itself otherwise) */}
-          <HAIdentitiesCard users={users} />
+          <HAIdentitiesCard
+            users={users}
+            roles={roles}
+            patients={patients}
+            onUsersChanged={fetchUsers}
+            onPatientsChanged={fetchPatients}
+          />
         </div>
 
         {/* Create User Dialog */}

--- a/frontend/src/pages/admin-v2/components/HAIdentitiesCard.jsx
+++ b/frontend/src/pages/admin-v2/components/HAIdentitiesCard.jsx
@@ -114,7 +114,9 @@ export default function HAIdentitiesCard({
   const openImport = (item) => {
     setImportError(null);
     setImportForm({
-      username: item.username || slugify(item.name),
+      // slugify can come up empty (all-non-ASCII names); fall back to a stable
+      // handle from the HA user id so the dialog always opens submittable.
+      username: item.username || slugify(item.name) || `ha_${item.ha_user_id.slice(0, 8)}`,
       full_name: item.name || item.username || '',
       role_ids: [],
       patient_ids: [],

--- a/frontend/src/pages/admin-v2/components/HAIdentitiesCard.jsx
+++ b/frontend/src/pages/admin-v2/components/HAIdentitiesCard.jsx
@@ -15,58 +15,88 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-// Home Assistant identities seen on ingress, with link/unlink to app users.
-// Every HA user who opens the panel appears here automatically; linking one
-// makes them sign in with no prompts from then on. System-admin only (the
-// backend 403s otherwise, and the card hides itself).
+// Home Assistant user directory. As the HA add-on this lists EVERY HA user
+// (Supervisor API) so admins can link or import household members before
+// they ever open the panel; outside the add-on it falls back to identities
+// seen on ingress. Import creates a passwordless app profile pre-linked to
+// the HA login. System-admin only (the backend 403s; the card hides itself).
 import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Alert } from '@/components/ui/alert';
+import { Input } from '@/components/ui/input';
+import { Field } from '@/components/ui/field';
+import {
+  Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle,
+} from '@/components/ui/dialog';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
 } from '@/components/ui/select';
-import { isIngress } from '../../../config';
+import { ToggleList } from './ToggleList';
+import { isIngress, apiFetch, API_BASE_URL } from '../../../config';
 import {
-  listHaIdentities, linkHaIdentity, unlinkHaIdentity, forgetHaIdentity,
+  getHaDirectory, importHaUser, linkHaIdentity, unlinkHaIdentity, forgetHaIdentity,
 } from '../../../services/haIdentity';
 
-const identityLabel = (item) =>
-  item.display_name || item.username || `HA user ${item.ha_user_id.slice(0, 8)}…`;
+const rowLabel = (item) =>
+  item.name || item.username || `HA user ${item.ha_user_id.slice(0, 8)}…`;
 
 const lastSeen = (iso) => {
   try { return new Date(iso).toLocaleDateString(); } catch { return ''; }
 };
 
-export default function HAIdentitiesCard({ users = [] }) {
-  const [items, setItems] = useState(null); // null = loading/forbidden
+const slugify = (name) =>
+  (name || '').toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+
+// "Nancy De La Cruz" -> first "Nancy", last "De La Cruz" (both editable after).
+const splitName = (name) => {
+  const parts = (name || '').trim().split(/\s+/);
+  return { first: parts[0] || '', last: parts.slice(1).join(' ') };
+};
+
+export default function HAIdentitiesCard({
+  users = [], roles = [], patients = [], onUsersChanged, onPatientsChanged,
+}) {
+  const [data, setData] = useState(null); // {available, users} | null (loading / not permitted)
   const [error, setError] = useState(null);
   const [busyId, setBusyId] = useState(null);
   const [pendingLink, setPendingLink] = useState({}); // ha_user_id -> selected app user id
 
+  // Import dialog
+  const [importTarget, setImportTarget] = useState(null); // directory row | null
+  const [importForm, setImportForm] = useState({ username: '', full_name: '', role_ids: [], patient_ids: [] });
+  const [importError, setImportError] = useState(null);
+  const [importing, setImporting] = useState(false);
+
+  // Add-as-patient dialog
+  const [patientTarget, setPatientTarget] = useState(null); // directory row | null
+  const [patientForm, setPatientForm] = useState({ first_name: '', last_name: '' });
+  const [patientError, setPatientError] = useState(null);
+  const [savingPatient, setSavingPatient] = useState(false);
+
   const load = async () => {
     try {
-      setItems(await listHaIdentities());
+      setData(await getHaDirectory());
       setError(null);
     } catch (err) {
       if (err.status === 403 || err.status === 401) {
         // Not a system admin: this card simply isn't for them.
-        setItems(null);
+        setData(null);
       } else {
-        // Real failure: keep (or create) the card so the error is visible.
         setError(err.message);
-        setItems((prev) => prev ?? []);
+        setData((prev) => prev ?? { available: false, users: [] });
       }
     }
   };
 
   useEffect(() => { load(); }, []);
 
-  if (!items) return null; // loading, or not permitted
+  if (!data) return null; // loading, or not permitted
+  const items = data.users;
   if (items.length === 0 && !isIngress() && !error) return null;
 
-  const unmapped = items.filter((i) => !i.mapped_user).length;
+  const unmapped = items.filter((i) => i.status !== 'linked').length;
 
   const act = async (haUserId, fn) => {
     setBusyId(haUserId);
@@ -81,6 +111,90 @@ export default function HAIdentitiesCard({ users = [] }) {
     }
   };
 
+  const openImport = (item) => {
+    setImportError(null);
+    setImportForm({
+      username: item.username || slugify(item.name),
+      full_name: item.name || item.username || '',
+      role_ids: [],
+      patient_ids: [],
+    });
+    setImportTarget(item);
+  };
+
+  const importIsAdmin = () => importForm.role_ids.some((rid) => {
+    const role = roles.find((r) => r.id === rid);
+    return role && role.name === 'system_admin';
+  });
+
+  const handleImport = async (e) => {
+    e.preventDefault();
+    setImportError(null);
+    setImporting(true);
+    try {
+      const created = await importHaUser({
+        ha_user_id: importTarget.ha_user_id,
+        username: importForm.username,
+        full_name: importForm.full_name,
+        role_ids: importForm.role_ids,
+      });
+      if (importForm.patient_ids.length > 0 && !importIsAdmin()) {
+        await apiFetch(`${API_BASE_URL}/api/users/${created.id}/patients`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ patient_ids: importForm.patient_ids }),
+        });
+      }
+      setImportTarget(null);
+      await load();
+      onUsersChanged?.();
+    } catch (err) {
+      setImportError(err.message);
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const openAddPatient = (item) => {
+    setPatientError(null);
+    const { first, last } = splitName(item.name || item.username);
+    setPatientForm({ first_name: first, last_name: last });
+    setPatientTarget(item);
+  };
+
+  const handleAddPatient = async (e) => {
+    e.preventDefault();
+    setPatientError(null);
+    setSavingPatient(true);
+    try {
+      const res = await apiFetch(`${API_BASE_URL}/api/patients`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patientForm),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(typeof body.detail === 'string' ? body.detail : 'Failed to create patient');
+      }
+      setPatientTarget(null);
+      onPatientsChanged?.();
+    } catch (err) {
+      setPatientError(err.message);
+    } finally {
+      setSavingPatient(false);
+    }
+  };
+
+  const statusBadge = (item) => {
+    if (item.status === 'linked') {
+      return <Badge variant="secondary">Signs in as {item.mapped_user.full_name}</Badge>;
+    }
+    if (item.status === 'seen') {
+      return <Badge variant="outline">Opened the app · last seen {lastSeen(item.last_seen)}</Badge>;
+    }
+    return <Badge variant="outline">Never opened the app</Badge>;
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -89,33 +203,43 @@ export default function HAIdentitiesCard({ users = [] }) {
           {unmapped > 0 && <Badge variant="default">{unmapped} not linked</Badge>}
         </div>
         <p className="text-sm text-muted-foreground">
-          Anyone who opens the app from the Home Assistant sidebar shows up here.
-          Link them to a profile and they'll be signed in automatically — no
-          password, no picker.
+          {data.available
+            ? 'Everyone with a Home Assistant login. Link them to an existing profile, ' +
+              'create a profile for them (they sign in automatically — no password), ' +
+              'or add them as a patient.'
+            : 'Anyone who opens the app from the Home Assistant sidebar shows up here. ' +
+              'Link them to a profile and they\'ll be signed in automatically.'}
         </p>
+        {!data.available && items.length > 0 && (
+          <p className="text-xs text-muted-foreground">
+            Showing only Home Assistant users who have opened the app — running as
+            the Home Assistant add-on lists everyone automatically.
+          </p>
+        )}
       </CardHeader>
       <CardContent className="space-y-3">
         {error && <Alert variant="destructive">{error}</Alert>}
         {items.length === 0 ? (
           <p className="text-sm text-muted-foreground">
-            No Home Assistant users have opened the app yet. Have them open it
-            from the HA sidebar once and they'll appear here.
+            No Home Assistant users found yet. Have them open the app from the HA
+            sidebar once and they'll appear here.
           </p>
         ) : (
           items.map((item) => (
             <div
               key={item.ha_user_id}
-              className="flex flex-col gap-2 rounded-md border border-border p-3 sm:flex-row sm:items-center sm:justify-between"
+              className="flex flex-col gap-2 rounded-md border border-border p-3"
             >
-              <div className="flex min-w-0 flex-col">
-                <span className="truncate font-medium text-foreground">{identityLabel(item)}</span>
-                <span className="truncate text-xs text-muted-foreground">
-                  {item.username ? `@${item.username} · ` : ''}last seen {lastSeen(item.last_seen)}
-                </span>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-medium text-foreground">{rowLabel(item)}</span>
+                {item.username && <span className="text-xs text-muted-foreground">@{item.username}</span>}
+                {item.ha_is_owner ? <Badge variant="outline">HA owner</Badge>
+                  : item.ha_is_admin ? <Badge variant="outline">HA admin</Badge> : null}
+                {!item.in_directory && <Badge variant="outline">Not in Home Assistant</Badge>}
+                {statusBadge(item)}
               </div>
-              {item.mapped_user ? (
+              {item.status === 'linked' ? (
                 <div className="flex items-center gap-2">
-                  <Badge variant="secondary">Signs in as {item.mapped_user.full_name}</Badge>
                   <Button
                     variant="secondary" size="sm"
                     disabled={busyId === item.ha_user_id}
@@ -125,12 +249,12 @@ export default function HAIdentitiesCard({ users = [] }) {
                   </Button>
                 </div>
               ) : (
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   <Select
                     value={pendingLink[item.ha_user_id] || ''}
                     onValueChange={(v) => setPendingLink((prev) => ({ ...prev, [item.ha_user_id]: v }))}
                   >
-                    <SelectTrigger className="w-44"><SelectValue placeholder="Choose profile…" /></SelectTrigger>
+                    <SelectTrigger className="w-44"><SelectValue placeholder="Link to profile…" /></SelectTrigger>
                     <SelectContent>
                       {users.filter((u) => u.is_active).map((u) => (
                         <SelectItem key={u.id} value={String(u.id)}>{u.full_name}</SelectItem>
@@ -145,19 +269,138 @@ export default function HAIdentitiesCard({ users = [] }) {
                   >
                     Link
                   </Button>
-                  <Button
-                    variant="ghost" size="sm"
-                    disabled={busyId === item.ha_user_id}
-                    onClick={() => act(item.ha_user_id, () => forgetHaIdentity(item.ha_user_id))}
-                  >
-                    Remove
+                  <Button variant="secondary" size="sm" onClick={() => openImport(item)}>
+                    Create profile
                   </Button>
+                  <Button variant="secondary" size="sm" onClick={() => openAddPatient(item)}>
+                    Add as patient
+                  </Button>
+                  {!item.in_directory && item.status === 'seen' && (
+                    <Button
+                      variant="ghost" size="sm"
+                      disabled={busyId === item.ha_user_id}
+                      onClick={() => act(item.ha_user_id, () => forgetHaIdentity(item.ha_user_id))}
+                    >
+                      Remove
+                    </Button>
+                  )}
                 </div>
               )}
             </div>
           ))
         )}
       </CardContent>
+
+      {/* Import: create a passwordless, pre-linked app profile */}
+      <Dialog open={!!importTarget} onOpenChange={(o) => { if (!o) setImportTarget(null); }}>
+        <DialogContent className="sm:max-w-[520px]" aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>Create profile for {importTarget ? rowLabel(importTarget) : ''}</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleImport} className="flex flex-col gap-4">
+            {importError && <Alert variant="destructive">{importError}</Alert>}
+            <p className="text-sm text-muted-foreground">
+              No password needed — opening the app from the Home Assistant sidebar
+              signs them in. A password or PIN can be added later for shared devices.
+            </p>
+            <Field label="Full Name" required htmlFor="ha-import-fullname">
+              <Input
+                id="ha-import-fullname"
+                value={importForm.full_name}
+                onChange={(e) => setImportForm({ ...importForm, full_name: e.target.value })}
+                required
+              />
+            </Field>
+            <Field label="Username" required htmlFor="ha-import-username">
+              <Input
+                id="ha-import-username"
+                value={importForm.username}
+                onChange={(e) => setImportForm({ ...importForm, username: e.target.value })}
+                required minLength={3}
+              />
+            </Field>
+            <Field label="Roles">
+              <ToggleList
+                items={roles}
+                selectedIds={importForm.role_ids}
+                onToggle={(rid) => setImportForm((prev) => ({
+                  ...prev,
+                  role_ids: prev.role_ids.includes(rid)
+                    ? prev.role_ids.filter((id) => id !== rid)
+                    : [...prev.role_ids, rid],
+                }))}
+                getId={(r) => r.id}
+                renderLabel={(r) => r.display_name}
+                empty="No roles available"
+              />
+            </Field>
+            <Field label="Patient Assignments">
+              {importIsAdmin() ? (
+                <div className="rounded-md border border-border bg-background/40 p-3 text-sm text-muted-foreground">
+                  System admins have access to all patients automatically.
+                </div>
+              ) : (
+                <ToggleList
+                  items={patients}
+                  selectedIds={importForm.patient_ids}
+                  onToggle={(pid) => setImportForm((prev) => ({
+                    ...prev,
+                    patient_ids: prev.patient_ids.includes(pid)
+                      ? prev.patient_ids.filter((id) => id !== pid)
+                      : [...prev.patient_ids, pid],
+                  }))}
+                  getId={(p) => p.id}
+                  renderLabel={(p) => `${p.first_name} ${p.last_name}`}
+                  empty="No patients configured yet."
+                />
+              )}
+            </Field>
+            <DialogFooter>
+              <Button type="button" variant="secondary" onClick={() => setImportTarget(null)}>Cancel</Button>
+              <Button type="submit" disabled={importing}>
+                {importing ? 'Creating…' : 'Create profile'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Add the HA user as a patient (name prefilled, both fields editable) */}
+      <Dialog open={!!patientTarget} onOpenChange={(o) => { if (!o) setPatientTarget(null); }}>
+        <DialogContent className="sm:max-w-[440px]" aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>Add {patientTarget ? rowLabel(patientTarget) : ''} as a patient</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleAddPatient} className="flex flex-col gap-4">
+            {patientError && <Alert variant="destructive">{patientError}</Alert>}
+            <Field label="First Name" required htmlFor="ha-patient-first">
+              <Input
+                id="ha-patient-first"
+                value={patientForm.first_name}
+                onChange={(e) => setPatientForm({ ...patientForm, first_name: e.target.value })}
+                required
+              />
+            </Field>
+            <Field label="Last Name" required htmlFor="ha-patient-last">
+              <Input
+                id="ha-patient-last"
+                value={patientForm.last_name}
+                onChange={(e) => setPatientForm({ ...patientForm, last_name: e.target.value })}
+                required
+              />
+            </Field>
+            <p className="text-sm text-muted-foreground">
+              Date of birth and other details can be filled in afterward on the Patients page.
+            </p>
+            <DialogFooter>
+              <Button type="button" variant="secondary" onClick={() => setPatientTarget(null)}>Cancel</Button>
+              <Button type="submit" disabled={savingPatient}>
+                {savingPatient ? 'Adding…' : 'Add patient'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/frontend/src/pages/admin-v2/components/HAIdentitiesCard.jsx
+++ b/frontend/src/pages/admin-v2/components/HAIdentitiesCard.jsx
@@ -158,7 +158,7 @@ export default function HAIdentitiesCard({
   const openAddPatient = (item) => {
     setPatientError(null);
     const { first, last } = splitName(item.name || item.username);
-    setPatientForm({ first_name: first, last_name: last });
+    setPatientForm({ first_name: first, last_name: last, existing_id: '' });
     setPatientTarget(item);
   };
 
@@ -167,16 +167,30 @@ export default function HAIdentitiesCard({
     setPatientError(null);
     setSavingPatient(true);
     try {
-      const res = await apiFetch(`${API_BASE_URL}/api/patients`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(patientForm),
-      });
+      // ha_user_id records the provenance so this HA login can only be turned
+      // into a patient once (the button disappears afterward). Either stamp it
+      // onto an existing patient or create a new one carrying it.
+      const res = patientForm.existing_id
+        ? await apiFetch(`${API_BASE_URL}/api/patients/${patientForm.existing_id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ha_user_id: patientTarget.ha_user_id }),
+          })
+        : await apiFetch(`${API_BASE_URL}/api/patients`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              first_name: patientForm.first_name,
+              last_name: patientForm.last_name,
+              ha_user_id: patientTarget.ha_user_id,
+            }),
+          });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        throw new Error(typeof body.detail === 'string' ? body.detail : 'Failed to create patient');
+        throw new Error(typeof body.detail === 'string' ? body.detail : 'Failed to save patient');
       }
       setPatientTarget(null);
+      await load();
       onPatientsChanged?.();
     } catch (err) {
       setPatientError(err.message);
@@ -237,6 +251,11 @@ export default function HAIdentitiesCard({
                   : item.ha_is_admin ? <Badge variant="outline">HA admin</Badge> : null}
                 {!item.in_directory && <Badge variant="outline">Not in Home Assistant</Badge>}
                 {statusBadge(item)}
+                {item.patient && (
+                  <Badge variant="secondary">
+                    Patient: {item.patient.first_name} {item.patient.last_name}
+                  </Badge>
+                )}
               </div>
               {item.status === 'linked' ? (
                 <div className="flex items-center gap-2">
@@ -272,9 +291,11 @@ export default function HAIdentitiesCard({
                   <Button variant="secondary" size="sm" onClick={() => openImport(item)}>
                     Create profile
                   </Button>
-                  <Button variant="secondary" size="sm" onClick={() => openAddPatient(item)}>
-                    Add as patient
-                  </Button>
+                  {!item.patient && (
+                    <Button variant="secondary" size="sm" onClick={() => openAddPatient(item)}>
+                      Add as patient
+                    </Button>
+                  )}
                   {!item.in_directory && item.status === 'seen' && (
                     <Button
                       variant="ghost" size="sm"
@@ -373,29 +394,48 @@ export default function HAIdentitiesCard({
           </DialogHeader>
           <form onSubmit={handleAddPatient} className="flex flex-col gap-4">
             {patientError && <Alert variant="destructive">{patientError}</Alert>}
-            <Field label="First Name" required htmlFor="ha-patient-first">
-              <Input
-                id="ha-patient-first"
-                value={patientForm.first_name}
-                onChange={(e) => setPatientForm({ ...patientForm, first_name: e.target.value })}
-                required
-              />
-            </Field>
-            <Field label="Last Name" required htmlFor="ha-patient-last">
-              <Input
-                id="ha-patient-last"
-                value={patientForm.last_name}
-                onChange={(e) => setPatientForm({ ...patientForm, last_name: e.target.value })}
-                required
-              />
-            </Field>
-            <p className="text-sm text-muted-foreground">
-              Date of birth and other details can be filled in afterward on the Patients page.
-            </p>
+            {patients.length > 0 && (
+              <Field label="Link an existing patient (optional)">
+                <Select
+                  value={patientForm.existing_id}
+                  onValueChange={(v) => setPatientForm({ ...patientForm, existing_id: v })}
+                >
+                  <SelectTrigger><SelectValue placeholder="No — create a new patient" /></SelectTrigger>
+                  <SelectContent>
+                    {patients.map((p) => (
+                      <SelectItem key={p.id} value={String(p.id)}>{p.first_name} {p.last_name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+            )}
+            {!patientForm.existing_id && (
+              <>
+                <Field label="First Name" required htmlFor="ha-patient-first">
+                  <Input
+                    id="ha-patient-first"
+                    value={patientForm.first_name}
+                    onChange={(e) => setPatientForm({ ...patientForm, first_name: e.target.value })}
+                    required
+                  />
+                </Field>
+                <Field label="Last Name" required htmlFor="ha-patient-last">
+                  <Input
+                    id="ha-patient-last"
+                    value={patientForm.last_name}
+                    onChange={(e) => setPatientForm({ ...patientForm, last_name: e.target.value })}
+                    required
+                  />
+                </Field>
+                <p className="text-sm text-muted-foreground">
+                  Date of birth and other details can be filled in afterward on the Patients page.
+                </p>
+              </>
+            )}
             <DialogFooter>
               <Button type="button" variant="secondary" onClick={() => setPatientTarget(null)}>Cancel</Button>
               <Button type="submit" disabled={savingPatient}>
-                {savingPatient ? 'Adding…' : 'Add patient'}
+                {savingPatient ? 'Saving…' : (patientForm.existing_id ? 'Link patient' : 'Add patient')}
               </Button>
             </DialogFooter>
           </form>

--- a/frontend/src/pages/admin-v2/components/HAIdentitiesCard.test.jsx
+++ b/frontend/src/pages/admin-v2/components/HAIdentitiesCard.test.jsx
@@ -112,6 +112,16 @@ describe('HAIdentitiesCard directory mode', () => {
     expect(screen.getAllByRole('button', { name: 'Remove' }).length).toBe(1);
   });
 
+  it('falls back to an id-derived username when the HA user has no usable name', async () => {
+    getHaDirectory.mockResolvedValue({
+      available: true,
+      users: [{ ha_user_id: HA_C, name: '日本語', username: null, status: 'never_opened', in_directory: true }],
+    });
+    await renderCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
+    expect(screen.getByDisplayValue(`ha_${HA_C.slice(0, 8)}`)).toBeInTheDocument();
+  });
+
   it('hides "Add as patient" once the HA login produced a patient', async () => {
     getHaDirectory.mockResolvedValue({
       available: true,

--- a/frontend/src/pages/admin-v2/components/HAIdentitiesCard.test.jsx
+++ b/frontend/src/pages/admin-v2/components/HAIdentitiesCard.test.jsx
@@ -112,6 +112,21 @@ describe('HAIdentitiesCard directory mode', () => {
     expect(screen.getAllByRole('button', { name: 'Remove' }).length).toBe(1);
   });
 
+  it('hides "Add as patient" once the HA login produced a patient', async () => {
+    getHaDirectory.mockResolvedValue({
+      available: true,
+      users: [{
+        ha_user_id: HA_B, name: 'Elijah', status: 'never_opened', in_directory: true,
+        patient: { id: 7, first_name: 'Elijah', last_name: 'Carty' },
+      }],
+    });
+    await renderCard();
+    expect(await screen.findByText('Patient: Elijah Carty')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add as patient' })).not.toBeInTheDocument();
+    // The other actions stay available.
+    expect(screen.getByRole('button', { name: 'Create profile' })).toBeInTheDocument();
+  });
+
   it('imports an HA user with chosen roles, then assigns patients and refreshes', async () => {
     getHaDirectory.mockResolvedValue(DIRECTORY);
     importHaUser.mockResolvedValue({ id: 42, username: 'nurse_nancy' });
@@ -152,7 +167,10 @@ describe('HAIdentitiesCard directory mode', () => {
 
     await waitFor(() => expect(apiFetch).toHaveBeenCalledWith(
       'http://api/api/patients',
-      expect.objectContaining({ method: 'POST', body: JSON.stringify({ first_name: 'Nurse', last_name: 'Nancy' }) }),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ first_name: 'Nurse', last_name: 'Nancy', ha_user_id: HA_B }),
+      }),
     ));
     await waitFor(() => expect(onPatientsChanged).toHaveBeenCalled());
   });

--- a/frontend/src/pages/admin-v2/components/HAIdentitiesCard.test.jsx
+++ b/frontend/src/pages/admin-v2/components/HAIdentitiesCard.test.jsx
@@ -1,0 +1,183 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// HAIdentitiesCard: directory mode (all HA users + import/patient actions)
+// vs seen-only fallback; import dialog wiring. Services and config mocked;
+// Radix dialogs rendered inline (portal/focus-trap noise).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Radix (via ToggleList's Checkbox) probes element size; jsdom has no ResizeObserver.
+vi.stubGlobal('ResizeObserver', class { observe() {} unobserve() {} disconnect() {} });
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }) => <div>{children}</div>,
+  DialogHeader: ({ children }) => <div>{children}</div>,
+  DialogTitle: ({ children }) => <h2>{children}</h2>,
+  DialogFooter: ({ children }) => <div>{children}</div>,
+}));
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }) => <div>{children}</div>,
+  SelectTrigger: ({ children }) => <div>{children}</div>,
+  SelectValue: () => null,
+  SelectContent: ({ children }) => <div>{children}</div>,
+  SelectItem: ({ children }) => <div>{children}</div>,
+}));
+
+const apiFetch = vi.fn();
+vi.mock('../../../config', () => ({
+  isIngress: () => true,
+  apiFetch: (...a) => apiFetch(...a),
+  API_BASE_URL: 'http://api',
+}));
+
+const getHaDirectory = vi.fn();
+const importHaUser = vi.fn();
+const linkHaIdentity = vi.fn();
+const unlinkHaIdentity = vi.fn();
+const forgetHaIdentity = vi.fn();
+vi.mock('../../../services/haIdentity', () => ({
+  getHaDirectory: (...a) => getHaDirectory(...a),
+  importHaUser: (...a) => importHaUser(...a),
+  linkHaIdentity: (...a) => linkHaIdentity(...a),
+  unlinkHaIdentity: (...a) => unlinkHaIdentity(...a),
+  forgetHaIdentity: (...a) => forgetHaIdentity(...a),
+}));
+
+import HAIdentitiesCard from './HAIdentitiesCard';
+
+const HA_A = 'a'.repeat(32);
+const HA_B = 'b'.repeat(32);
+const HA_C = 'c'.repeat(32);
+
+const DIRECTORY = {
+  available: true,
+  users: [
+    { ha_user_id: HA_A, name: 'John', username: 'john', status: 'linked', in_directory: true, ha_is_owner: true, mapped_user: { id: 1, username: 'john', full_name: 'John' } },
+    { ha_user_id: HA_B, name: 'Nurse Nancy', username: null, status: 'never_opened', in_directory: true },
+    { ha_user_id: HA_C, name: 'Old Phone', username: null, status: 'seen', in_directory: false, last_seen: '2026-08-01T00:00:00Z' },
+  ],
+};
+
+const ROLES = [
+  { id: 1, name: 'system_admin', display_name: 'System Administrator' },
+  { id: 2, name: 'caregiver', display_name: 'Caregiver' },
+];
+const USERS = [{ id: 1, full_name: 'John', is_active: true }];
+const PATIENTS = [{ id: 5, first_name: 'Eli', last_name: 'C' }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.__BASE_PATH__ = '/api/hassio_ingress/tok';
+});
+
+const renderCard = async (props = {}) => {
+  render(
+    <HAIdentitiesCard
+      users={USERS} roles={ROLES} patients={PATIENTS}
+      onUsersChanged={props.onUsersChanged || vi.fn()}
+      onPatientsChanged={props.onPatientsChanged || vi.fn()}
+    />
+  );
+  await waitFor(() => expect(getHaDirectory).toHaveBeenCalled());
+};
+
+describe('HAIdentitiesCard directory mode', () => {
+  it('renders all HA users with status chips and actions', async () => {
+    getHaDirectory.mockResolvedValue(DIRECTORY);
+    await renderCard();
+    expect(await screen.findByText('Nurse Nancy')).toBeInTheDocument();
+    expect(screen.getByText('Signs in as John')).toBeInTheDocument();
+    expect(screen.getByText('Never opened the app')).toBeInTheDocument();
+    expect(screen.getByText('HA owner')).toBeInTheDocument();
+    expect(screen.getByText('Not in Home Assistant')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Create profile' }).length).toBe(2);
+    expect(screen.getAllByRole('button', { name: 'Add as patient' }).length).toBe(2);
+    // Remove only offered for the stale seen row.
+    expect(screen.getAllByRole('button', { name: 'Remove' }).length).toBe(1);
+  });
+
+  it('imports an HA user with chosen roles, then assigns patients and refreshes', async () => {
+    getHaDirectory.mockResolvedValue(DIRECTORY);
+    importHaUser.mockResolvedValue({ id: 42, username: 'nurse_nancy' });
+    apiFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+    const onUsersChanged = vi.fn();
+    await renderCard({ onUsersChanged });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Create profile' })[0]);
+    // Prefilled from the HA name.
+    expect(screen.getByDisplayValue('Nurse Nancy')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('nurse_nancy')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Caregiver'));
+    fireEvent.click(screen.getByText('Eli C'));
+    // Dialog renders after the rows, so the last "Create profile" is the submit.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Create profile' }).at(-1));
+
+    await waitFor(() => expect(importHaUser).toHaveBeenCalledWith({
+      ha_user_id: HA_B, username: 'nurse_nancy', full_name: 'Nurse Nancy', role_ids: [2],
+    }));
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledWith(
+      'http://api/api/users/42/patients',
+      expect.objectContaining({ method: 'PUT' }),
+    ));
+    await waitFor(() => expect(onUsersChanged).toHaveBeenCalled());
+  });
+
+  it('adds an HA user as a patient with the name pre-split', async () => {
+    getHaDirectory.mockResolvedValue(DIRECTORY);
+    apiFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+    const onPatientsChanged = vi.fn();
+    await renderCard({ onPatientsChanged });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add as patient' })[0]);
+    expect(screen.getByDisplayValue('Nurse')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Nancy')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Add patient' }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledWith(
+      'http://api/api/patients',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ first_name: 'Nurse', last_name: 'Nancy' }) }),
+    ));
+    await waitFor(() => expect(onPatientsChanged).toHaveBeenCalled());
+  });
+});
+
+describe('HAIdentitiesCard fallback mode', () => {
+  it('shows the seen-only hint when the directory is unavailable', async () => {
+    getHaDirectory.mockResolvedValue({
+      available: false,
+      users: [{ ha_user_id: HA_A, name: 'John', status: 'seen', in_directory: true, last_seen: '2026-08-01T00:00:00Z' }],
+    });
+    await renderCard();
+    expect(await screen.findByText(/Showing only Home Assistant users who have opened the app/)).toBeInTheDocument();
+    // Stale flag never shows in fallback mode.
+    expect(screen.queryByText('Not in Home Assistant')).not.toBeInTheDocument();
+  });
+
+  it('hides itself when the backend says not permitted', async () => {
+    const err = new Error('forbidden');
+    err.status = 403;
+    getHaDirectory.mockRejectedValue(err);
+    const { container } = render(
+      <HAIdentitiesCard users={USERS} roles={ROLES} patients={PATIENTS} />
+    );
+    await waitFor(() => expect(getHaDirectory).toHaveBeenCalled());
+    expect(container.querySelector('.font-medium')).toBeNull();
+  });
+});

--- a/frontend/src/services/haIdentity.js
+++ b/frontend/src/services/haIdentity.js
@@ -36,6 +36,24 @@ export async function listHaIdentities() {
   return asJsonOrThrow(await apiFetch(`${base()}/identities`), 'Failed to load Home Assistant identities');
 }
 
+// Merged directory: everyone in HA (when running as the add-on) plus
+// identities seen on ingress and mapped users. {available, users: [...]}.
+export async function getHaDirectory() {
+  return asJsonOrThrow(await apiFetch(`${base()}/directory`), 'Failed to load the Home Assistant user directory');
+}
+
+// Create a passwordless app user pre-linked to an HA identity.
+export async function importHaUser({ ha_user_id, username, full_name, role_ids = [] }) {
+  return asJsonOrThrow(
+    await apiFetch(`${base()}/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ha_user_id, username, full_name, role_ids }),
+    }),
+    'Failed to import Home Assistant user',
+  );
+}
+
 export async function linkHaIdentity(haUserId, userId) {
   return asJsonOrThrow(
     await apiFetch(`${base()}/identities/${haUserId}/link`, {


### PR DESCRIPTION
Follow-up to #79: the admin card only knew HA users after they opened the panel, so a freshly created HA user was invisible (nothing to link, nothing to import).

## What's new
- **Full HA user directory.** Running as the add-on, the backend fetches `config/auth/list` over the Supervisor's core WS proxy (`SUPERVISOR_TOKEN`; uses the already-pinned `websockets` dep) and merges it with seen-on-ingress identities and mapped users: `GET /api/auth/ha/directory`. Always 200 — outside the add-on it returns `available:false` and degrades to today's seen-only list (also fixing a gap where mapped-but-never-seen users were invisible).
- **One-step import.** `POST /api/auth/ha/import` creates a passwordless app user pre-linked to the HA identity (random hash, `force_password_reset=False` — the HA login is the credential) with chosen roles; the UI then assigns patients via the existing `PUT /api/users/{id}/patients`.
- **Card rework.** "Home Assistant users" now shows everyone with status chips (Linked / Opened the app / Never opened), HA owner/admin badges, stale-row flag ("Not in Home Assistant"), and per-row actions: Link, **Create profile** (dialog with roles + patients), **Add as patient** (name-prefilled dialog → existing `POST /api/patients`).
- **Bug fix:** `create_patient` dropped `account_id` (route supplied it, constructor ignored it) — new patients were invisible to every account-filtered consumer (backup, MQTT publishing, integrations). Fixed + regression test.
- Add-on: `hassio_api` + `homeassistant_api` flags (**uninstall + reinstall required**; CHANGELOG's incorrect "data survives uninstall" claim corrected — back up `/data` first), DOCS section.

## Verified live on the dev HA
`config/auth/list` over the proxy returns the real user list; `/directory` served all four household HA users (owner flagged) with correct statuses; importing one produced a caregiver profile whose very next ingress login was a zero-prompt full session; LAN forged-header login still 403s. Backend 442 tests green (13 new), frontend 322 green (5 new), ESLint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Djmoqd4QNDTRWMYF8QT2SK