### PR TITLE
Release workflow: native arm64 runners (v0.2.0 publish hit the 6h QEMU timeout)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,12 @@ name: Publish image
 # Builds the unified app image (backend API + built SPA, one container) and
 # pushes it to GHCR on every version tag, so users can pull
 # ghcr.io/smart-home-health/platform instead of building from source.
-# Multi-arch: amd64 (PCs/servers) + arm64 (Raspberry Pi and friends).
-# Uses the built-in GITHUB_TOKEN — no extra secrets, same as shh-reader.
+#
+# Multi-arch via NATIVE runners: amd64 on ubuntu-latest, arm64 on GitHub's
+# free arm64 runners (public repos). The previous single-job QEMU build hit
+# the 6-hour job timeout emulating arm64 — the v0.2.0 publish died that way.
+# Each arch pushes by digest; a merge job stitches them into one manifest
+# with the metadata-action tags. Uses the built-in GITHUB_TOKEN.
 #
 # workflow_dispatch publishes :latest from whatever ref it runs on (semver
 # tags only appear on v* tag pushes).
@@ -13,16 +17,76 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+env:
+  # Must be lowercase for docker; matches what metadata-action derives.
+  IMAGE: ghcr.io/smart-home-health/platform
+
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v3        # arm64 emulation
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          # Push by digest only; the merge job applies the human tags.
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=release-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=release-${{ matrix.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -34,20 +98,18 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v5
         with:
-          # metadata-action lowercases this to ghcr.io/smart-home-health/platform
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ env.IMAGE }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
The tag-triggered unified-image publish for v0.2.0 was killed by GitHub's 6-hour job timeout — the arm64 half ran under QEMU emulation and never finished, so `ghcr.io/smart-home-health/platform:0.2.0` was never pushed (the add-on images were unaffected; their workflow builds per-arch).

Fix: the canonical native-runner matrix pattern — amd64 on `ubuntu-latest`, arm64 on GitHub's free `ubuntu-24.04-arm` runners (public repos), each pushing by digest with per-arch GHA build cache, then a merge job stitches the multi-arch manifest under the same metadata-action tags (`0.2.0`, `0.2`, `latest`). Expected wall time drops from >6h (timeout) to ~15–30 min. 90-minute per-arch timeout as a tripwire.

After merging: re-run for the existing release with either a re-pushed tag or `workflow_dispatch` from `dev/main` (dispatch publishes `:latest`; only a tag push produces the semver tags — see workflow comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Djmoqd4QNDTRWMYF8QT2SK