### PR TITLE
Inbound Home Assistant integration: map HA entities to vitals + environment

### DIFF
--- a/backend/alembic/versions/039_ha_entity_mappings.py
+++ b/backend/alembic/versions/039_ha_entity_mappings.py
@@ -1,0 +1,72 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Inbound HA entity mappings
+
+Revision ID: 039_ha_entity_mappings
+Revises: 038_patient_ha_identity
+Create Date: 2026-08-15
+
+ha_entity_mappings routes selected Home Assistant entities into SHH:
+target_kind "vital" (patient vitals) or "environment" (environmental
+observations). See backend/homeassistant/.
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '039_ha_entity_mappings'
+down_revision: Union[str, None] = '038_patient_ha_identity'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'ha_entity_mappings',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('account_id', sa.Integer(), nullable=True),
+        sa.Column('entity_id', sa.String(length=255), nullable=False),
+        sa.Column('friendly_name', sa.String(length=255), nullable=True),
+        sa.Column('device_class', sa.String(length=50), nullable=True),
+        sa.Column('source_unit', sa.String(length=50), nullable=True),
+        sa.Column('target_kind', sa.String(length=20), nullable=False),
+        sa.Column('patient_id', sa.Integer(), nullable=True),
+        sa.Column('vital_type', sa.String(length=50), nullable=True),
+        sa.Column('vital_group', sa.String(length=50), nullable=True),
+        sa.Column('metric', sa.String(length=50), nullable=True),
+        sa.Column('scope', sa.String(length=20), nullable=True),
+        sa.Column('location', sa.String(length=100), nullable=True),
+        sa.Column('enabled', sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column('min_interval_seconds', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('last_seen_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('last_value', sa.Float(), nullable=True),
+        sa.Column('last_error', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['account_id'], ['accounts.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['patient_id'], ['patients.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('entity_id', name='uq_ha_entity_mappings_entity_id'),
+    )
+    op.create_index('ix_ha_entity_mappings_account_id', 'ha_entity_mappings', ['account_id'])
+    op.create_index('ix_ha_entity_mappings_patient_id', 'ha_entity_mappings', ['patient_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_ha_entity_mappings_patient_id', table_name='ha_entity_mappings')
+    op.drop_index('ix_ha_entity_mappings_account_id', table_name='ha_entity_mappings')
+    op.drop_table('ha_entity_mappings')

--- a/backend/environment/connectors/home_assistant.py
+++ b/backend/environment/connectors/home_assistant.py
@@ -1,0 +1,51 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Home Assistant room-sensor connector (GH #48) — push-mode registry entry.
+
+Readings arrive through the WS listener in backend/homeassistant/, which
+calls service.emit_observations directly with source_type "home_assistant";
+this class only makes the source visible to the environment framework
+(/api/environment/connectors and the Environment admin page). Configuration
+lives at /api/integrations/home_assistant, not in connector config.
+"""
+from typing import Dict
+
+from environment.base import EnvironmentConnector
+from environment.registry import register
+
+
+@register
+class HomeAssistantEnvConnector(EnvironmentConnector):
+    slug = "home_assistant"
+    name = "Home Assistant"
+    description = ("Room and indoor sensors ingested live from mapped Home "
+                   "Assistant entities (configure under Integrations > Home Assistant)")
+    metrics_provided = [
+        "temperature", "relative_humidity", "co2", "pm25", "voc",
+        "noise_level", "barometric_pressure", "aqi",
+    ]
+    poll_capable = False
+
+    @classmethod
+    def is_configured(cls, config: Dict) -> bool:
+        from homeassistant.service import connection_available, get_config
+        from state_manager import get_db_session
+        try:
+            with get_db_session() as db:
+                return connection_available(get_config(db))
+        except Exception:
+            return False

--- a/backend/homeassistant/__init__.py
+++ b/backend/homeassistant/__init__.py
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-Environment connector implementations.
+Inbound Home Assistant integration: read selected HA entities and record them
+as patient vitals or environmental observations.
 
-Importing a connector module triggers its ``@register`` decorator, which is
-how the registry gets populated — add new connectors to the import list below
-(same convention as ``integrations/__init__.py``).
+- ``client``: HA REST/WebSocket API client (supervisor-proxy or external).
+- ``service``: config/state accessors, entity-state -> vital/observation routing.
+- ``listener``: the background WS subscription loop started from main.py.
 """
-from . import open_meteo  # noqa: F401
-from . import home_assistant  # noqa: F401

--- a/backend/homeassistant/client.py
+++ b/backend/homeassistant/client.py
@@ -1,0 +1,303 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Home Assistant REST/WebSocket API client.
+
+Two connection modes, auto-detected in ``from_config``:
+
+- **Supervisor proxy** (running as the HA add-on): the Supervisor injects
+  SUPERVISOR_TOKEN and proxies an admin-privileged Core API at
+  http://supervisor/core/api + ws://supervisor/core/websocket
+  (``homeassistant_api: true`` in addon/config.yaml). Zero user config.
+- **External**: any reachable HA instance via its base URL and a
+  user-created long-lived access token.
+
+The WS auth handshake follows the same shape as ``utils/ha_core.py``
+(auth_required -> auth -> auth_ok). Registry lookups (entity/device/area)
+require an admin token; on a non-admin token they fail and we degrade to
+``get_states``-only metadata rather than erroring the whole listing.
+"""
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
+
+import httpx
+
+logger = logging.getLogger("homeassistant")
+
+SUPERVISOR_WS_URL = "ws://supervisor/core/websocket"
+SUPERVISOR_REST_URL = "http://supervisor/core/api"
+
+# SHH's own MQTT discovery publishes devices with this manufacturer and
+# identifiers prefixed shh_ (see mqtt/discovery.py) — those entities must
+# never be ingested back in, or SHH would re-record its own output.
+SHH_MANUFACTURER = "Smart Home Health"
+SHH_IDENTIFIER_PREFIX = "shh_"
+
+
+class HAClientError(Exception):
+    """HA unreachable, timed out, or replied unexpectedly."""
+
+
+class HAAuthError(HAClientError):
+    """Token rejected by HA."""
+
+
+@dataclass
+class HAEntity:
+    """One HA entity, as shown in the mapping picker."""
+    entity_id: str
+    state: Optional[str]
+    friendly_name: Optional[str]
+    device_class: Optional[str]
+    unit_of_measurement: Optional[str]
+    domain: str
+    area: Optional[str] = None
+    is_shh: bool = False
+    last_updated: Optional[str] = None
+
+
+def supervisor_available() -> bool:
+    """True when running as the HA add-on (Supervisor injected its token)."""
+    return bool(os.environ.get("SUPERVISOR_TOKEN"))
+
+
+def _entity_from_state(state_obj: Dict[str, Any]) -> HAEntity:
+    attrs = state_obj.get("attributes") or {}
+    entity_id = state_obj.get("entity_id", "")
+    return HAEntity(
+        entity_id=entity_id,
+        state=state_obj.get("state"),
+        friendly_name=attrs.get("friendly_name"),
+        device_class=attrs.get("device_class"),
+        unit_of_measurement=attrs.get("unit_of_measurement"),
+        domain=entity_id.split(".", 1)[0] if "." in entity_id else "",
+        last_updated=state_obj.get("last_updated"),
+    )
+
+
+class HAClient:
+    def __init__(self, ws_url: str, rest_url: str, token: str):
+        self.ws_url = ws_url
+        self.rest_url = rest_url.rstrip("/")
+        self.token = token
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "HAClient":
+        """
+        Build a client from the saved integration config, preferring the
+        Supervisor proxy when available unless config forces external mode.
+        Raises HAClientError when neither path is usable.
+        """
+        config = config or {}
+        mode = config.get("mode") or "auto"
+        supervisor_token = os.environ.get("SUPERVISOR_TOKEN")
+        if mode != "external" and supervisor_token:
+            return cls(SUPERVISOR_WS_URL, SUPERVISOR_REST_URL, supervisor_token)
+
+        base_url = (config.get("base_url") or "").strip().rstrip("/")
+        token = (config.get("token") or "").strip()
+        if not base_url or not token:
+            raise HAClientError(
+                "Home Assistant is not configured: set a base URL and "
+                "long-lived access token (or run as the HA add-on)"
+            )
+        if base_url.startswith("https://"):
+            ws_url = "wss://" + base_url[len("https://"):] + "/api/websocket"
+        elif base_url.startswith("http://"):
+            ws_url = "ws://" + base_url[len("http://"):] + "/api/websocket"
+        else:
+            raise HAClientError(f"Base URL must start with http:// or https:// (got {base_url!r})")
+        return cls(ws_url, base_url + "/api", token)
+
+    # ------------------------------------------------------------------
+    # REST
+    # ------------------------------------------------------------------
+
+    async def _rest_get(self, path: str, timeout: float = 10.0) -> Any:
+        headers = {"Authorization": f"Bearer {self.token}"}
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as http:
+                resp = await http.get(f"{self.rest_url}{path}", headers=headers)
+        except httpx.HTTPError as e:
+            raise HAClientError(f"Home Assistant unreachable: {e}") from e
+        if resp.status_code == 401:
+            raise HAAuthError("Home Assistant rejected the access token")
+        if resp.status_code >= 400:
+            raise HAClientError(f"GET {path} failed: HTTP {resp.status_code}")
+        try:
+            return resp.json()
+        except ValueError as e:
+            raise HAClientError(f"GET {path} returned invalid JSON") from e
+
+    async def test_connection(self) -> Dict[str, Any]:
+        """Cheap reachability + auth check. Returns HA version/location."""
+        config = await self._rest_get("/config")
+        return {
+            "version": config.get("version"),
+            "location_name": config.get("location_name"),
+        }
+
+    async def get_states(self) -> List[Dict[str, Any]]:
+        """All current entity states (REST /api/states). Used for seeding."""
+        states = await self._rest_get("/states", timeout=20.0)
+        if not isinstance(states, list):
+            raise HAClientError("/states returned an unexpected payload")
+        return states
+
+    # ------------------------------------------------------------------
+    # WebSocket
+    # ------------------------------------------------------------------
+
+    async def _ws_connect(self, timeout: float = 10.0):
+        from websockets.asyncio.client import connect
+        try:
+            ws = await connect(self.ws_url, open_timeout=timeout, max_size=16 * 1024 * 1024)
+        except Exception as e:
+            raise HAClientError(f"WebSocket connect failed: {e}") from e
+        try:
+            msg = json.loads(await asyncio.wait_for(ws.recv(), timeout))
+            if msg.get("type") != "auth_required":
+                raise HAClientError(f"Unexpected WS greeting: {msg.get('type')}")
+            await ws.send(json.dumps({"type": "auth", "access_token": self.token}))
+            msg = json.loads(await asyncio.wait_for(ws.recv(), timeout))
+            if msg.get("type") != "auth_ok":
+                raise HAAuthError(f"WS auth failed: {msg.get('type')}")
+        except HAClientError:
+            await ws.close()
+            raise
+        except Exception as e:
+            await ws.close()
+            raise HAClientError(f"WS handshake failed: {e}") from e
+        return ws
+
+    @staticmethod
+    async def _ws_command(ws, msg_id: int, command: Dict[str, Any],
+                          timeout: float = 10.0) -> Any:
+        """Send one command and wait for its result frame."""
+        await ws.send(json.dumps({"id": msg_id, **command}))
+        while True:
+            msg = json.loads(await asyncio.wait_for(ws.recv(), timeout))
+            if msg.get("id") == msg_id and msg.get("type") == "result":
+                if not msg.get("success"):
+                    error = (msg.get("error") or {}).get("message", "unknown error")
+                    raise HAClientError(f"{command.get('type')} failed: {error}")
+                return msg.get("result")
+
+    async def list_entities(self) -> List[HAEntity]:
+        """
+        All HA entities with picker metadata. Area names and robust SHH-device
+        detection come from the registry endpoints, which need an admin token —
+        when they fail we log and fall back to state-only metadata.
+        """
+        ws = await self._ws_connect()
+        try:
+            states = await self._ws_command(ws, 1, {"type": "get_states"}, timeout=20.0)
+            entities = [_entity_from_state(s) for s in states or []]
+
+            try:
+                entity_reg = await self._ws_command(ws, 2, {"type": "config/entity_registry/list"})
+                device_reg = await self._ws_command(ws, 3, {"type": "config/device_registry/list"})
+                area_reg = await self._ws_command(ws, 4, {"type": "config/area_registry/list"})
+            except (HAClientError, asyncio.TimeoutError) as e:
+                logger.info(f"HA registry enrichment unavailable (non-admin token?): {e}")
+                return entities
+
+            areas = {a.get("area_id"): a.get("name") for a in area_reg or []}
+            devices: Dict[str, Dict[str, Any]] = {d.get("id"): d for d in device_reg or []}
+            by_entity: Dict[str, Dict[str, Any]] = {
+                e.get("entity_id"): e for e in entity_reg or []
+            }
+            for entity in entities:
+                reg = by_entity.get(entity.entity_id)
+                if not reg:
+                    continue
+                device = devices.get(reg.get("device_id")) or {}
+                area_id = reg.get("area_id") or device.get("area_id")
+                entity.area = areas.get(area_id)
+                entity.is_shh = _is_shh_device(device)
+            return entities
+        finally:
+            await ws.close()
+
+    async def listen(
+        self,
+        entity_ids: Set[str],
+        on_state: Callable[[Dict[str, Any]], Awaitable[None]],
+        stop: asyncio.Event,
+    ) -> None:
+        """
+        Subscribe to state_changed events and invoke ``on_state(new_state)``
+        for entities in ``entity_ids``. Returns when ``stop`` is set; raises
+        HAClientError when the connection drops (caller reconnects).
+        """
+        ws = await self._ws_connect()
+        try:
+            await self._ws_command(ws, 1, {
+                "type": "subscribe_events", "event_type": "state_changed",
+            })
+            logger.info(f"[homeassistant] Subscribed to state_changed ({len(entity_ids)} mapped entities)")
+            while not stop.is_set():
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=30.0)
+                except asyncio.TimeoutError:
+                    continue  # idle tick; loop re-checks the stop event
+                except Exception as e:
+                    raise HAClientError(f"WebSocket receive failed: {e}") from e
+                try:
+                    msg = json.loads(raw)
+                except ValueError:
+                    continue
+                if msg.get("type") != "event":
+                    continue
+                data = (msg.get("event") or {}).get("data") or {}
+                new_state = data.get("new_state")
+                if not new_state or data.get("entity_id") not in entity_ids:
+                    continue
+                try:
+                    await on_state(new_state)
+                except Exception:
+                    logger.exception(f"Error handling state for {data.get('entity_id')}")
+        finally:
+            await ws.close()
+
+
+def _is_shh_device(device: Dict[str, Any]) -> bool:
+    """Whether a device-registry entry is SHH's own MQTT discovery device."""
+    if not device:
+        return False
+    if device.get("manufacturer") == SHH_MANUFACTURER:
+        return True
+    for identifier in device.get("identifiers") or []:
+        # identifiers is a list of [domain, id] pairs
+        for part in identifier if isinstance(identifier, (list, tuple)) else [identifier]:
+            if isinstance(part, str) and part.startswith(SHH_IDENTIFIER_PREFIX):
+                return True
+    return False
+
+
+def parse_ha_timestamp(value: Optional[str]) -> Optional[datetime]:
+    """Parse an HA ISO timestamp (e.g. last_updated), tolerating a Z suffix."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None

--- a/backend/homeassistant/listener.py
+++ b/backend/homeassistant/listener.py
@@ -1,0 +1,219 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Background loop subscribing to Home Assistant state changes for the mapped
+entities (see main.py startup, same pattern as environment_poll_loop).
+
+Config or mapping changes call ``request_reload()`` and the loop reconnects
+with fresh settings; connection loss reconnects with exponential backoff.
+"""
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Set
+
+from db import get_db
+from homeassistant import service
+from homeassistant.client import HAClient, HAClientError
+
+logger = logging.getLogger("homeassistant")
+
+IDLE_RECHECK_SECONDS = 60
+BACKOFF_INITIAL_SECONDS = 1
+BACKOFF_MAX_SECONDS = 60
+
+_reload_event: Optional[asyncio.Event] = None
+_runtime: Dict[str, Any] = {
+    "connected": False,
+    "connected_since": None,
+    "last_event_at": None,
+    "entity_count": 0,
+    "last_error": None,
+}
+
+
+def _get_reload_event() -> asyncio.Event:
+    global _reload_event
+    if _reload_event is None:
+        _reload_event = asyncio.Event()
+    return _reload_event
+
+
+def request_reload() -> None:
+    """Ask the listener to reconnect with fresh config/mappings."""
+    try:
+        _get_reload_event().set()
+    except RuntimeError:
+        pass  # no event loop yet (startup ordering); the loop reads fresh config anyway
+
+
+def runtime_status() -> Dict[str, Any]:
+    return dict(_runtime)
+
+
+async def _wait_or_reload(seconds: float) -> None:
+    """Sleep, but wake early when a reload is requested."""
+    try:
+        await asyncio.wait_for(_get_reload_event().wait(), timeout=seconds)
+    except asyncio.TimeoutError:
+        pass
+
+
+def _load_enabled_entity_ids() -> Set[str]:
+    from schemas.ha_entity_mapping import HAEntityMapping
+    db = next(get_db())
+    try:
+        rows = db.query(HAEntityMapping.entity_id).filter(
+            HAEntityMapping.enabled == True  # noqa: E712
+        ).all()
+        return {r.entity_id for r in rows}
+    finally:
+        db.close()
+
+
+async def _handle_state(new_state: Dict[str, Any]) -> None:
+    """Route one state_changed payload through its mapping (fresh session so
+    mapping edits apply immediately)."""
+    from schemas.ha_entity_mapping import HAEntityMapping
+
+    entity_id = new_state.get("entity_id")
+    if not entity_id:
+        return
+
+    def _process():
+        db = next(get_db())
+        try:
+            mapping = db.query(HAEntityMapping).filter(
+                HAEntityMapping.entity_id == entity_id,
+                HAEntityMapping.enabled == True,  # noqa: E712
+            ).first()
+            if mapping is None:
+                return False
+            recorded = service.handle_state_event(db, mapping, new_state)
+            db.commit()
+            return recorded
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    recorded = await asyncio.to_thread(_process)
+    if recorded:
+        _runtime["last_event_at"] = datetime.now(timezone.utc).isoformat()
+
+
+async def _seed_current_states(client: HAClient, entity_ids: Set[str]) -> None:
+    """Record each mapped entity's current state once at connect time, so a
+    rarely-changing sensor (weight, BP) shows up without waiting for its next
+    change. handle_state_event's timestamp check makes reconnects no-ops."""
+    try:
+        states = await client.get_states()
+    except HAClientError as e:
+        logger.warning(f"[homeassistant] Seeding skipped, get_states failed: {e}")
+        return
+    for state_obj in states:
+        if state_obj.get("entity_id") in entity_ids:
+            await _handle_state(state_obj)
+
+
+async def _shh_entity_ids(client: HAClient) -> Set[str]:
+    """Entity ids belonging to SHH's own MQTT discovery device (never ingest)."""
+    try:
+        return {e.entity_id for e in await client.list_entities() if e.is_shh}
+    except HAClientError as e:
+        logger.info(f"[homeassistant] SHH-entity lookup unavailable: {e}")
+        return set()
+
+
+def _set_connected(connected: bool, error: Optional[str] = None,
+                   entity_count: int = 0) -> None:
+    now_iso = datetime.now(timezone.utc).isoformat()
+    _runtime["connected"] = connected
+    _runtime["connected_since"] = now_iso if connected else None
+    _runtime["entity_count"] = entity_count
+    _runtime["last_error"] = error
+    # Persist for the admin UI across restarts; best-effort.
+    try:
+        db = next(get_db())
+        try:
+            service.save_state(db, connected=connected, last_error=error,
+                               **({"last_connect_at": now_iso} if connected else {}))
+        finally:
+            db.close()
+    except Exception:
+        logger.exception("[homeassistant] Failed to persist connection state")
+
+
+async def ha_listener_loop():
+    """Startup task (see main.py): keep a WS subscription to HA while the
+    integration is enabled and has mappings."""
+    logger.info("[homeassistant] Listener loop started")
+    service.set_main_loop(asyncio.get_running_loop())
+    backoff = BACKOFF_INITIAL_SECONDS
+    while True:
+        try:
+            _get_reload_event().clear()
+
+            db = next(get_db())
+            try:
+                config = service.get_config(db)
+            finally:
+                db.close()
+
+            if not (config.get("enabled") and service.connection_available(config)):
+                if _runtime["connected"]:
+                    _set_connected(False)
+                await _wait_or_reload(IDLE_RECHECK_SECONDS)
+                continue
+
+            entity_ids = _load_enabled_entity_ids()
+            if not entity_ids:
+                if _runtime["connected"]:
+                    _set_connected(False)
+                await _wait_or_reload(IDLE_RECHECK_SECONDS)
+                continue
+
+            client = HAClient.from_config(config)
+            active_ids = entity_ids - await _shh_entity_ids(client)
+            await _seed_current_states(client, active_ids)
+
+            _set_connected(True, entity_count=len(active_ids))
+            backoff = BACKOFF_INITIAL_SECONDS
+            logger.info(f"[homeassistant] Connected; listening on {len(active_ids)} entities")
+
+            stop = asyncio.Event()
+
+            async def _stop_on_reload():
+                await _get_reload_event().wait()
+                stop.set()
+
+            reload_task = asyncio.create_task(_stop_on_reload())
+            try:
+                await client.listen(active_ids, _handle_state, stop)
+            finally:
+                reload_task.cancel()
+            # listen() returned cleanly -> reload requested; reconnect at once.
+            _set_connected(False)
+        except HAClientError as e:
+            logger.warning(f"[homeassistant] Connection lost: {e} (retry in {backoff}s)")
+            _set_connected(False, error=str(e)[:500])
+            await _wait_or_reload(backoff)
+            backoff = min(backoff * 2, BACKOFF_MAX_SECONDS)
+        except Exception as e:
+            logger.exception(f"[homeassistant] Listener loop error: {e}")
+            _set_connected(False, error=str(e)[:500])
+            await _wait_or_reload(BACKOFF_MAX_SECONDS)

--- a/backend/homeassistant/service.py
+++ b/backend/homeassistant/service.py
@@ -1,0 +1,313 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Inbound HA ingestion logic: config/state accessors and the routing of one HA
+entity state into either a Vital row or an environmental observation.
+
+Connection config is home-level (settings table, same two-key pattern as
+environment connectors: config vs machine-state so status writes never race a
+user's config save). Entity mappings live in the ha_entity_mappings table.
+"""
+import hashlib
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from environment import metrics as env_metrics
+from environment import service as env_service
+from environment.base import EnvObservation
+from homeassistant.client import parse_ha_timestamp, supervisor_available
+from schemas.ha_entity_mapping import HAEntityMapping
+from schemas.vital import Vital
+
+logger = logging.getLogger("homeassistant")
+
+CONFIG_KEY = "homeassistant.config"   # {enabled, mode, base_url, token}
+STATE_KEY = "homeassistant.state"     # {connected, last_connect_at, last_event_at, last_error}
+
+SOURCE_TYPE = "home_assistant"
+
+# HA state strings that are lifecycle placeholders, not readings.
+NON_NUMERIC_STATES = {"unavailable", "unknown", "none", ""}
+
+TARGET_KINDS = ("vital", "environment")
+
+# The app's event loop, set by the listener at startup so vital_saved events
+# can be published from worker threads (asyncio.to_thread) as well.
+_main_loop = None
+
+
+def set_main_loop(loop) -> None:
+    global _main_loop
+    _main_loop = loop
+
+
+# ---------------------------------------------------------------------------
+# Config / state (settings table)
+# ---------------------------------------------------------------------------
+
+def get_config(db: Session) -> Dict:
+    from crud.settings import get_setting
+    return get_setting(db, CONFIG_KEY) or {}
+
+
+def save_config(db: Session, config: Dict) -> None:
+    from crud.settings import save_setting
+    import json
+    save_setting(db, CONFIG_KEY, json.dumps(config), data_type="json",
+                 description="Inbound Home Assistant integration config")
+
+
+def get_state(db: Session) -> Dict:
+    from crud.settings import get_setting
+    return get_setting(db, STATE_KEY) or {}
+
+
+def save_state(db: Session, **updates) -> Dict:
+    """Merge ``updates`` into the persisted runtime state and return it."""
+    from crud.settings import save_setting
+    import json
+    state = get_state(db)
+    state.update(updates)
+    save_setting(db, STATE_KEY, json.dumps(state), data_type="json",
+                 description="Inbound Home Assistant integration state")
+    return state
+
+
+def connection_available(config: Dict) -> bool:
+    """Whether a connection could be established with this config."""
+    config = config or {}
+    if (config.get("mode") or "auto") != "external" and supervisor_available():
+        return True
+    return bool((config.get("base_url") or "").strip() and (config.get("token") or "").strip())
+
+
+# ---------------------------------------------------------------------------
+# Unit conversion (environment targets only; vitals store HA's unit as-is)
+# ---------------------------------------------------------------------------
+
+def _c_from_f(v: float) -> float:
+    return (v - 32.0) * 5.0 / 9.0
+
+
+# metric -> {source unit (lowercased) -> converter to the canonical unit}.
+# The canonical unit itself always passes through; aliases listed explicitly.
+_ENV_CONVERTERS: Dict[str, Dict[str, Any]] = {
+    "temperature": {"°c": None, "c": None, "°f": _c_from_f, "f": _c_from_f,
+                    "k": lambda v: v - 273.15},
+    "barometric_pressure": {
+        "hpa": None, "mbar": None, "mmhg": lambda v: v * 1.33322,
+        "inhg": lambda v: v * 33.8639, "kpa": lambda v: v * 10.0,
+        "psi": lambda v: v * 68.9476, "pa": lambda v: v / 100.0,
+    },
+    "relative_humidity": {"%": None},
+    "precipitation": {"mm": None, "in": lambda v: v * 25.4},
+    "aqi": {"aqi": None, "": None},
+    "pm25": {"µg/m³": None, "ug/m3": None, "µg/m3": None,
+             "mg/m³": lambda v: v * 1000.0, "mg/m3": lambda v: v * 1000.0},
+    "ozone": {"µg/m³": None, "ug/m3": None, "µg/m3": None,
+              "mg/m³": lambda v: v * 1000.0, "mg/m3": lambda v: v * 1000.0},
+    "pollen": {"grains/m³": None, "grains/m3": None},
+    "co2": {"ppm": None},
+    "voc": {"ppb": None, "ppm": lambda v: v * 1000.0},
+    "noise_level": {"db": None, "dba": None, "db(a)": None},
+}
+_ENV_CONVERTERS["barometric_pressure_msl"] = _ENV_CONVERTERS["barometric_pressure"]
+
+
+def convert_to_canonical(value: float, source_unit: Optional[str], metric: str) -> float:
+    """
+    Convert a reading to the metric's canonical unit. An empty source unit is
+    trusted as already-canonical (some HA sensors omit units). Raises
+    ValueError for units we can't convert — better loud than silently wrong.
+    """
+    canonical = env_metrics.canonical_unit(metric)  # raises on unknown metric
+    unit = (source_unit or "").strip()
+    if not unit or unit == canonical:
+        return float(value)
+    converter_map = _ENV_CONVERTERS.get(metric, {})
+    if unit.lower() in converter_map:
+        converter = converter_map[unit.lower()]
+        return float(value) if converter is None else float(converter(float(value)))
+    raise ValueError(
+        f"Cannot convert unit {source_unit!r} to {canonical!r} for metric {metric!r}"
+    )
+
+
+def convertible_unit(source_unit: Optional[str], metric: str) -> bool:
+    try:
+        convert_to_canonical(1.0, source_unit, metric)
+        return True
+    except ValueError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# State-event routing
+# ---------------------------------------------------------------------------
+
+def handle_state_event(db: Session, mapping: HAEntityMapping,
+                       new_state: Dict[str, Any]) -> bool:
+    """
+    Route one HA state object through a mapping. Returns True when a row was
+    recorded. The caller owns the commit. Never raises: routing errors are
+    written to mapping.last_error instead (visible in the admin UI).
+    """
+    raw_value = new_state.get("state")
+    if raw_value is None or str(raw_value).strip().lower() in NON_NUMERIC_STATES:
+        return False
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        mapping.last_error = f"Non-numeric state: {raw_value!r}"
+        return False
+
+    ts = parse_ha_timestamp(new_state.get("last_updated")) or datetime.now(timezone.utc)
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+
+    last_seen = mapping.last_seen_at
+    if last_seen is not None and last_seen.tzinfo is None:
+        last_seen = last_seen.replace(tzinfo=timezone.utc)
+    if last_seen is not None:
+        # Replays (reconnect seeding) and out-of-order frames.
+        if ts <= last_seen:
+            return False
+        # Optional per-mapping throttle, measured against the last *recorded*
+        # reading so a chatty sensor can't starve itself.
+        if mapping.min_interval_seconds and \
+                (ts - last_seen).total_seconds() < mapping.min_interval_seconds:
+            return False
+
+    attributes = new_state.get("attributes") or {}
+    unit = attributes.get("unit_of_measurement") or mapping.source_unit
+
+    try:
+        if mapping.target_kind == "vital":
+            _record_vital(db, mapping, value, unit, ts, new_state)
+        elif mapping.target_kind == "environment":
+            _record_environment(db, mapping, value, unit, ts)
+        else:
+            mapping.last_error = f"Unknown target_kind: {mapping.target_kind!r}"
+            return False
+    except Exception as e:
+        logger.error(f"[homeassistant] {mapping.entity_id}: recording failed: {e}")
+        mapping.last_error = str(e)[:500]
+        return False
+
+    mapping.last_seen_at = ts
+    mapping.last_value = value
+    mapping.last_error = None
+    return True
+
+
+def _external_id(entity_id: str, ts: datetime) -> str:
+    """Stable dedup id within Vital.external_id's String(100) limit."""
+    digest = hashlib.sha1(f"{entity_id}|{ts.isoformat()}".encode()).hexdigest()[:32]
+    return f"ha:{digest}"
+
+
+def _record_vital(db: Session, mapping: HAEntityMapping, value: float,
+                  unit: Optional[str], ts: datetime, new_state: Dict[str, Any]) -> None:
+    from terminology import loinc_for, ucum_for
+
+    external_id = _external_id(mapping.entity_id, ts)
+    if db.query(Vital.id).filter(Vital.external_id == external_id).first():
+        return
+
+    # BP components are stored as vital_type="blood_pressure" + vital_group,
+    # but LOINC codes are per-component.
+    loinc_type = mapping.vital_type
+    if mapping.vital_type == "blood_pressure" and mapping.vital_group in ("systolic", "diastolic", "map"):
+        loinc_type = f"blood_pressure_{mapping.vital_group}"
+
+    now = datetime.utcnow()
+    db.add(Vital(
+        account_id=mapping.account_id,
+        patient_id=mapping.patient_id,
+        vital_type=mapping.vital_type,
+        vital_group=mapping.vital_group,
+        value=value,
+        unit=unit,
+        code=loinc_for(loinc_type, source=SOURCE_TYPE),
+        ucum_unit=ucum_for(unit),
+        source=SOURCE_TYPE,
+        device_id=mapping.entity_id[:100],
+        external_id=external_id,
+        raw_data={"entity_id": mapping.entity_id,
+                  "state": new_state.get("state"),
+                  "attributes": new_state.get("attributes")},
+        timestamp=ts,
+        created_at=now,
+    ))
+    _publish_vital_saved(mapping, value)
+
+
+def _publish_vital_saved(mapping: HAEntityMapping, value: float) -> None:
+    """
+    Publish the same "vital_saved" topic event the manual-vitals route emits,
+    so the websocket module refreshes clients and the MQTT module republishes
+    weight/temperature/BP on the patient's combined-state topic. from_manual
+    here means "did not arrive via our MQTT broker" — the flag exists for MQTT
+    loop prevention, and the HA WebSocket is a different transport entirely.
+    """
+    if mapping.vital_type == "blood_pressure" and mapping.vital_group:
+        vital_data: Dict[str, Any] = {mapping.vital_group: value}
+    elif mapping.vital_type == "temperature":
+        key = "skin_temp" if mapping.vital_group == "skin" else "body_temp"
+        vital_data = {key: value}
+    else:
+        vital_data = {"value": value}
+    try:
+        import asyncio
+        from main import get_modules
+        event_bus = get_modules().get("event_bus")
+        if not event_bus:
+            return
+        event = {"type": "vital_saved", "data": {
+            "vital_type": mapping.vital_type,
+            "vital_data": vital_data,
+            "from_manual": True,
+            "patient_id": mapping.patient_id,
+        }}
+        coro = event_bus.publish(event, topic="vital_saved")
+        try:
+            asyncio.get_running_loop().create_task(coro)
+        except RuntimeError:
+            # Worker thread (asyncio.to_thread in the listener).
+            if _main_loop is not None:
+                asyncio.run_coroutine_threadsafe(coro, _main_loop)
+            else:
+                coro.close()
+    except Exception as e:
+        logger.error(f"Failed to publish vital_saved for {mapping.entity_id}: {e}")
+
+
+def _record_environment(db: Session, mapping: HAEntityMapping, value: float,
+                        unit: Optional[str], ts: datetime) -> None:
+    canonical_value = convert_to_canonical(value, unit, mapping.metric)
+    env_service.emit_observations(db, SOURCE_TYPE, [EnvObservation(
+        timestamp=ts,
+        metric=mapping.metric,
+        value=round(canonical_value, 2),
+        unit=env_metrics.canonical_unit(mapping.metric),
+        scope=mapping.scope or "room",
+        location=mapping.location or "",
+        source_id=mapping.entity_id,
+        quality="measured",
+    )])

--- a/backend/homeassistant/service.py
+++ b/backend/homeassistant/service.py
@@ -199,9 +199,9 @@ def handle_state_event(db: Session, mapping: HAEntityMapping,
 
     try:
         if mapping.target_kind == "vital":
-            _record_vital(db, mapping, value, unit, ts, new_state)
+            recorded = _record_vital(db, mapping, value, unit, ts, new_state)
         elif mapping.target_kind == "environment":
-            _record_environment(db, mapping, value, unit, ts)
+            recorded = _record_environment(db, mapping, value, unit, ts)
         else:
             mapping.last_error = f"Unknown target_kind: {mapping.target_kind!r}"
             return False
@@ -210,10 +210,13 @@ def handle_state_event(db: Session, mapping: HAEntityMapping,
         mapping.last_error = str(e)[:500]
         return False
 
+    # Staleness reflects the last successfully routed state either way; the
+    # return value reports whether a NEW row landed (a dedup hit means this
+    # exact reading is already stored, so it's a no-op, not a record).
     mapping.last_seen_at = ts
     mapping.last_value = value
     mapping.last_error = None
-    return True
+    return recorded
 
 
 def _external_id(entity_id: str, ts: datetime) -> str:
@@ -223,12 +226,13 @@ def _external_id(entity_id: str, ts: datetime) -> str:
 
 
 def _record_vital(db: Session, mapping: HAEntityMapping, value: float,
-                  unit: Optional[str], ts: datetime, new_state: Dict[str, Any]) -> None:
+                  unit: Optional[str], ts: datetime, new_state: Dict[str, Any]) -> bool:
+    """Insert a Vital row; returns False when the reading is already stored."""
     from terminology import loinc_for, ucum_for
 
     external_id = _external_id(mapping.entity_id, ts)
     if db.query(Vital.id).filter(Vital.external_id == external_id).first():
-        return
+        return False
 
     # BP components are stored as vital_type="blood_pressure" + vital_group,
     # but LOINC codes are per-component.
@@ -256,6 +260,7 @@ def _record_vital(db: Session, mapping: HAEntityMapping, value: float,
         created_at=now,
     ))
     _publish_vital_saved(mapping, value)
+    return True
 
 
 def _publish_vital_saved(mapping: HAEntityMapping, value: float) -> None:
@@ -299,9 +304,10 @@ def _publish_vital_saved(mapping: HAEntityMapping, value: float) -> None:
 
 
 def _record_environment(db: Session, mapping: HAEntityMapping, value: float,
-                        unit: Optional[str], ts: datetime) -> None:
+                        unit: Optional[str], ts: datetime) -> bool:
+    """Emit one observation; returns False when deduped as already stored."""
     canonical_value = convert_to_canonical(value, unit, mapping.metric)
-    env_service.emit_observations(db, SOURCE_TYPE, [EnvObservation(
+    return 0 < env_service.emit_observations(db, SOURCE_TYPE, [EnvObservation(
         timestamp=ts,
         metric=mapping.metric,
         value=round(canonical_value, 2),

--- a/backend/integrations/__init__.py
+++ b/backend/integrations/__init__.py
@@ -48,3 +48,4 @@ from . import epic
 from . import mqtt
 from . import ventilator
 from . import frigate
+from . import home_assistant

--- a/backend/integrations/home_assistant.py
+++ b/backend/integrations/home_assistant.py
@@ -1,0 +1,89 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Home Assistant inbound integration (registry entry).
+
+Like the MQTT integration this is config-only: the actual work is push-based
+(the WS listener in backend/homeassistant/), so sync_data is a no-op. Being
+registered gives it an integrations-table row (used as the `source` label on
+ingested vitals) and a card in the integrations UI. Connection config and
+entity mappings live under /api/integrations/home_assistant (home-level, not
+per-patient).
+"""
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from .base import BaseIntegration, DeviceInfo, SyncResult, VitalType
+from .registry import register
+
+
+@register
+class HomeAssistantIntegration(BaseIntegration):
+    slug = "home_assistant"
+    name = "Home Assistant"
+    description = "Ingest selected Home Assistant entities as patient vitals or environmental observations"
+    auth_type = "none"
+    supported_vitals = [
+        VitalType.SPO2.value,
+        VitalType.HEART_RATE.value,
+        VitalType.BLOOD_PRESSURE_SYSTOLIC.value,
+        VitalType.BLOOD_PRESSURE_DIASTOLIC.value,
+        VitalType.BLOOD_PRESSURE_MAP.value,
+        VitalType.TEMPERATURE.value,
+        VitalType.RESPIRATORY_RATE.value,
+        VitalType.BLOOD_GLUCOSE.value,
+        VitalType.WEIGHT.value,
+    ]
+
+    @classmethod
+    def get_config_schema(cls) -> Dict[str, Any]:
+        # Home-level config; managed by /api/integrations/home_assistant, not
+        # the per-patient integration settings editor.
+        return {"type": "object", "properties": {}}
+
+    async def authenticate(self, auth_data: Dict[str, Any]) -> Dict[str, Any]:
+        return {"authenticated": True, "type": "home_assistant"}
+
+    async def refresh_credentials(self) -> Dict[str, Any]:
+        return {"authenticated": True, "type": "home_assistant"}
+
+    async def fetch_devices(self) -> List[DeviceInfo]:
+        return []
+
+    async def sync_data(
+        self,
+        since: Optional[datetime] = None,
+        device_ids: Optional[List[str]] = None,
+    ) -> SyncResult:
+        return SyncResult(
+            success=True,
+            readings_count=0,
+            readings=[],
+            error_message="Home Assistant ingestion is push-based (live WebSocket), no sync needed.",
+            sync_timestamp=datetime.utcnow(),
+        )
+
+    async def test_connection(self) -> bool:
+        from homeassistant.client import HAClient, HAClientError
+        from homeassistant.service import get_config
+        from state_manager import get_db_session
+        try:
+            with get_db_session() as db:
+                config = get_config(db)
+            await HAClient.from_config(config).test_connection()
+            return True
+        except (HAClientError, Exception):
+            return False

--- a/backend/main.py
+++ b/backend/main.py
@@ -56,7 +56,7 @@ from modules.mqtt_module import MQTTModule
 from modules.state_module import StateModule
 
 # Import route modules
-from routes import core, settings, vitals, medications, care_tasks, equipment, monitoring, mqtt, status, patients, nutrition, businesses, providers, auth, users, schedule, dashboard, symptoms, diagnoses, implants, dme_shipments, account, integrations, integration_imports, frigate as frigate_routes, readers, backup, analysis, reports, messages, system, security, environment, ha_auth
+from routes import core, settings, vitals, medications, care_tasks, equipment, monitoring, mqtt, status, patients, nutrition, businesses, providers, auth, users, schedule, dashboard, symptoms, diagnoses, implants, dme_shipments, account, integrations, integration_imports, frigate as frigate_routes, readers, backup, analysis, reports, messages, system, security, environment, ha_auth, home_assistant as home_assistant_routes
 
 # Import legacy components
 from mqtt import initialize_mqtt_service, shutdown_mqtt_service
@@ -138,6 +138,7 @@ app.include_router(messages.router)
 app.include_router(system.router)
 app.include_router(security.router)  # HTTPS / certificate management (system admin)
 app.include_router(environment.router)  # Environmental observations + connectors
+app.include_router(home_assistant_routes.router)  # Inbound HA entity ingestion
 
 # --- Static frontend (unified single-image deploy) --------------------------
 # In the unified production image the built SPA is copied in and STATIC_DIR
@@ -353,6 +354,11 @@ async def startup_event():
     from environment.poller import environment_poll_loop
     asyncio.create_task(environment_poll_loop())
     logger.info("[main] Environment poll loop started")
+
+    # 8. Inbound Home Assistant listener (idles until enabled + mapped).
+    from homeassistant.listener import ha_listener_loop
+    asyncio.create_task(ha_listener_loop())
+    logger.info("[main] Home Assistant listener started")
 
     logger.info("[main] Event-driven system startup complete")
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -58,6 +58,7 @@ from schemas.vent_sample import VentSample
 from schemas.vent_device_info import VentDeviceInfo
 from schemas.dme_shipment import DMEShipment, DMEShipmentItem, DMEReceiptItem, DMEShipmentAlert, DMEShipmentDocument
 from schemas.environmental_observation import EnvironmentalObservation
+from schemas.ha_entity_mapping import HAEntityMapping
 from models.readers import Reader
 from models.ha_identity import HASeenIdentity
 from models.custom_vital_definition import CustomVitalDefinition
@@ -81,5 +82,5 @@ __all__ = [
     'OrganizationType', 'PatientAccess', 'AccessLevel', 'Reader', 'CustomVitalDefinition',
     'UserMessage', 'UserMessageAcknowledgement', 'VentIngestedFile',
     'DMEShipment', 'DMEShipmentItem', 'DMEReceiptItem', 'DMEShipmentAlert', 'DMEShipmentDocument',
-    'EnvironmentalObservation', 'HASeenIdentity'
+    'EnvironmentalObservation', 'HASeenIdentity', 'HAEntityMapping'
 ]

--- a/backend/models/home_assistant.py
+++ b/backend/models/home_assistant.py
@@ -1,0 +1,62 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Pydantic request/response models for /api/integrations/home_assistant.
+"""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class HAConfigUpdate(BaseModel):
+    enabled: bool = False
+    # "auto" prefers the Supervisor proxy when running as the HA add-on;
+    # "external" forces the base_url + token path.
+    mode: str = Field("auto", pattern="^(auto|external)$")
+    base_url: Optional[str] = Field(None, max_length=255)
+    # None = keep the currently saved token (so the masked value round-trips).
+    token: Optional[str] = None
+
+
+class HAMappingCreate(BaseModel):
+    entity_id: str = Field(..., min_length=1, max_length=255)
+    friendly_name: Optional[str] = Field(None, max_length=255)
+    device_class: Optional[str] = Field(None, max_length=50)
+    source_unit: Optional[str] = Field(None, max_length=50)
+    target_kind: str = Field(..., pattern="^(vital|environment)$")
+    patient_id: Optional[int] = None
+    vital_type: Optional[str] = Field(None, max_length=50)
+    vital_group: Optional[str] = Field(None, max_length=50)
+    metric: Optional[str] = Field(None, max_length=50)
+    scope: Optional[str] = Field(None, max_length=20)
+    location: Optional[str] = Field(None, max_length=100)
+    enabled: bool = True
+    min_interval_seconds: int = Field(0, ge=0, le=86400)
+
+
+class HAMappingUpdate(BaseModel):
+    friendly_name: Optional[str] = Field(None, max_length=255)
+    device_class: Optional[str] = Field(None, max_length=50)
+    source_unit: Optional[str] = Field(None, max_length=50)
+    target_kind: Optional[str] = Field(None, pattern="^(vital|environment)$")
+    patient_id: Optional[int] = None
+    vital_type: Optional[str] = Field(None, max_length=50)
+    vital_group: Optional[str] = Field(None, max_length=50)
+    metric: Optional[str] = Field(None, max_length=50)
+    scope: Optional[str] = Field(None, max_length=20)
+    location: Optional[str] = Field(None, max_length=100)
+    enabled: Optional[bool] = None
+    min_interval_seconds: Optional[int] = Field(None, ge=0, le=86400)

--- a/backend/routes/home_assistant.py
+++ b/backend/routes/home_assistant.py
@@ -138,11 +138,13 @@ async def test_connection(
 async def get_status(
     db: Session = Depends(get_db),
     _: bool = Depends(require_read_access),
+    account_id: int = Depends(get_current_account_id),
 ):
     return {
         **service.get_state(db),
         **listener.runtime_status(),
-        "mapping_count": db.query(HAEntityMapping).count(),
+        "mapping_count": db.query(HAEntityMapping).filter(
+            HAEntityMapping.account_id == account_id).count(),
     }
 
 
@@ -151,6 +153,7 @@ async def list_entities(
     exclude_shh: bool = True,
     db: Session = Depends(get_db),
     _: bool = Depends(require_read_access),
+    account_id: int = Depends(get_current_account_id),
 ):
     """HA entities for the mapping picker, annotated with mapped state."""
     config = service.get_config(db)
@@ -159,7 +162,8 @@ async def list_entities(
     except HAClientError as e:
         raise HTTPException(status_code=502, detail=str(e))
     mapped = {
-        row.entity_id for row in db.query(HAEntityMapping.entity_id).all()
+        row.entity_id for row in db.query(HAEntityMapping.entity_id).filter(
+            HAEntityMapping.account_id == account_id).all()
     }
     result = []
     for entity in entities:
@@ -267,8 +271,11 @@ def _validate_target(db: Session, account_id: int, data: dict) -> None:
 async def list_mappings(
     db: Session = Depends(get_db),
     _: bool = Depends(require_read_access),
+    account_id: int = Depends(get_current_account_id),
 ):
-    rows = db.query(HAEntityMapping).order_by(HAEntityMapping.entity_id).all()
+    rows = db.query(HAEntityMapping).filter(
+        HAEntityMapping.account_id == account_id,
+    ).order_by(HAEntityMapping.entity_id).all()
     return [_mapping_to_dict(m) for m in rows]
 
 
@@ -303,7 +310,10 @@ async def update_mapping(
     _: bool = Depends(require_full_auth),
     account_id: int = Depends(get_current_account_id),
 ):
-    mapping = db.query(HAEntityMapping).filter(HAEntityMapping.id == mapping_id).first()
+    mapping = db.query(HAEntityMapping).filter(
+        HAEntityMapping.id == mapping_id,
+        HAEntityMapping.account_id == account_id,
+    ).first()
     if mapping is None:
         raise HTTPException(status_code=404, detail="Mapping not found")
     updates = body.model_dump(exclude_unset=True)
@@ -323,8 +333,12 @@ async def delete_mapping(
     mapping_id: int,
     db: Session = Depends(get_db),
     _: bool = Depends(require_full_auth),
+    account_id: int = Depends(get_current_account_id),
 ):
-    mapping = db.query(HAEntityMapping).filter(HAEntityMapping.id == mapping_id).first()
+    mapping = db.query(HAEntityMapping).filter(
+        HAEntityMapping.id == mapping_id,
+        HAEntityMapping.account_id == account_id,
+    ).first()
     if mapping is None:
         raise HTTPException(status_code=404, detail="Mapping not found")
     db.delete(mapping)

--- a/backend/routes/home_assistant.py
+++ b/backend/routes/home_assistant.py
@@ -1,0 +1,333 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Inbound Home Assistant integration routes: connection config, entity picker,
+and entity->target mappings. No bare "" route so this router can share the
+/api/integrations prefix space without colliding with /api/integrations/{slug}.
+"""
+import logging
+from dataclasses import asdict
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from db import get_db
+from dependencies import get_current_account_id, require_full_auth, require_read_access
+from environment import metrics as env_metrics
+from homeassistant import listener, service
+from homeassistant.client import HAClient, HAClientError, supervisor_available
+from integrations.base import VitalType
+from models.home_assistant import HAConfigUpdate, HAMappingCreate, HAMappingUpdate
+from schemas.ha_entity_mapping import HAEntityMapping
+from schemas.patient import Patient
+
+logger = logging.getLogger("homeassistant")
+
+router = APIRouter(prefix="/api/integrations/home_assistant", tags=["home-assistant"])
+
+# Storage-convention vital types offered by the mapping UI. BP and temperature
+# use the grouped convention (vital_type + vital_group) that the vitals UI and
+# MQTT combined-state expect (same as Withings ingest).
+VITAL_TYPE_OPTIONS = [
+    {"value": "spo2", "label": "SpO2", "groups": []},
+    {"value": "heart_rate", "label": "Heart rate", "groups": []},
+    {"value": "blood_pressure", "label": "Blood pressure", "groups": ["systolic", "diastolic", "map"]},
+    {"value": "temperature", "label": "Temperature", "groups": ["body", "skin"]},
+    {"value": "respiratory_rate", "label": "Respiratory rate", "groups": []},
+    {"value": "blood_glucose", "label": "Blood glucose", "groups": []},
+    {"value": "weight", "label": "Weight", "groups": []},
+    {"value": "bmi", "label": "BMI", "groups": []},
+    {"value": "body_fat", "label": "Body fat", "groups": []},
+    {"value": "muscle_mass", "label": "Muscle mass", "groups": []},
+    {"value": "bone_mass", "label": "Bone mass", "groups": []},
+    {"value": "water_percentage", "label": "Water percentage", "groups": []},
+    {"value": "steps", "label": "Steps", "groups": []},
+    {"value": "perfusion_index", "label": "Perfusion index", "groups": []},
+]
+
+_STANDARD_VITAL_TYPES = (
+    {opt["value"] for opt in VITAL_TYPE_OPTIONS} | {vt.value for vt in VitalType}
+)
+
+
+def _config_response(db: Session) -> dict:
+    config = service.get_config(db)
+    return {
+        "enabled": bool(config.get("enabled")),
+        "mode": config.get("mode") or "auto",
+        "base_url": config.get("base_url") or "",
+        "token_set": bool(config.get("token")),
+        "supervisor_available": supervisor_available(),
+        "connection_available": service.connection_available(config),
+    }
+
+
+@router.get("/config")
+async def get_config(
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_read_access),
+):
+    return _config_response(db)
+
+
+@router.put("/config")
+async def update_config(
+    body: HAConfigUpdate,
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_full_auth),
+):
+    existing = service.get_config(db)
+    config = {
+        "enabled": body.enabled,
+        "mode": body.mode,
+        "base_url": (body.base_url or "").strip(),
+        # None keeps the saved token so the UI's masked value can round-trip.
+        "token": (body.token.strip() if body.token is not None
+                  else existing.get("token") or ""),
+    }
+    if config["enabled"] and not service.connection_available(config):
+        raise HTTPException(
+            status_code=400,
+            detail="Set a base URL and access token (or run as the HA add-on) before enabling",
+        )
+    service.save_config(db, config)
+    listener.request_reload()
+    return _config_response(db)
+
+
+@router.post("/test")
+async def test_connection(
+    body: Optional[HAConfigUpdate] = None,
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_full_auth),
+):
+    """Reachability/auth check with the submitted (or saved) config."""
+    saved = service.get_config(db)
+    if body is not None:
+        config = {
+            "mode": body.mode,
+            "base_url": (body.base_url or "").strip(),
+            "token": (body.token.strip() if body.token is not None
+                      else saved.get("token") or ""),
+        }
+    else:
+        config = saved
+    try:
+        info = await HAClient.from_config(config).test_connection()
+    except HAClientError as e:
+        return {"ok": False, "error": str(e)}
+    return {"ok": True, **info}
+
+
+@router.get("/status")
+async def get_status(
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_read_access),
+):
+    return {
+        **service.get_state(db),
+        **listener.runtime_status(),
+        "mapping_count": db.query(HAEntityMapping).count(),
+    }
+
+
+@router.get("/entities")
+async def list_entities(
+    exclude_shh: bool = True,
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_read_access),
+):
+    """HA entities for the mapping picker, annotated with mapped state."""
+    config = service.get_config(db)
+    try:
+        entities = await HAClient.from_config(config).list_entities()
+    except HAClientError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+    mapped = {
+        row.entity_id for row in db.query(HAEntityMapping.entity_id).all()
+    }
+    result = []
+    for entity in entities:
+        if exclude_shh and entity.is_shh:
+            continue
+        result.append({**asdict(entity), "mapped": entity.entity_id in mapped})
+    result.sort(key=lambda e: (e["domain"], e["friendly_name"] or e["entity_id"]))
+    return result
+
+
+@router.get("/vital-types")
+async def list_vital_types(
+    patient_id: Optional[int] = None,
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_read_access),
+):
+    """Vital-type options for the mapping editor (+ the patient's custom vitals)."""
+    options = [dict(opt) for opt in VITAL_TYPE_OPTIONS]
+    if patient_id is not None:
+        from models.custom_vital_definition import CustomVitalDefinition
+        customs = db.query(CustomVitalDefinition).filter(
+            CustomVitalDefinition.patient_id == patient_id
+        ).all()
+        seen = {opt["value"] for opt in options}
+        for definition in customs:
+            if definition.name not in seen:
+                options.append({
+                    "value": definition.name,
+                    "label": definition.display_label or definition.name,
+                    "groups": [],
+                    "custom": True,
+                })
+    return options
+
+
+# ---------------------------------------------------------------------------
+# Mappings
+# ---------------------------------------------------------------------------
+
+def _mapping_to_dict(m: HAEntityMapping) -> dict:
+    return {
+        "id": m.id,
+        "entity_id": m.entity_id,
+        "friendly_name": m.friendly_name,
+        "device_class": m.device_class,
+        "source_unit": m.source_unit,
+        "target_kind": m.target_kind,
+        "patient_id": m.patient_id,
+        "vital_type": m.vital_type,
+        "vital_group": m.vital_group,
+        "metric": m.metric,
+        "scope": m.scope,
+        "location": m.location,
+        "enabled": m.enabled,
+        "min_interval_seconds": m.min_interval_seconds,
+        "last_seen_at": m.last_seen_at.isoformat() if m.last_seen_at else None,
+        "last_value": m.last_value,
+        "last_error": m.last_error,
+    }
+
+
+def _validate_target(db: Session, account_id: int, data: dict) -> None:
+    """Reject mappings whose target can't be recorded. Raises HTTPException."""
+    kind = data.get("target_kind")
+    if kind == "vital":
+        patient_id = data.get("patient_id")
+        vital_type = data.get("vital_type")
+        if not patient_id or not vital_type:
+            raise HTTPException(status_code=400,
+                                detail="Vital mappings need patient_id and vital_type")
+        patient = db.query(Patient).filter(Patient.id == patient_id).first()
+        if patient is None or (patient.account_id is not None
+                               and patient.account_id != account_id):
+            raise HTTPException(status_code=404, detail="Patient not found")
+        if vital_type not in _STANDARD_VITAL_TYPES:
+            from models.custom_vital_definition import CustomVitalDefinition
+            custom = db.query(CustomVitalDefinition).filter(
+                CustomVitalDefinition.patient_id == patient_id,
+                CustomVitalDefinition.name == vital_type,
+            ).first()
+            if custom is None:
+                raise HTTPException(status_code=400,
+                                    detail=f"Unknown vital type: {vital_type}")
+    elif kind == "environment":
+        metric = data.get("metric")
+        scope = data.get("scope")
+        if not metric or not scope:
+            raise HTTPException(status_code=400,
+                                detail="Environment mappings need metric and scope")
+        if metric not in env_metrics.METRICS or env_metrics.is_derived(metric):
+            raise HTTPException(status_code=400, detail=f"Unknown metric: {metric}")
+        if scope not in env_metrics.SCOPES:
+            raise HTTPException(status_code=400, detail=f"Unknown scope: {scope}")
+        if not service.convertible_unit(data.get("source_unit"), metric):
+            raise HTTPException(
+                status_code=400,
+                detail=(f"Unit {data.get('source_unit')!r} can't be converted to "
+                        f"{env_metrics.canonical_unit(metric)!r} for {metric}"),
+            )
+    else:
+        raise HTTPException(status_code=400, detail=f"Unknown target_kind: {kind}")
+
+
+@router.get("/mappings")
+async def list_mappings(
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_read_access),
+):
+    rows = db.query(HAEntityMapping).order_by(HAEntityMapping.entity_id).all()
+    return [_mapping_to_dict(m) for m in rows]
+
+
+@router.post("/mappings", status_code=201)
+async def create_mapping(
+    body: HAMappingCreate,
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_full_auth),
+    account_id: int = Depends(get_current_account_id),
+):
+    data = body.model_dump()
+    _validate_target(db, account_id, data)
+    if db.query(HAEntityMapping).filter(
+            HAEntityMapping.entity_id == body.entity_id).first():
+        raise HTTPException(status_code=409,
+                            detail=f"{body.entity_id} is already mapped")
+    now = datetime.utcnow()
+    mapping = HAEntityMapping(account_id=account_id, created_at=now, updated_at=now,
+                              **data)
+    db.add(mapping)
+    db.commit()
+    db.refresh(mapping)
+    listener.request_reload()
+    return _mapping_to_dict(mapping)
+
+
+@router.put("/mappings/{mapping_id}")
+async def update_mapping(
+    mapping_id: int,
+    body: HAMappingUpdate,
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_full_auth),
+    account_id: int = Depends(get_current_account_id),
+):
+    mapping = db.query(HAEntityMapping).filter(HAEntityMapping.id == mapping_id).first()
+    if mapping is None:
+        raise HTTPException(status_code=404, detail="Mapping not found")
+    updates = body.model_dump(exclude_unset=True)
+    merged = {**_mapping_to_dict(mapping), **updates}
+    _validate_target(db, account_id, merged)
+    for key, value in updates.items():
+        setattr(mapping, key, value)
+    mapping.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(mapping)
+    listener.request_reload()
+    return _mapping_to_dict(mapping)
+
+
+@router.delete("/mappings/{mapping_id}")
+async def delete_mapping(
+    mapping_id: int,
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_full_auth),
+):
+    mapping = db.query(HAEntityMapping).filter(HAEntityMapping.id == mapping_id).first()
+    if mapping is None:
+        raise HTTPException(status_code=404, detail="Mapping not found")
+    db.delete(mapping)
+    db.commit()
+    listener.request_reload()
+    return {"status": "deleted"}

--- a/backend/schemas/ha_entity_mapping.py
+++ b/backend/schemas/ha_entity_mapping.py
@@ -1,0 +1,67 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from sqlalchemy import (
+    Boolean, Column, Float, ForeignKey, Integer, String, Text, TIMESTAMP,
+)
+from schemas import Base
+
+
+class HAEntityMapping(Base):
+    """
+    One inbound Home Assistant entity -> SHH target mapping.
+
+    ``target_kind`` decides which target columns apply:
+    - "vital": patient_id + vital_type (+ optional vital_group) -> vitals table
+    - "environment": metric + scope (+ optional location) -> environmental_observations
+    """
+    __tablename__ = 'ha_entity_mappings'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    account_id = Column(Integer, ForeignKey('accounts.id', ondelete='CASCADE'),
+                        nullable=True, index=True)
+    # One mapping per entity keeps ingestion routing unambiguous.
+    entity_id = Column(String(255), nullable=False, unique=True)
+
+    # Picker metadata cached at save time (display only; refreshed on edit).
+    friendly_name = Column(String(255), nullable=True)
+    device_class = Column(String(50), nullable=True)
+    source_unit = Column(String(50), nullable=True)
+
+    target_kind = Column(String(20), nullable=False)  # "vital" | "environment"
+
+    # vital target
+    patient_id = Column(Integer, ForeignKey('patients.id', ondelete='CASCADE'),
+                        nullable=True, index=True)
+    vital_type = Column(String(50), nullable=True)
+    vital_group = Column(String(50), nullable=True)
+
+    # environment target
+    metric = Column(String(50), nullable=True)
+    scope = Column(String(20), nullable=True)
+    location = Column(String(100), nullable=True, default="")
+
+    enabled = Column(Boolean, nullable=False, default=True)
+    # 0 = record every state change; otherwise skip changes arriving sooner
+    # than this many seconds after the last recorded one.
+    min_interval_seconds = Column(Integer, nullable=False, default=0)
+
+    # Staleness/debug surface for the admin UI.
+    last_seen_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    last_value = Column(Float, nullable=True)
+    last_error = Column(Text, nullable=True)
+
+    created_at = Column(TIMESTAMP(timezone=True), nullable=False)
+    updated_at = Column(TIMESTAMP(timezone=True), nullable=False)

--- a/backend/tests/test_home_assistant.py
+++ b/backend/tests/test_home_assistant.py
@@ -166,6 +166,14 @@ def test_vital_recording_and_dedup(db_session, patient):
     assert not ha_service.handle_state_event(db_session, mapping, _state("72"))
     assert db_session.query(Vital).filter(Vital.patient_id == patient.id).count() == 1
 
+    # Dedup hit with no last_seen (e.g. mapping re-created): the existing row
+    # is found via external_id -> no-op result, but staleness still refreshes.
+    mapping.last_seen_at = None
+    mapping.last_value = None
+    assert not ha_service.handle_state_event(db_session, mapping, _state("72"))
+    assert db_session.query(Vital).filter(Vital.patient_id == patient.id).count() == 1
+    assert mapping.last_value == 72.0
+
 
 def test_bp_component_gets_component_loinc(db_session, patient):
     from terminology import loinc_for
@@ -348,6 +356,25 @@ def test_vital_mapping_foreign_patient_rejected(admin_client, db_session):
     resp = admin_client.post("/api/integrations/home_assistant/mappings",
                              json=_vital_mapping_body(foreign))
     assert resp.status_code == 404
+
+
+def test_mappings_scoped_to_account(admin_client, db_session):
+    """Another account's mappings are invisible to list/update/delete."""
+    from models.users import Account
+    other = Account(name="Other House 2", slug="other-house-2", password_hash="x")
+    db_session.add(other)
+    db_session.flush()
+    foreign = _mapping(db_session, entity_id="sensor.foreign_co2",
+                       account_id=other.id, target_kind="environment",
+                       metric="co2", scope="room", location="")
+
+    assert admin_client.get("/api/integrations/home_assistant/mappings").json() == []
+    assert admin_client.get("/api/integrations/home_assistant/status").json()["mapping_count"] == 0
+    assert admin_client.put(
+        f"/api/integrations/home_assistant/mappings/{foreign.id}",
+        json={"enabled": False}).status_code == 404
+    assert admin_client.delete(
+        f"/api/integrations/home_assistant/mappings/{foreign.id}").status_code == 404
 
 
 def test_environment_mapping_validation(admin_client):

--- a/backend/tests/test_home_assistant.py
+++ b/backend/tests/test_home_assistant.py
@@ -1,0 +1,458 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Inbound Home Assistant integration: client config resolution, unit
+conversion, state-event -> vital/observation routing, and the
+/api/integrations/home_assistant routes. No sockets — the HA client is
+monkeypatched at the route module (same approach as test_ha_directory.py).
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from homeassistant import service as ha_service
+from homeassistant.client import (
+    HAClient, HAClientError, HAEntity, _is_shh_device, parse_ha_timestamp,
+    SUPERVISOR_REST_URL, SUPERVISOR_WS_URL,
+)
+from schemas.ha_entity_mapping import HAEntityMapping
+from schemas.environmental_observation import EnvironmentalObservation
+from schemas.vital import Vital
+
+
+# ---------------------------------------------------------------------------
+# Client config resolution
+# ---------------------------------------------------------------------------
+
+def test_from_config_prefers_supervisor(monkeypatch):
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "sup-token")
+    client = HAClient.from_config({})
+    assert client.ws_url == SUPERVISOR_WS_URL
+    assert client.rest_url == SUPERVISOR_REST_URL
+    assert client.token == "sup-token"
+
+
+def test_from_config_external_mode_ignores_supervisor(monkeypatch):
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "sup-token")
+    client = HAClient.from_config({
+        "mode": "external", "base_url": "http://ha.local:8123", "token": "llat",
+    })
+    assert client.ws_url == "ws://ha.local:8123/api/websocket"
+    assert client.rest_url == "http://ha.local:8123/api"
+    assert client.token == "llat"
+
+
+def test_from_config_https_derives_wss(monkeypatch):
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    client = HAClient.from_config({"base_url": "https://ha.example.org/", "token": "t"})
+    assert client.ws_url == "wss://ha.example.org/api/websocket"
+    assert client.rest_url == "https://ha.example.org/api"
+
+
+def test_from_config_unconfigured_raises(monkeypatch):
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    with pytest.raises(HAClientError):
+        HAClient.from_config({})
+
+
+def test_connection_available(monkeypatch):
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    assert not ha_service.connection_available({})
+    assert ha_service.connection_available({"base_url": "http://x", "token": "t"})
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "sup")
+    assert ha_service.connection_available({})
+    assert not ha_service.connection_available({"mode": "external"})
+
+
+def test_is_shh_device_detection():
+    assert _is_shh_device({"manufacturer": "Smart Home Health"})
+    assert _is_shh_device({"identifiers": [["mqtt", "shh_pat_ient"]]})
+    assert not _is_shh_device({"manufacturer": "Aranet", "identifiers": [["ble", "aranet4"]]})
+    assert not _is_shh_device({})
+
+
+def test_parse_ha_timestamp():
+    ts = parse_ha_timestamp("2026-08-15T12:00:00.123456+00:00")
+    assert ts is not None and ts.tzinfo is not None
+    assert parse_ha_timestamp("2026-08-15T12:00:00Z") is not None
+    assert parse_ha_timestamp("garbage") is None
+    assert parse_ha_timestamp(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit conversion
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value,unit,metric,expected", [
+    (68.0, "°F", "temperature", 20.0),
+    (20.0, "°C", "temperature", 20.0),
+    (29.92, "inHg", "barometric_pressure", pytest.approx(1013.2, abs=0.5)),
+    (101.3, "kPa", "barometric_pressure", pytest.approx(1013.0)),
+    (0.012, "mg/m³", "pm25", pytest.approx(12.0)),
+    (45.0, "%", "relative_humidity", 45.0),
+    (700.0, "ppm", "co2", 700.0),
+    (0.5, "ppm", "voc", 500.0),
+    (42.0, None, "aqi", 42.0),  # unitless sensors trusted as canonical
+])
+def test_convert_to_canonical(value, unit, metric, expected):
+    assert ha_service.convert_to_canonical(value, unit, metric) == expected
+
+
+def test_convert_unknown_unit_raises():
+    with pytest.raises(ValueError, match="Cannot convert"):
+        ha_service.convert_to_canonical(1.0, "furlongs", "temperature")
+    assert not ha_service.convertible_unit("furlongs", "temperature")
+    assert ha_service.convertible_unit("°F", "temperature")
+
+
+# ---------------------------------------------------------------------------
+# State-event routing
+# ---------------------------------------------------------------------------
+
+def _mapping(db, patient=None, **kw):
+    now = datetime.utcnow()
+    defaults = dict(
+        entity_id="sensor.test_entity", target_kind="vital",
+        enabled=True, min_interval_seconds=0, created_at=now, updated_at=now,
+    )
+    if patient is not None:
+        defaults.update(patient_id=patient.id, account_id=patient.account_id)
+    defaults.update(kw)
+    mapping = HAEntityMapping(**defaults)
+    db.add(mapping)
+    db.commit()
+    return mapping
+
+
+def _state(value, ts="2026-08-15T12:00:00+00:00", unit="bpm", entity="sensor.test_entity"):
+    return {
+        "entity_id": entity,
+        "state": value,
+        "attributes": {"unit_of_measurement": unit, "friendly_name": "Test"},
+        "last_updated": ts,
+    }
+
+
+def test_vital_recording_and_dedup(db_session, patient):
+    mapping = _mapping(db_session, patient, vital_type="heart_rate")
+    assert ha_service.handle_state_event(db_session, mapping, _state("72"))
+    db_session.commit()
+
+    vital = db_session.query(Vital).filter(Vital.patient_id == patient.id).one()
+    assert vital.vital_type == "heart_rate"
+    assert vital.value == 72.0
+    assert vital.unit == "bpm"
+    assert vital.source == "home_assistant"
+    assert vital.device_id == "sensor.test_entity"
+    assert vital.external_id.startswith("ha:")
+    assert vital.code is not None  # LOINC enrichment
+    assert mapping.last_value == 72.0
+    assert mapping.last_error is None
+
+    # Same timestamp again (reconnect seed replay) -> nothing recorded.
+    assert not ha_service.handle_state_event(db_session, mapping, _state("72"))
+    assert db_session.query(Vital).filter(Vital.patient_id == patient.id).count() == 1
+
+
+def test_bp_component_gets_component_loinc(db_session, patient):
+    from terminology import loinc_for
+    mapping = _mapping(db_session, patient, vital_type="blood_pressure",
+                       vital_group="systolic", entity_id="sensor.bp_sys")
+    assert ha_service.handle_state_event(
+        db_session, mapping, _state("118", unit="mmHg", entity="sensor.bp_sys"))
+    db_session.commit()  # SessionLocal has autoflush=False
+    vital = db_session.query(Vital).filter(Vital.vital_group == "systolic").one()
+    assert vital.vital_type == "blood_pressure"
+    assert vital.code == loinc_for("blood_pressure_systolic")
+
+
+@pytest.mark.parametrize("bad_state", ["unavailable", "unknown", "", None])
+def test_lifecycle_states_skipped(db_session, patient, bad_state):
+    mapping = _mapping(db_session, patient, vital_type="heart_rate")
+    assert not ha_service.handle_state_event(db_session, mapping, _state(bad_state))
+    assert db_session.query(Vital).filter(Vital.patient_id == patient.id).count() == 0
+    assert mapping.last_error is None  # lifecycle states are not errors
+
+
+def test_non_numeric_state_sets_last_error(db_session, patient):
+    mapping = _mapping(db_session, patient, vital_type="heart_rate")
+    assert not ha_service.handle_state_event(db_session, mapping, _state("detected"))
+    assert "Non-numeric" in mapping.last_error
+
+
+def test_min_interval_throttle(db_session, patient):
+    mapping = _mapping(db_session, patient, vital_type="heart_rate",
+                       min_interval_seconds=3600)
+    base = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
+    assert ha_service.handle_state_event(
+        db_session, mapping, _state("70", ts=base.isoformat()))
+    # 60s later: inside the interval -> skipped, last_seen unchanged.
+    assert not ha_service.handle_state_event(
+        db_session, mapping, _state("71", ts=(base + timedelta(seconds=60)).isoformat()))
+    assert mapping.last_value == 70.0
+    # 2h later: recorded.
+    assert ha_service.handle_state_event(
+        db_session, mapping, _state("75", ts=(base + timedelta(hours=2)).isoformat()))
+    assert mapping.last_value == 75.0
+
+
+def test_environment_recording_with_conversion(db_session):
+    mapping = _mapping(
+        db_session, target_kind="environment", entity_id="sensor.bedroom_temp",
+        metric="temperature", scope="room", location="bedroom",
+    )
+    assert ha_service.handle_state_event(
+        db_session, mapping,
+        _state("68.0", unit="°F", entity="sensor.bedroom_temp"))
+    db_session.commit()
+
+    obs = db_session.query(EnvironmentalObservation).filter(
+        EnvironmentalObservation.source_type == "home_assistant").one()
+    assert obs.metric == "temperature"
+    assert obs.value == 20.0            # converted to °C
+    assert obs.unit == "°C"
+    assert obs.scope == "room"
+    assert obs.location == "bedroom"
+    assert obs.source_id == "sensor.bedroom_temp"
+    assert obs.quality == "measured"
+
+
+def test_environment_unconvertible_unit_sets_error(db_session):
+    mapping = _mapping(
+        db_session, target_kind="environment", entity_id="sensor.weird",
+        metric="co2", scope="room", location="",
+    )
+    assert not ha_service.handle_state_event(
+        db_session, mapping, _state("500", unit="banana", entity="sensor.weird"))
+    assert "Cannot convert" in mapping.last_error
+
+
+# ---------------------------------------------------------------------------
+# Routes: config
+# ---------------------------------------------------------------------------
+
+def test_config_roundtrip_and_token_masking(admin_client, monkeypatch):
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    resp = admin_client.get("/api/integrations/home_assistant/config")
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False
+
+    resp = admin_client.put("/api/integrations/home_assistant/config", json={
+        "enabled": True, "base_url": "http://ha.local:8123", "token": "secret-llat",
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is True
+    assert body["token_set"] is True
+    assert "secret-llat" not in resp.text  # token never leaves the backend
+
+    # Token omitted on re-save -> saved token kept.
+    resp = admin_client.put("/api/integrations/home_assistant/config", json={
+        "enabled": True, "base_url": "http://ha.local:8123",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["token_set"] is True
+
+
+def test_enable_without_connection_rejected(admin_client, monkeypatch):
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    resp = admin_client.put("/api/integrations/home_assistant/config", json={
+        "enabled": True,
+    })
+    assert resp.status_code == 400
+
+
+def test_test_endpoint_reports_failure_as_ok_false(admin_client, monkeypatch):
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    resp = admin_client.post("/api/integrations/home_assistant/test", json={
+        "enabled": False, "base_url": "", "token": "",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# Routes: mappings
+# ---------------------------------------------------------------------------
+
+def _vital_mapping_body(patient, **kw):
+    body = {
+        "entity_id": "sensor.spo2_ring", "target_kind": "vital",
+        "patient_id": patient.id, "vital_type": "spo2", "source_unit": "%",
+    }
+    body.update(kw)
+    return body
+
+
+def test_mapping_crud(admin_client, patient):
+    resp = admin_client.post("/api/integrations/home_assistant/mappings",
+                             json=_vital_mapping_body(patient))
+    assert resp.status_code == 201
+    mapping_id = resp.json()["id"]
+
+    # Duplicate entity -> 409.
+    resp = admin_client.post("/api/integrations/home_assistant/mappings",
+                             json=_vital_mapping_body(patient))
+    assert resp.status_code == 409
+
+    resp = admin_client.get("/api/integrations/home_assistant/mappings")
+    assert [m["entity_id"] for m in resp.json()] == ["sensor.spo2_ring"]
+
+    resp = admin_client.put(
+        f"/api/integrations/home_assistant/mappings/{mapping_id}",
+        json={"enabled": False, "min_interval_seconds": 300})
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False
+    assert resp.json()["min_interval_seconds"] == 300
+
+    resp = admin_client.delete(f"/api/integrations/home_assistant/mappings/{mapping_id}")
+    assert resp.status_code == 200
+    assert admin_client.get("/api/integrations/home_assistant/mappings").json() == []
+
+
+def test_vital_mapping_requires_patient_and_type(admin_client, patient):
+    body = _vital_mapping_body(patient)
+    del body["patient_id"]
+    assert admin_client.post("/api/integrations/home_assistant/mappings",
+                             json=body).status_code == 400
+
+    body = _vital_mapping_body(patient, vital_type="parsecs")
+    assert admin_client.post("/api/integrations/home_assistant/mappings",
+                             json=body).status_code == 400
+
+
+def test_vital_mapping_foreign_patient_rejected(admin_client, db_session):
+    from models.users import Account
+    other = Account(name="Other House", slug="other-house", password_hash="x")
+    db_session.add(other)
+    db_session.flush()
+    from crud.patients import create_patient
+    foreign = create_patient(db_session, {
+        "first_name": "Not", "last_name": "Mine",
+        "account_id": other.id, "is_active": True,
+    })
+    db_session.commit()
+    resp = admin_client.post("/api/integrations/home_assistant/mappings",
+                             json=_vital_mapping_body(foreign))
+    assert resp.status_code == 404
+
+
+def test_environment_mapping_validation(admin_client):
+    base = {"entity_id": "sensor.bedroom_co2", "target_kind": "environment",
+            "metric": "co2", "scope": "room", "location": "bedroom",
+            "source_unit": "ppm"}
+    assert admin_client.post("/api/integrations/home_assistant/mappings",
+                             json=base).status_code == 201
+    assert admin_client.post(
+        "/api/integrations/home_assistant/mappings",
+        json={**base, "entity_id": "sensor.x", "metric": "vibes"},
+    ).status_code == 400
+    assert admin_client.post(
+        "/api/integrations/home_assistant/mappings",
+        json={**base, "entity_id": "sensor.y", "scope": "space"},
+    ).status_code == 400
+    # Derived metrics are computed, never mapped.
+    assert admin_client.post(
+        "/api/integrations/home_assistant/mappings",
+        json={**base, "entity_id": "sensor.z", "metric": "pressure_delta_6h"},
+    ).status_code == 400
+    # Unit that can't be converted to canonical.
+    assert admin_client.post(
+        "/api/integrations/home_assistant/mappings",
+        json={**base, "entity_id": "sensor.w", "source_unit": "banana"},
+    ).status_code == 400
+
+
+def test_vital_types_includes_custom(admin_client, db_session, patient):
+    from models.custom_vital_definition import CustomVitalDefinition
+    db_session.add(CustomVitalDefinition(patient_id=patient.id, name="etco2",
+                                         unit="mmHg", display_label="EtCO2"))
+    db_session.commit()
+    resp = admin_client.get(
+        f"/api/integrations/home_assistant/vital-types?patient_id={patient.id}")
+    values = {opt["value"] for opt in resp.json()}
+    assert {"spo2", "blood_pressure", "temperature", "etco2"} <= values
+
+
+# ---------------------------------------------------------------------------
+# Routes: entities (client monkeypatched at the route module)
+# ---------------------------------------------------------------------------
+
+def test_entities_annotated_and_shh_excluded(admin_client, patient, monkeypatch):
+    from routes import home_assistant as ha_routes
+
+    entities = [
+        HAEntity(entity_id="sensor.spo2_ring", state="97", friendly_name="SpO2 Ring",
+                 device_class=None, unit_of_measurement="%", domain="sensor"),
+        HAEntity(entity_id="sensor.shh_pat_spo2", state="97", friendly_name="SHH SpO2",
+                 device_class=None, unit_of_measurement="%", domain="sensor",
+                 is_shh=True),
+    ]
+
+    class FakeClient:
+        @classmethod
+        def from_config(cls, config):
+            return cls()
+
+        async def list_entities(self):
+            return entities
+
+    monkeypatch.setattr(ha_routes, "HAClient", FakeClient)
+
+    admin_client.post("/api/integrations/home_assistant/mappings",
+                      json=_vital_mapping_body(patient))
+    resp = admin_client.get("/api/integrations/home_assistant/entities")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [e["entity_id"] for e in body] == ["sensor.spo2_ring"]  # SHH excluded
+    assert body[0]["mapped"] is True
+
+    resp = admin_client.get("/api/integrations/home_assistant/entities?exclude_shh=false")
+    assert len(resp.json()) == 2
+
+
+def test_entities_unreachable_returns_502(admin_client, monkeypatch):
+    from routes import home_assistant as ha_routes
+
+    class DeadClient:
+        @classmethod
+        def from_config(cls, config):
+            raise HAClientError("not configured")
+
+    monkeypatch.setattr(ha_routes, "HAClient", DeadClient)
+    resp = admin_client.get("/api/integrations/home_assistant/entities")
+    assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# Status + registries
+# ---------------------------------------------------------------------------
+
+def test_status_endpoint(admin_client):
+    resp = admin_client.get("/api/integrations/home_assistant/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["connected"] is False
+    assert body["mapping_count"] == 0
+
+
+def test_registered_in_both_frameworks():
+    from integrations.registry import get_integration
+    from environment.registry import registry as env_registry
+    assert get_integration("home_assistant") is not None
+    env_connector = env_registry.get("home_assistant")
+    assert env_connector is not None
+    assert env_connector.poll_capable is False

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -68,6 +68,7 @@ import AdminV2Backup from './pages/admin-v2/AdminV2Backup';
 import AdminV2SystemHealth from './pages/admin-v2/AdminV2SystemHealth';
 import AdminV2Security from './pages/admin-v2/AdminV2Security';
 import AdminV2Environment from './pages/admin-v2/AdminV2Environment';
+import AdminV2HomeAssistant from './pages/admin-v2/AdminV2HomeAssistant';
 import AdminV2Connections from './pages/admin-v2/AdminV2Connections';
 import AdminV2Mqtt from './pages/admin-v2/AdminV2Mqtt';
 import { AdminV2SettingsGeneral } from './pages/admin-v2/settings';
@@ -207,6 +208,7 @@ function AppContent() {
           <Route path="/care/configuration/system-health" element={<ProtectedRoute><Layout><AdminV2SystemHealth /></Layout></ProtectedRoute>} />
           <Route path="/care/configuration/security" element={<ProtectedRoute><Layout><AdminV2Security /></Layout></ProtectedRoute>} />
           <Route path="/care/configuration/environment" element={<ProtectedRoute><Layout><AdminV2Environment /></Layout></ProtectedRoute>} />
+          <Route path="/care/configuration/home-assistant" element={<ProtectedRoute><Layout><AdminV2HomeAssistant /></Layout></ProtectedRoute>} />
           <Route path="/care/configuration/users" element={<ProtectedRoute><Layout><AdminV2Users /></Layout></ProtectedRoute>} />
           <Route path="/care/configuration/users/roles" element={<ProtectedRoute><Layout><AdminV2Roles /></Layout></ProtectedRoute>} />
           <Route path="/care/configuration/users/roles/:roleId" element={<ProtectedRoute><Layout><AdminV2RoleDetail /></Layout></ProtectedRoute>} />

--- a/frontend/src/components/Icons.jsx
+++ b/frontend/src/components/Icons.jsx
@@ -749,6 +749,14 @@ export const LeafIcon = ({ size = 20 }) => (
   </svg>
 );
 
+export const HomeIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    <polyline points="9 22 9 12 15 12 15 22" />
+  </svg>
+);
+
 export const BarChartIcon = ({ size = 20 }) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" 
        strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
@@ -1,0 +1,655 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Configuration → Home Assistant: inbound entity ingestion. Pick HA entities
+// and map each to a patient vital or an environmental observation. Running as
+// the HA add-on needs no connection config (Supervisor proxy); standalone
+// installs supply a base URL + long-lived access token.
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import AdminV2Layout from './AdminV2Layout';
+import config, { apiFetch } from '../../config';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert } from '@/components/ui/alert';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from '@/components/ui/select';
+import { HomeIcon, PlusIcon, RefreshIcon, TrashIcon, EditIcon } from '../../components/Icons';
+import './AdminV2.css';
+
+const API = () => `${config.apiUrl}/api/integrations/home_assistant`;
+
+const formatWhen = (iso) => {
+  if (!iso) return 'Never';
+  const d = new Date(iso);
+  return isNaN(d) ? 'Never' : d.toLocaleString('en-US', {
+    month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+  });
+};
+
+const describeTarget = (m) => {
+  if (m.target_kind === 'vital') {
+    return `Vital: ${m.vital_type}${m.vital_group ? ` (${m.vital_group})` : ''}`;
+  }
+  const where = m.location ? `${m.scope} / ${m.location}` : m.scope;
+  return `Environment: ${m.metric} (${where})`;
+};
+
+const readError = async (res) => {
+  const body = await res.json().catch(() => ({}));
+  return typeof body.detail === 'string' ? body.detail : `HTTP ${res.status}`;
+};
+
+const EMPTY_FORM = {
+  entity_id: '', friendly_name: '', device_class: '', source_unit: '',
+  target_kind: 'vital', patient_id: '', vital_type: '', vital_group: '',
+  metric: '', scope: 'room', location: '', min_interval_seconds: 0,
+};
+
+const AdminV2HomeAssistant = () => {
+  const [cfg, setCfg] = useState(null);
+  const [status, setStatus] = useState(null);
+  const [mappings, setMappings] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [notice, setNotice] = useState(null);
+  const [busy, setBusy] = useState(null);
+
+  // Connection form
+  const [enabled, setEnabled] = useState(false);
+  const [baseUrl, setBaseUrl] = useState('');
+  const [token, setToken] = useState('');       // '' = keep saved token
+
+  // Mapping dialog
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingId, setEditingId] = useState(null); // null = create
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [entities, setEntities] = useState(null);
+  const [entitySearch, setEntitySearch] = useState('');
+  const [patients, setPatients] = useState([]);
+  const [vitalTypes, setVitalTypes] = useState([]);
+  const [metrics, setMetrics] = useState([]);
+
+  const statusTimer = useRef(null);
+
+  const loadAll = useCallback(async () => {
+    try {
+      setError(null);
+      const [cfgRes, statusRes, mappingsRes] = await Promise.all([
+        apiFetch(`${API()}/config`),
+        apiFetch(`${API()}/status`),
+        apiFetch(`${API()}/mappings`),
+      ]);
+      if (!cfgRes.ok) throw new Error(await readError(cfgRes));
+      const cfgBody = await cfgRes.json();
+      setCfg(cfgBody);
+      setEnabled(Boolean(cfgBody.enabled));
+      setBaseUrl(cfgBody.base_url || '');
+      if (statusRes.ok) setStatus(await statusRes.json());
+      if (mappingsRes.ok) setMappings(await mappingsRes.json());
+    } catch (err) {
+      setError(`Failed to load Home Assistant settings: ${err.message}`);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const refreshStatus = useCallback(async () => {
+    try {
+      const [statusRes, mappingsRes] = await Promise.all([
+        apiFetch(`${API()}/status`),
+        apiFetch(`${API()}/mappings`),
+      ]);
+      if (statusRes.ok) setStatus(await statusRes.json());
+      if (mappingsRes.ok) setMappings(await mappingsRes.json());
+    } catch {
+      /* transient; the visible status just goes stale */
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAll();
+    statusTimer.current = setInterval(refreshStatus, 10000);
+    return () => clearInterval(statusTimer.current);
+  }, [loadAll, refreshStatus]);
+
+  const saveConfig = async () => {
+    setError(null);
+    setNotice(null);
+    setBusy('save');
+    try {
+      const body = { enabled, mode: 'auto', base_url: baseUrl || null };
+      if (token) body.token = token;
+      const res = await apiFetch(`${API()}/config`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error(await readError(res));
+      setCfg(await res.json());
+      setToken('');
+      setNotice('Saved.');
+    } catch (err) {
+      setError(`Save failed: ${err.message}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const testConnection = async () => {
+    setError(null);
+    setNotice(null);
+    setBusy('test');
+    try {
+      const body = { enabled, mode: 'auto', base_url: baseUrl || null };
+      if (token) body.token = token;
+      const res = await apiFetch(`${API()}/test`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error(await readError(res));
+      const result = await res.json();
+      if (result.ok) {
+        setNotice(`Connected to ${result.location_name || 'Home Assistant'} (version ${result.version || '?'}).`);
+      } else {
+        setError(`Connection failed: ${result.error || 'unknown error'}`);
+      }
+    } catch (err) {
+      setError(`Test failed: ${err.message}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  // ---- Mapping dialog -------------------------------------------------
+
+  const openDialog = async (mapping = null) => {
+    setError(null);
+    setNotice(null);
+    setEditingId(mapping ? mapping.id : null);
+    setForm(mapping ? {
+      ...EMPTY_FORM,
+      ...Object.fromEntries(Object.entries(mapping).map(
+        ([k, v]) => [k, v == null ? EMPTY_FORM[k] ?? '' : v])),
+      patient_id: mapping.patient_id ? String(mapping.patient_id) : '',
+    } : EMPTY_FORM);
+    setEntitySearch('');
+    setDialogOpen(true);
+
+    // Pickers load in the background; the dialog stays usable meanwhile.
+    if (!mapping) {
+      setEntities(null);
+      apiFetch(`${API()}/entities`).then(async (res) => {
+        if (res.ok) setEntities(await res.json());
+        else setError(`Couldn't list Home Assistant entities: ${await readError(res)}`);
+      }).catch((err) => setError(`Couldn't list Home Assistant entities: ${err.message}`));
+    }
+    apiFetch(`${config.apiUrl}/api/patients/`).then(async (res) => {
+      if (res.ok) setPatients(await res.json());
+    }).catch(() => {});
+    apiFetch(`${config.apiUrl}/api/environment/metrics`).then(async (res) => {
+      if (res.ok) setMetrics((await res.json()).filter((m) => !m.derived));
+    }).catch(() => {});
+  };
+
+  // Vital-type options depend on the selected patient (custom vitals).
+  useEffect(() => {
+    if (!dialogOpen) return;
+    const qs = form.patient_id ? `?patient_id=${form.patient_id}` : '';
+    apiFetch(`${API()}/vital-types${qs}`).then(async (res) => {
+      if (res.ok) setVitalTypes(await res.json());
+    }).catch(() => {});
+  }, [dialogOpen, form.patient_id]);
+
+  const pickEntity = (entity) => {
+    setForm((f) => ({
+      ...f,
+      entity_id: entity.entity_id,
+      friendly_name: entity.friendly_name || '',
+      device_class: entity.device_class || '',
+      source_unit: entity.unit_of_measurement || '',
+    }));
+  };
+
+  const setField = (key, value) => setForm((f) => ({ ...f, [key]: value }));
+
+  const selectedVitalType = vitalTypes.find((t) => t.value === form.vital_type);
+
+  const saveMapping = async () => {
+    setError(null);
+    setBusy('mapping');
+    try {
+      const body = {
+        entity_id: form.entity_id,
+        friendly_name: form.friendly_name || null,
+        device_class: form.device_class || null,
+        source_unit: form.source_unit || null,
+        target_kind: form.target_kind,
+        min_interval_seconds: Number(form.min_interval_seconds) || 0,
+      };
+      if (form.target_kind === 'vital') {
+        body.patient_id = form.patient_id ? Number(form.patient_id) : null;
+        body.vital_type = form.vital_type || null;
+        body.vital_group = form.vital_group || null;
+      } else {
+        body.metric = form.metric || null;
+        body.scope = form.scope || null;
+        body.location = form.location || null;
+      }
+      const res = await apiFetch(
+        editingId ? `${API()}/mappings/${editingId}` : `${API()}/mappings`,
+        {
+          method: editingId ? 'PUT' : 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.ok) throw new Error(await readError(res));
+      setDialogOpen(false);
+      setNotice(editingId ? 'Mapping updated.' : 'Mapping added.');
+      refreshStatus();
+    } catch (err) {
+      setError(`Mapping save failed: ${err.message}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const toggleMapping = async (mapping) => {
+    const res = await apiFetch(`${API()}/mappings/${mapping.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: !mapping.enabled }),
+    });
+    if (res.ok) refreshStatus();
+    else setError(`Update failed: ${await readError(res)}`);
+  };
+
+  const deleteMapping = async (mapping) => {
+    if (!window.confirm(`Stop ingesting ${mapping.friendly_name || mapping.entity_id}?`)) return;
+    const res = await apiFetch(`${API()}/mappings/${mapping.id}`, { method: 'DELETE' });
+    if (res.ok) refreshStatus();
+    else setError(`Delete failed: ${await readError(res)}`);
+  };
+
+  if (isLoading) {
+    return (
+      <AdminV2Layout>
+        <div className="admin-v2-page">
+          <div className="admin-v2-loading">Loading Home Assistant settings…</div>
+        </div>
+      </AdminV2Layout>
+    );
+  }
+
+  const supervisor = Boolean(cfg?.supervisor_available);
+  const connected = Boolean(status?.connected);
+  const searchLower = entitySearch.trim().toLowerCase();
+  const filteredEntities = (entities || []).filter((e) =>
+    !searchLower
+    || e.entity_id.toLowerCase().includes(searchLower)
+    || (e.friendly_name || '').toLowerCase().includes(searchLower)
+    || (e.device_class || '').toLowerCase().includes(searchLower));
+
+  return (
+    <AdminV2Layout>
+      <div className="admin-v2-page">
+        <div className="tw space-y-6">
+          {error && <Alert variant="destructive">{error}</Alert>}
+          {notice && <Alert variant="success">{notice}</Alert>}
+
+          {/* Connection */}
+          <Card>
+            <CardHeader>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-3">
+                  <span className="text-muted-foreground" aria-hidden><HomeIcon size={22} /></span>
+                  <div className="flex flex-col gap-0.5">
+                    <CardTitle>Home Assistant</CardTitle>
+                    <p className="text-sm text-muted-foreground">
+                      Bring readings from Home Assistant into Smart Home Health —
+                      pulse oximeters, blood pressure cuffs, room sensors, anything HA can see.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Badge variant={connected ? 'success' : 'muted'}>
+                    {connected ? 'Connected' : 'Not connected'}
+                  </Badge>
+                  <Button variant="secondary" onClick={loadAll} className="gap-1.5">
+                    <RefreshIcon size={16} /> Refresh
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-5">
+                {supervisor ? (
+                  <Alert>
+                    Running as the Home Assistant add-on — the connection is automatic,
+                    no URL or token needed.
+                  </Alert>
+                ) : (
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="ha-base-url">Home Assistant URL</Label>
+                      <Input id="ha-base-url" placeholder="http://homeassistant.local:8123"
+                             value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="ha-token">Long-lived access token</Label>
+                      <Input id="ha-token" type="password"
+                             placeholder={cfg?.token_set ? 'Saved — enter to replace' : 'Paste token'}
+                             value={token} onChange={(e) => setToken(e.target.value)} />
+                      <p className="text-xs text-muted-foreground">
+                        Create one in HA under your profile, Security tab. An administrator
+                        user's token is recommended (needed for room names).
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex items-center gap-2">
+                  <Checkbox id="ha-enabled" checked={enabled}
+                            onCheckedChange={(v) => setEnabled(Boolean(v))} />
+                  <Label htmlFor="ha-enabled">Ingest mapped entities live</Label>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button onClick={saveConfig} disabled={busy === 'save'}>
+                    {busy === 'save' ? 'Saving…' : 'Save'}
+                  </Button>
+                  <Button variant="secondary" onClick={testConnection} disabled={busy === 'test'}>
+                    {busy === 'test' ? 'Testing…' : 'Test connection'}
+                  </Button>
+                </div>
+
+                {status?.last_error && !connected && (
+                  <Alert variant="destructive">Last connection error: {status.last_error}</Alert>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Mappings */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex flex-col gap-0.5">
+                  <CardTitle>Entity mappings</CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    Each mapped entity is recorded as a patient vital or an
+                    environmental reading whenever its value changes in HA.
+                  </p>
+                </div>
+                <Button onClick={() => openDialog()} className="gap-1.5 shrink-0">
+                  <PlusIcon size={16} /> Add mapping
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {mappings.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No entities mapped yet. Add a mapping to start ingesting data.
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                        <th className="py-2 pr-4">Entity</th>
+                        <th className="py-2 pr-4">Target</th>
+                        <th className="py-2 pr-4">Last seen</th>
+                        <th className="py-2 pr-4">Last value</th>
+                        <th className="py-2 pr-4">On</th>
+                        <th className="py-2" />
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {mappings.map((m) => (
+                        <tr key={m.id}>
+                          <td className="py-2 pr-4">
+                            <div className="font-medium text-foreground">
+                              {m.friendly_name || m.entity_id}
+                            </div>
+                            <div className="text-xs text-muted-foreground">{m.entity_id}</div>
+                          </td>
+                          <td className="py-2 pr-4">{describeTarget(m)}</td>
+                          <td className="py-2 pr-4">{formatWhen(m.last_seen_at)}</td>
+                          <td className="py-2 pr-4">
+                            {m.last_value != null
+                              ? `${m.last_value}${m.source_unit ? ` ${m.source_unit}` : ''}`
+                              : '—'}
+                            {m.last_error && (
+                              <div className="text-xs text-destructive">{m.last_error}</div>
+                            )}
+                          </td>
+                          <td className="py-2 pr-4">
+                            <Checkbox checked={m.enabled}
+                                      aria-label={`Toggle ${m.entity_id}`}
+                                      onCheckedChange={() => toggleMapping(m)} />
+                          </td>
+                          <td className="py-2">
+                            <div className="flex justify-end gap-1">
+                              <Button variant="ghost" size="icon" aria-label={`Edit ${m.entity_id}`}
+                                      onClick={() => openDialog(m)}>
+                                <EditIcon size={16} />
+                              </Button>
+                              <Button variant="ghost" size="icon" aria-label={`Delete ${m.entity_id}`}
+                                      onClick={() => deleteMapping(m)}>
+                                <TrashIcon size={16} />
+                              </Button>
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Add/edit mapping dialog */}
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogContent className="max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>{editingId ? 'Edit mapping' : 'Add mapping'}</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-4">
+                {/* Entity picker (create only) */}
+                {!editingId && (
+                  <div className="space-y-2">
+                    <Label htmlFor="ha-entity-search">Home Assistant entity</Label>
+                    {form.entity_id ? (
+                      <div className="flex items-center justify-between rounded-lg border border-border p-3 text-sm">
+                        <div>
+                          <div className="font-medium">{form.friendly_name || form.entity_id}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {form.entity_id}
+                            {form.source_unit ? ` · ${form.source_unit}` : ''}
+                          </div>
+                        </div>
+                        <Button variant="secondary" onClick={() => setField('entity_id', '')}>
+                          Change
+                        </Button>
+                      </div>
+                    ) : (
+                      <>
+                        <Input id="ha-entity-search" placeholder="Search entities…"
+                               value={entitySearch}
+                               onChange={(e) => setEntitySearch(e.target.value)} />
+                        <div className="max-h-56 overflow-y-auto rounded-lg border border-border divide-y divide-border">
+                          {entities === null && (
+                            <div className="p-3 text-sm text-muted-foreground">Loading entities…</div>
+                          )}
+                          {entities !== null && filteredEntities.length === 0 && (
+                            <div className="p-3 text-sm text-muted-foreground">No matching entities.</div>
+                          )}
+                          {filteredEntities.slice(0, 50).map((e) => (
+                            <button key={e.entity_id} type="button" onClick={() => pickEntity(e)}
+                                    disabled={e.mapped}
+                                    className="flex w-full items-center justify-between p-3 text-left text-sm hover:bg-secondary/60 disabled:opacity-50">
+                              <span>
+                                <span className="font-medium">{e.friendly_name || e.entity_id}</span>
+                                <span className="ml-2 text-xs text-muted-foreground">{e.entity_id}</span>
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                {e.mapped ? 'Mapped' : [e.state, e.unit_of_measurement].filter(Boolean).join(' ')}
+                              </span>
+                            </button>
+                          ))}
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )}
+
+                {/* Target */}
+                <div className="space-y-2">
+                  <Label>Record as</Label>
+                  <Select value={form.target_kind} onValueChange={(v) => setField('target_kind', v)}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="vital">Patient vital</SelectItem>
+                      <SelectItem value="environment">Environmental reading</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {form.target_kind === 'vital' ? (
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                    <div className="space-y-2">
+                      <Label>Patient</Label>
+                      <Select value={form.patient_id}
+                              onValueChange={(v) => setField('patient_id', v)}>
+                        <SelectTrigger><SelectValue placeholder="Choose…" /></SelectTrigger>
+                        <SelectContent>
+                          {patients.map((p) => (
+                            <SelectItem key={p.id} value={String(p.id)}>
+                              {[p.first_name, p.last_name].filter(Boolean).join(' ') || `Patient ${p.id}`}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Vital type</Label>
+                      <Select value={form.vital_type}
+                              onValueChange={(v) => { setField('vital_type', v); setField('vital_group', ''); }}>
+                        <SelectTrigger><SelectValue placeholder="Choose…" /></SelectTrigger>
+                        <SelectContent>
+                          {vitalTypes.map((t) => (
+                            <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    {selectedVitalType?.groups?.length > 0 && (
+                      <div className="space-y-2">
+                        <Label>Component</Label>
+                        <Select value={form.vital_group}
+                                onValueChange={(v) => setField('vital_group', v)}>
+                          <SelectTrigger><SelectValue placeholder="Choose…" /></SelectTrigger>
+                          <SelectContent>
+                            {selectedVitalType.groups.map((g) => (
+                              <SelectItem key={g} value={g}>{g}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                    <div className="space-y-2">
+                      <Label>Metric</Label>
+                      <Select value={form.metric} onValueChange={(v) => setField('metric', v)}>
+                        <SelectTrigger><SelectValue placeholder="Choose…" /></SelectTrigger>
+                        <SelectContent>
+                          {metrics.map((m) => (
+                            <SelectItem key={m.name} value={m.name}>
+                              {m.label} ({m.unit})
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Scope</Label>
+                      <Select value={form.scope} onValueChange={(v) => setField('scope', v)}>
+                        <SelectTrigger><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="room">Room</SelectItem>
+                          <SelectItem value="indoor">Indoor (whole home)</SelectItem>
+                          <SelectItem value="outdoor">Outdoor</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="ha-map-location">Location</Label>
+                      <Input id="ha-map-location" placeholder="e.g. bedroom"
+                             value={form.location}
+                             onChange={(e) => setField('location', e.target.value)} />
+                    </div>
+                  </div>
+                )}
+
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="ha-map-interval">Minimum seconds between recordings</Label>
+                    <Input id="ha-map-interval" type="number" min="0" max="86400"
+                           value={form.min_interval_seconds}
+                           onChange={(e) => setField('min_interval_seconds', e.target.value)} />
+                    <p className="text-xs text-muted-foreground">
+                      0 records every change; e.g. 300 keeps a chatty sensor to one reading per 5 minutes.
+                    </p>
+                  </div>
+                  {form.source_unit && (
+                    <div className="space-y-2">
+                      <Label>Detected unit</Label>
+                      <p className="pt-2 text-sm text-muted-foreground">{form.source_unit}</p>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <DialogFooter>
+                <Button variant="secondary" onClick={() => setDialogOpen(false)}>Cancel</Button>
+                <Button onClick={saveMapping}
+                        disabled={busy === 'mapping' || !form.entity_id
+                          || (form.target_kind === 'vital' && (!form.patient_id || !form.vital_type))
+                          || (form.target_kind === 'environment' && !form.metric)}>
+                  {busy === 'mapping' ? 'Saving…' : (editingId ? 'Save changes' : 'Add mapping')}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+    </AdminV2Layout>
+  );
+};
+
+export default AdminV2HomeAssistant;

--- a/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
@@ -206,7 +206,9 @@ const AdminV2HomeAssistant = () => {
         else setError(`Couldn't list Home Assistant entities: ${await readError(res)}`);
       }).catch((err) => setError(`Couldn't list Home Assistant entities: ${err.message}`));
     }
-    apiFetch(`${config.apiUrl}/api/patients/`).then(async (res) => {
+    // No trailing slash: the collection route is declared @router.get("") and
+    // the slash variant 307s (see the trailing-slash pitfall in CLAUDE.md).
+    apiFetch(`${config.apiUrl}/api/patients`).then(async (res) => {
       if (res.ok) setPatients(await res.json());
     }).catch(() => {});
     apiFetch(`${config.apiUrl}/api/environment/metrics`).then(async (res) => {

--- a/frontend/src/pages/admin-v2/AdminV2HomeAssistant.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2HomeAssistant.test.jsx
@@ -17,7 +17,7 @@
  */
 // AdminV2HomeAssistant: connection card (supervisor banner vs token form),
 // mappings table, and the add-mapping dialog's entity picker.
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act, fireEvent } from '@testing-library/react';
 
 vi.mock('./AdminV2Layout', () => ({ default: ({ children }) => <div>{children}</div> }));
@@ -91,6 +91,10 @@ const renderPage = async () => {
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   apiFetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('AdminV2HomeAssistant', () => {

--- a/frontend/src/pages/admin-v2/AdminV2HomeAssistant.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2HomeAssistant.test.jsx
@@ -1,0 +1,179 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// AdminV2HomeAssistant: connection card (supervisor banner vs token form),
+// mappings table, and the add-mapping dialog's entity picker.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+
+vi.mock('./AdminV2Layout', () => ({ default: ({ children }) => <div>{children}</div> }));
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }));
+vi.mock('../../config', () => ({
+  default: { apiUrl: '' },
+  apiFetch: apiFetchMock,
+}));
+
+import AdminV2HomeAssistant from './AdminV2HomeAssistant';
+
+const jsonResponse = (body, status = 200) => ({
+  ok: status < 400,
+  status,
+  json: async () => body,
+});
+
+const baseConfig = {
+  enabled: false,
+  mode: 'auto',
+  base_url: '',
+  token_set: false,
+  supervisor_available: false,
+  connection_available: false,
+};
+
+const baseStatus = { connected: false, mapping_count: 0 };
+
+const sampleMapping = {
+  id: 1,
+  entity_id: 'sensor.spo2_ring',
+  friendly_name: 'SpO2 Ring',
+  device_class: null,
+  source_unit: '%',
+  target_kind: 'vital',
+  patient_id: 5,
+  vital_type: 'spo2',
+  vital_group: null,
+  metric: null,
+  scope: null,
+  location: null,
+  enabled: true,
+  min_interval_seconds: 0,
+  last_seen_at: '2026-08-15T10:00:00+00:00',
+  last_value: 97,
+  last_error: null,
+};
+
+// Route the page's parallel fetches by URL.
+const routeFetches = ({ config = baseConfig, status = baseStatus, mappings = [],
+                        entities = [], patients = [], vitalTypes = [], metrics = [] } = {}) => {
+  apiFetchMock.mockImplementation(async (url) => {
+    if (url.includes('/home_assistant/config')) return jsonResponse(config);
+    if (url.includes('/home_assistant/status')) return jsonResponse(status);
+    if (url.includes('/home_assistant/mappings')) return jsonResponse(mappings);
+    if (url.includes('/home_assistant/entities')) return jsonResponse(entities);
+    if (url.includes('/home_assistant/vital-types')) return jsonResponse(vitalTypes);
+    if (url.includes('/api/patients')) return jsonResponse(patients);
+    if (url.includes('/api/environment/metrics')) return jsonResponse(metrics);
+    return jsonResponse({}, 404);
+  });
+};
+
+const renderPage = async () => {
+  await act(async () => {
+    render(<AdminV2HomeAssistant />);
+  });
+};
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiFetchMock.mockReset();
+});
+
+describe('AdminV2HomeAssistant', () => {
+  it('shows the token form when not running as the add-on', async () => {
+    routeFetches();
+    await renderPage();
+
+    expect(screen.getByLabelText('Home Assistant URL')).toBeInTheDocument();
+    expect(screen.getByLabelText('Long-lived access token')).toBeInTheDocument();
+    expect(screen.getByText('Not connected')).toBeInTheDocument();
+  });
+
+  it('shows the add-on banner instead of the token form under the Supervisor', async () => {
+    routeFetches({
+      config: { ...baseConfig, supervisor_available: true, connection_available: true },
+      status: { ...baseStatus, connected: true },
+    });
+    await renderPage();
+
+    expect(screen.getByText(/Running as the Home Assistant add-on/)).toBeInTheDocument();
+    expect(screen.queryByLabelText('Home Assistant URL')).not.toBeInTheDocument();
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+  });
+
+  it('renders existing mappings with target and last value', async () => {
+    routeFetches({ mappings: [sampleMapping] });
+    await renderPage();
+
+    expect(screen.getByText('SpO2 Ring')).toBeInTheDocument();
+    expect(screen.getByText('Vital: spo2')).toBeInTheDocument();
+    expect(screen.getByText('97 %')).toBeInTheDocument();
+  });
+
+  it('opens the add-mapping dialog and lists pickable entities', async () => {
+    routeFetches({
+      entities: [
+        { entity_id: 'sensor.bedroom_temp', friendly_name: 'Bedroom Temp',
+          state: '71', unit_of_measurement: '°F', device_class: 'temperature',
+          domain: 'sensor', mapped: false },
+        { entity_id: 'sensor.already', friendly_name: 'Already Mapped',
+          state: '1', unit_of_measurement: null, device_class: null,
+          domain: 'sensor', mapped: true },
+      ],
+      vitalTypes: [{ value: 'spo2', label: 'SpO2', groups: [] }],
+      metrics: [{ name: 'temperature', label: 'Temperature', unit: '°C', derived: false }],
+    });
+    await renderPage();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Add mapping/ }));
+    });
+
+    expect(screen.getByText('Bedroom Temp')).toBeInTheDocument();
+    const mappedRow = screen.getByText('Already Mapped').closest('button');
+    expect(mappedRow).toBeDisabled();
+
+    // Picking an entity captures its metadata into the form.
+    await act(async () => {
+      fireEvent.click(screen.getByText('Bedroom Temp').closest('button'));
+    });
+    expect(screen.getByText(/sensor\.bedroom_temp\s*·\s*°F/)).toBeInTheDocument();
+  });
+
+  it('filters entities by search text', async () => {
+    routeFetches({
+      entities: [
+        { entity_id: 'sensor.bedroom_temp', friendly_name: 'Bedroom Temp',
+          state: '71', unit_of_measurement: '°F', device_class: 'temperature',
+          domain: 'sensor', mapped: false },
+        { entity_id: 'sensor.pulse_ox', friendly_name: 'Pulse Ox',
+          state: '97', unit_of_measurement: '%', device_class: null,
+          domain: 'sensor', mapped: false },
+      ],
+    });
+    await renderPage();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Add mapping/ }));
+    });
+    fireEvent.change(screen.getByPlaceholderText('Search entities…'),
+                     { target: { value: 'pulse' } });
+
+    expect(screen.getByText('Pulse Ox')).toBeInTheDocument();
+    expect(screen.queryByText('Bedroom Temp')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/admin-v2/AdminV2Layout.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Layout.jsx
@@ -166,6 +166,7 @@ const getTopNavItems = (section, hasAnyPermission, hasReadAccess, isSystemAdmin)
       ...(hasAnyPermission(['roles.read', 'roles.create', 'roles.update', 'roles.delete', 'users.read'])
         ? [{ path: '/care/configuration/users/roles', label: 'Roles' }] : []),
       { path: '/care/configuration/mqtt', label: 'MQTT' },
+      { path: '/care/configuration/home-assistant', label: 'Home Assistant' },
       { path: '/care/configuration/environment', label: 'Environment' },
       ...(isSystemAdmin
         ? [{ path: '/care/configuration/backup', label: 'Backup' }] : []),

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,5 +85,6 @@ nav:
       - Epic / FHIR: integrations/epic-fhir.md
       - Withings: integrations/withings.md
       - MQTT: integrations/mqtt.md
+      - Home Assistant (inbound): integrations/home-assistant.md
       - Frigate: integrations/frigate.md
       - Manual entry: integrations/manual-entry.md


### PR DESCRIPTION
## What

New **inbound** Home Assistant integration: SHH subscribes to selected HA entities over HA's WebSocket API and records them as **patient vitals** (SpO2, BP, glucose, weight, …) or **environmental observations** (temp/RH/CO2/PM2.5/… — fills the HA connector slot from #48). Counterpart to the existing outbound MQTT publish, which is untouched.

## How

- **`backend/homeassistant/`** — `client.py` (WS auth handshake generalized from `utils/ha_core.py`, `subscribe_events` for state_changed, REST seed via `/api/states`, registry enrichment best-effort), `service.py` (config/state in settings table; state-event → Vital row or `emit_observations()` with canonical-unit conversion), `listener.py` (startup loop, reconnect w/ backoff, reload on config/mapping change).
- **Connection modes:** auto-detects the Supervisor proxy when running as the HA add-on (`SUPERVISOR_TOKEN`, already granted by `homeassistant_api: true`) → zero config; standalone uses base URL + long-lived access token.
- **`ha_entity_mappings`** table (migration 039): one row per entity → target, with per-mapping throttle and last-seen/last-value/last-error staleness surface.
- **Vitals path** mirrors Withings persistence (`source`, `device_id`, `external_id` dedup, LOINC/UCUM enrichment) and publishes the `vital_saved` topic event so the live UI and outbound MQTT combined-state stay in sync.
- **Loop prevention:** SHH's own MQTT-discovered entities (manufacturer "Smart Home Health" / `shh_*` identifiers) are excluded from the picker and skipped by the listener.
- **Routes** under `/api/integrations/home_assistant` (config/test/status/entities/vital-types/mappings CRUD); thin registrations in the integrations registry and the environment connector registry.
- **admin-v2 page** at Configuration → Home Assistant: connection card (add-on banner vs token form), searchable entity picker, mapping editor (vital vs environment targets), staleness table.
- Docs page `docs/integrations/home-assistant.md` (+ mkdocs nav; docs dir itself is gitignored like the other integration docs).

## Behavior decisions (confirmed)

- v1 records vitals history only — HA entities do not drive the live dashboard/alarm pipeline (per-mapping flag is a listed follow-up).
- Initial state is recorded once at connect (external_id dedup makes reconnects no-ops).
- HA-sourced vitals keep republishing on SHH's combined-state MQTT topic.

## Testing

- Backend gate: **546 passed** (39 new in `tests/test_home_assistant.py` — client config resolution, unit conversion, recording/dedup/throttle, route validation incl. account scoping, SHH-entity exclusion). Migration exercised by the upgrade walk.
- Frontend: **329 passed** (5 new for the admin page); touched files ESLint-clean.
- Live smoke on the dev stack: migration 039 applied, listener idles until configured, all new endpoints respond, `home_assistant` appears as a push-mode environment connector.

Not yet exercised against a real HA instance — needs an on-device pass (map one env sensor + one health sensor; add-on Supervisor path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS8WMSAiMKmozbMuwbiocw