### PR TITLE
Release 0.2.1

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.2.1
+
+- **Reader devices work correctly under ingress.** Pairing a pulse-ox reader
+  while browsing from the HA sidebar now hands the device the hub's LAN
+  address (`http://<host>:8000`) instead of an unreachable ingress URL; the
+  backend also rejects ingress URLs outright as a backstop.
+- **Reader connection protection.** A live reader's connection slot can no
+  longer be taken over by an unauthenticated LAN peer — a reconnecting device
+  must prove it holds the pairing key with its first encrypted message before
+  the existing connection is replaced (replay-protected). Normal reconnects
+  are unaffected.
+- The reader data channel itself was audited and is untouched by the ingress
+  work — already-paired readers keep streaming as before.
+
 ## 0.2.0
 
 - **Home Assistant user directory.** Configuration → Users now lists *every*

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -5,7 +5,7 @@
 # Postgres data + uploaded artifacts live under the add-on's auto-persistent
 # /data, so they survive restarts and updates.
 name: Smart Home Health
-version: "0.2.0"
+version: "0.2.1"
 slug: smart_home_health
 description: Caregiving vitals monitor + medication / care-task scheduling hub
 url: https://github.com/Smart-Home-Health/platform


### PR DESCRIPTION
Add-on version bump + CHANGELOG for 0.2.1 (reader ingress-pairing fix, reader connection-slot protection). Tagging v0.2.1 on the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Djmoqd4QNDTRWMYF8QT2SK