### PR TITLE
Fix dialog overflow/positioning on phone widths

### DIFF
--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -43,7 +43,11 @@ const DialogContent = React.forwardRef(function DialogContent({ className, child
         ref={ref}
         data-slot="dialog-content"
         className={cn(
-          "tw fixed left-1/2 top-1/2 z-[1001] grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4",
+          // grid-cols-1 = minmax(0,1fr): without the minmax(0,...) the implicit
+          // auto column sizes to the widest child's min-content, so long
+          // unbreakable content (entity ids, urls) widens the dialog past the
+          // viewport on phones instead of truncating.
+          "tw fixed left-1/2 top-1/2 z-[1001] grid grid-cols-1 w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4",
           "max-h-[calc(100dvh-2rem)] overflow-y-auto rounded-xl border border-border bg-card p-6 text-card-foreground shadow-lg",
           className
         )}

--- a/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
@@ -476,7 +476,7 @@ const AdminV2HomeAssistant = () => {
 
           {/* Add/edit mapping dialog */}
           <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-            <DialogContent className="max-w-2xl">
+            <DialogContent className="sm:max-w-2xl" aria-describedby={undefined}>
               <DialogHeader>
                 <DialogTitle>{editingId ? 'Edit mapping' : 'Add mapping'}</DialogTitle>
               </DialogHeader>
@@ -486,15 +486,19 @@ const AdminV2HomeAssistant = () => {
                   <div className="space-y-2">
                     <Label htmlFor="ha-entity-search">Home Assistant entity</Label>
                     {form.entity_id ? (
-                      <div className="flex items-center justify-between rounded-lg border border-border p-3 text-sm">
-                        <div>
-                          <div className="font-medium">{form.friendly_name || form.entity_id}</div>
-                          <div className="text-xs text-muted-foreground">
+                      <div className="flex items-center justify-between gap-3 overflow-hidden rounded-lg border border-border p-3 text-sm">
+                        {/* overflow-hidden (not just min-w-0): without it the
+                            nowrap entity text sets the grid column's min-content
+                            and widens the whole dialog past the phone viewport */}
+                        <div className="min-w-0 overflow-hidden">
+                          <div className="truncate font-medium">{form.friendly_name || form.entity_id}</div>
+                          <div className="break-all text-xs text-muted-foreground">
                             {form.entity_id}
                             {form.source_unit ? ` · ${form.source_unit}` : ''}
                           </div>
                         </div>
-                        <Button variant="secondary" onClick={() => setField('entity_id', '')}>
+                        <Button variant="secondary" className="shrink-0"
+                                onClick={() => setField('entity_id', '')}>
                           Change
                         </Button>
                       </div>
@@ -513,12 +517,14 @@ const AdminV2HomeAssistant = () => {
                           {filteredEntities.slice(0, 50).map((e) => (
                             <button key={e.entity_id} type="button" onClick={() => pickEntity(e)}
                                     disabled={e.mapped}
-                                    className="flex w-full items-center justify-between p-3 text-left text-sm hover:bg-secondary/60 disabled:opacity-50">
-                              <span>
-                                <span className="font-medium">{e.friendly_name || e.entity_id}</span>
-                                <span className="ml-2 text-xs text-muted-foreground">{e.entity_id}</span>
+                                    className="flex w-full items-center justify-between gap-3 p-3 text-left text-sm hover:bg-secondary/60 disabled:opacity-50">
+                              {/* overflow-hidden + truncate: long entity ids must
+                                  never widen the dialog past the viewport on mobile */}
+                              <span className="min-w-0 overflow-hidden">
+                                <span className="block truncate font-medium">{e.friendly_name || e.entity_id}</span>
+                                <span className="block truncate text-xs text-muted-foreground">{e.entity_id}</span>
                               </span>
-                              <span className="text-xs text-muted-foreground">
+                              <span className="shrink-0 text-xs text-muted-foreground">
                                 {e.mapped ? 'Mapped' : [e.state, e.unit_of_measurement].filter(Boolean).join(' ')}
                               </span>
                             </button>

--- a/frontend/src/tailwind.css
+++ b/frontend/src/tailwind.css
@@ -185,9 +185,12 @@
 /* ---- Animations (replaces tw-animate-css for the few we use) ------------ */
 @keyframes tw-fade-in { from { opacity: 0 } to { opacity: 1 } }
 @keyframes tw-fade-out { from { opacity: 1 } to { opacity: 0 } }
-/* Dialog content is centered via translate(-50%,-50%); keep it during scale. */
-@keyframes tw-dialog-in { from { opacity: 0; transform: translate(-50%, -50%) scale(.96) } to { opacity: 1; transform: translate(-50%, -50%) scale(1) } }
-@keyframes tw-dialog-out { from { opacity: 1; transform: translate(-50%, -50%) scale(1) } to { opacity: 0; transform: translate(-50%, -50%) scale(.96) } }
+/* Dialog content centers via Tailwind v4's independent `translate` property
+   (-translate-x/y-1/2). The keyframes must NOT translate too — a v3-era
+   translate(-50%,-50%) here stacks on top of `translate` and shoves the
+   dialog off-screen for the whole animation (worst on phone widths). */
+@keyframes tw-dialog-in { from { opacity: 0; transform: scale(.96) } to { opacity: 1; transform: scale(1) } }
+@keyframes tw-dialog-out { from { opacity: 1; transform: scale(1) } to { opacity: 0; transform: scale(.96) } }
 /* Select popover is popper-positioned (no translate) — scale only. */
 @keyframes tw-pop-in { from { opacity: 0; transform: scale(.96) } to { opacity: 1; transform: scale(1) } }
 


### PR DESCRIPTION
Follow-up to #87: the HA add-mapping dialog overflowed on mobile. Reproducing at a 375px viewport with Playwright (long entity ids mocked in) exposed three stacked causes — two latent bugs in the shared dialog primitive affecting **every** dialog, one page-level:

1. **Off-screen entry animation (all dialogs):** `tw-dialog-in/out` keyframes still animated a Tailwind v3-era `transform: translate(-50%,-50%) scale(…)`. Tailwind v4 centers via the separate `translate` property, so the offsets stacked and dialogs rendered off-screen for the whole 150ms animation. Keyframes now scale/fade only.
2. **Min-content blowout (all dialogs):** `DialogContent`'s implicit grid column sized to the widest child's min-content, so long unbreakable text widened the dialog past the viewport (with hidden internal horizontal scroll) instead of truncating. `grid-cols-1` (`minmax(0,1fr)`) caps the column.
3. **Entity text hygiene (HA page):** picker rows / selected-entity card now truncate names and break long entity ids; dialog uses the `sm:max-w-2xl` convention.

Verified with a mobile-viewport Playwright run against the live stack: no page-level or in-dialog horizontal overflow in list and picked states, dialog fully within a 375px viewport. Frontend suite 329 green, lint clean.

(Commit moved here from dev/ha-inbound, which was pushed after #87 merged; that branch is reset to its merged tip.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS8WMSAiMKmozbMuwbiocw