### PR TITLE
Room sensors: HA-area location piggyback + room overlays on the timeline

### DIFF
--- a/backend/homeassistant/client.py
+++ b/backend/homeassistant/client.py
@@ -237,6 +237,20 @@ class HAClient:
         finally:
             await ws.close()
 
+    async def list_areas(self) -> List[str]:
+        """
+        HA area (room) names, for reusing the user's HA rooms as SHH
+        locations. Registry access needs an admin token — raises HAClientError
+        when unavailable so callers can degrade to free-text locations.
+        """
+        ws = await self._ws_connect()
+        try:
+            area_reg = await self._ws_command(ws, 1, {"type": "config/area_registry/list"})
+            names = [a.get("name") for a in area_reg or [] if a.get("name")]
+            return sorted(names, key=str.lower)
+        finally:
+            await ws.close()
+
     async def listen(
         self,
         entity_ids: Set[str],

--- a/backend/routes/home_assistant.py
+++ b/backend/routes/home_assistant.py
@@ -174,6 +174,25 @@ async def list_entities(
     return result
 
 
+@router.get("/areas")
+async def list_areas(
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_read_access),
+):
+    """
+    HA area (room) names, offered as location suggestions so SHH locations
+    stay consistent with the user's Home Assistant rooms. Empty list when HA
+    is unreachable or the token can't read the registry (non-admin) — the
+    location field then falls back to free text.
+    """
+    config = service.get_config(db)
+    try:
+        return await HAClient.from_config(config).list_areas()
+    except HAClientError as e:
+        logger.info(f"HA area listing unavailable: {e}")
+        return []
+
+
 @router.get("/vital-types")
 async def list_vital_types(
     patient_id: Optional[int] = None,

--- a/backend/tests/test_home_assistant.py
+++ b/backend/tests/test_home_assistant.py
@@ -451,6 +451,37 @@ def test_entities_annotated_and_shh_excluded(admin_client, patient, monkeypatch)
     assert len(resp.json()) == 2
 
 
+def test_areas_from_ha_registry(admin_client, monkeypatch):
+    from routes import home_assistant as ha_routes
+
+    class FakeClient:
+        @classmethod
+        def from_config(cls, config):
+            return cls()
+
+        async def list_areas(self):
+            return ["Bedroom", "Living Room"]
+
+    monkeypatch.setattr(ha_routes, "HAClient", FakeClient)
+    resp = admin_client.get("/api/integrations/home_assistant/areas")
+    assert resp.status_code == 200
+    assert resp.json() == ["Bedroom", "Living Room"]
+
+
+def test_areas_degrade_to_empty_when_unavailable(admin_client, monkeypatch):
+    from routes import home_assistant as ha_routes
+
+    class DeadClient:
+        @classmethod
+        def from_config(cls, config):
+            raise HAClientError("not configured")
+
+    monkeypatch.setattr(ha_routes, "HAClient", DeadClient)
+    resp = admin_client.get("/api/integrations/home_assistant/areas")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
 def test_entities_unreachable_returns_502(admin_client, monkeypatch):
     from routes import home_assistant as ha_routes
 

--- a/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
@@ -643,7 +643,8 @@ const AdminV2HomeAssistant = () => {
                         ))}
                       </datalist>
                       <p className="text-xs text-muted-foreground">
-                        Suggestions come from your Home Assistant areas.
+                        Suggestions come from your Home Assistant areas and
+                        rooms already in use here.
                       </p>
                     </div>
                   </div>

--- a/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
@@ -90,6 +90,9 @@ const AdminV2HomeAssistant = () => {
   const [patients, setPatients] = useState([]);
   const [vitalTypes, setVitalTypes] = useState([]);
   const [metrics, setMetrics] = useState([]);
+  // Location suggestions: the user's HA areas (rooms) + locations already
+  // seen in the data, so room names stay consistent across both platforms.
+  const [locationOptions, setLocationOptions] = useState([]);
 
   const statusTimer = useRef(null);
 
@@ -214,6 +217,15 @@ const AdminV2HomeAssistant = () => {
     apiFetch(`${config.apiUrl}/api/environment/metrics`).then(async (res) => {
       if (res.ok) setMetrics((await res.json()).filter((m) => !m.derived));
     }).catch(() => {});
+    Promise.all([
+      apiFetch(`${API()}/areas`).then((res) => (res.ok ? res.json() : [])),
+      apiFetch(`${config.apiUrl}/api/environment/locations`)
+        .then((res) => (res.ok ? res.json() : [])),
+    ]).then(([areas, locations]) => {
+      const seen = locations.filter((l) => l.scope !== 'outdoor' && l.location)
+                            .map((l) => l.location);
+      setLocationOptions([...new Set([...areas, ...seen])]);
+    }).catch(() => {});
   };
 
   // Vital-type options depend on the selected patient (custom vitals).
@@ -232,6 +244,9 @@ const AdminV2HomeAssistant = () => {
       friendly_name: entity.friendly_name || '',
       device_class: entity.device_class || '',
       source_unit: entity.unit_of_measurement || '',
+      // Piggyback the entity's HA area as the location so rooms stay
+      // consistent between HA and SHH; still editable below.
+      location: f.location || entity.area || '',
     }));
   };
 
@@ -619,8 +634,17 @@ const AdminV2HomeAssistant = () => {
                     <div className="space-y-2">
                       <Label htmlFor="ha-map-location">Location</Label>
                       <Input id="ha-map-location" placeholder="e.g. bedroom"
+                             list="ha-location-suggestions"
                              value={form.location}
                              onChange={(e) => setField('location', e.target.value)} />
+                      <datalist id="ha-location-suggestions">
+                        {locationOptions.map((loc) => (
+                          <option key={loc} value={loc} />
+                        ))}
+                      </datalist>
+                      <p className="text-xs text-muted-foreground">
+                        Suggestions come from your Home Assistant areas.
+                      </p>
                     </div>
                   </div>
                 )}

--- a/frontend/src/pages/admin-v2/AdminV2HomeAssistant.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2HomeAssistant.test.jsx
@@ -69,15 +69,18 @@ const sampleMapping = {
 
 // Route the page's parallel fetches by URL.
 const routeFetches = ({ config = baseConfig, status = baseStatus, mappings = [],
-                        entities = [], patients = [], vitalTypes = [], metrics = [] } = {}) => {
+                        entities = [], patients = [], vitalTypes = [], metrics = [],
+                        areas = [], locations = [] } = {}) => {
   apiFetchMock.mockImplementation(async (url) => {
     if (url.includes('/home_assistant/config')) return jsonResponse(config);
     if (url.includes('/home_assistant/status')) return jsonResponse(status);
     if (url.includes('/home_assistant/mappings')) return jsonResponse(mappings);
     if (url.includes('/home_assistant/entities')) return jsonResponse(entities);
     if (url.includes('/home_assistant/vital-types')) return jsonResponse(vitalTypes);
+    if (url.includes('/home_assistant/areas')) return jsonResponse(areas);
     if (url.includes('/api/patients')) return jsonResponse(patients);
     if (url.includes('/api/environment/metrics')) return jsonResponse(metrics);
+    if (url.includes('/api/environment/locations')) return jsonResponse(locations);
     return jsonResponse({}, 404);
   });
 };
@@ -156,6 +159,32 @@ describe('AdminV2HomeAssistant', () => {
       fireEvent.click(screen.getByText('Bedroom Temp').closest('button'));
     });
     expect(screen.getByText(/sensor\.bedroom_temp\s*·\s*°F/)).toBeInTheDocument();
+  });
+
+  it('offers HA areas + seen locations as location suggestions when editing', async () => {
+    routeFetches({
+      mappings: [{ ...sampleMapping, id: 3, entity_id: 'sensor.bedroom_co2',
+                   friendly_name: 'Bedroom CO2', target_kind: 'environment',
+                   patient_id: null, vital_type: null, metric: 'co2',
+                   scope: 'room', location: 'Bedroom' }],
+      areas: ['Bedroom', 'Living Room'],
+      locations: [
+        { scope: 'room', location: 'Office', last_seen: null, metric_count: 1 },
+        { scope: 'outdoor', location: '', last_seen: null, metric_count: 9 },
+      ],
+      metrics: [{ name: 'co2', label: 'CO2', unit: 'ppm', derived: false }],
+    });
+    await renderPage();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Edit sensor.bedroom_co2' }));
+    });
+
+    expect(screen.getByLabelText('Location')).toHaveValue('Bedroom');
+    const options = [...document.querySelectorAll('#ha-location-suggestions option')]
+      .map((o) => o.value);
+    expect(options).toEqual(expect.arrayContaining(['Bedroom', 'Living Room', 'Office']));
+    expect(options).not.toContain('');  // outdoor "" never suggested
   });
 
   it('filters entities by search text', async () => {

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
@@ -20,7 +20,7 @@ import Chart from 'chart.js/auto';
 import 'chartjs-adapter-date-fns';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import zoomPlugin from 'chartjs-plugin-zoom';
-import config from '../../config';
+import config, { apiFetch } from '../../config';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
 import {
   ChevronLeftIcon,
@@ -175,9 +175,8 @@ const AdminV2MonitoringTimeline = () => {
     setError(null);
     try {
       const dateParam = formatDateForApi(selectedDate);
-      const response = await fetch(
-        `${config.apiUrl}/api/monitoring/timeline?patient_id=${selectedPatient.id}&target_date=${dateParam}`,
-        { credentials: 'include' }
+      const response = await apiFetch(
+        `${config.apiUrl}/api/monitoring/timeline?patient_id=${selectedPatient.id}&target_date=${dateParam}`
       );
       if (!response.ok) throw new Error('Failed to fetch timeline data');
       const data = await response.json();
@@ -200,8 +199,7 @@ const AdminV2MonitoringTimeline = () => {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`${config.apiUrl}/api/environment/locations`,
-                                { credentials: 'include' });
+        const res = await apiFetch(`${config.apiUrl}/api/environment/locations`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const rows = await res.json();
         const rooms = [...new Set(rows.filter((r) => r.scope === 'room')
@@ -248,9 +246,8 @@ const AdminV2MonitoringTimeline = () => {
             if (roomLocation === null) { next[key] = []; return; }
             params.set('location', roomLocation);
           }
-          const res = await fetch(
-            `${config.apiUrl}/api/environment/observations?${params}`,
-            { credentials: 'include' }
+          const res = await apiFetch(
+            `${config.apiUrl}/api/environment/observations?${params}`
           );
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           const rows = await res.json();

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
@@ -30,6 +30,9 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Alert } from '@/components/ui/alert';
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from '@/components/ui/select';
 import { useChartColors } from '../../hooks/useChartColors';
 
 Chart.register(annotationPlugin, zoomPlugin);
@@ -56,21 +59,50 @@ const VITAL_SERIES = {
 // Environmental series (home-level, from /api/environment/observations).
 // `dashed: true` marks estimated/derived metrics — rendered with a dashed
 // line to distinguish them from measured readings.
+// `metric`/`scope` select the observation stream; room-scoped series also
+// filter by the picked room (see roomLocation below).
 const ENV_SERIES = {
   barometric_pressure: {
     label: 'Pressure', axisLabel: 'Pressure (hPa)', color: '#8d6e63',
     fill: 'rgba(141, 110, 99, 0.1)', gridTint: 'rgba(141, 110, 99, 0.08)',
     defaultMin: 990, defaultMax: 1030, minPad: 1, clampMax: null, dashed: false,
+    metric: 'barometric_pressure', scope: 'outdoor',
   },
   pressure_delta_6h: {
     label: 'Pressure Δ6h', axisLabel: 'Pressure change 6h (hPa)', color: '#a1887f',
     fill: 'rgba(161, 136, 127, 0.1)', gridTint: 'rgba(161, 136, 127, 0.08)',
     defaultMin: -5, defaultMax: 5, minPad: 0.5, clampMax: null, dashed: true,
+    metric: 'pressure_delta_6h', scope: 'outdoor',
   },
   relative_humidity: {
-    label: 'Humidity', axisLabel: 'Humidity (%)', color: '#26a69a',
+    label: 'Humidity (out)', axisLabel: 'Outdoor humidity (%)', color: '#26a69a',
     fill: 'rgba(38, 166, 154, 0.1)', gridTint: 'rgba(38, 166, 154, 0.08)',
     defaultMin: 20, defaultMax: 80, minPad: 2, clampMax: 100, dashed: false,
+    metric: 'relative_humidity', scope: 'outdoor',
+  },
+  room_temperature: {
+    label: 'Room temp', axisLabel: 'Room temp (°C)', color: '#ef6c00',
+    fill: 'rgba(239, 108, 0, 0.1)', gridTint: 'rgba(239, 108, 0, 0.08)',
+    defaultMin: 15, defaultMax: 30, minPad: 0.5, clampMax: null, dashed: false,
+    metric: 'temperature', scope: 'room',
+  },
+  room_humidity: {
+    label: 'Room humidity', axisLabel: 'Room humidity (%)', color: '#00897b',
+    fill: 'rgba(0, 137, 123, 0.1)', gridTint: 'rgba(0, 137, 123, 0.08)',
+    defaultMin: 20, defaultMax: 80, minPad: 2, clampMax: 100, dashed: false,
+    metric: 'relative_humidity', scope: 'room',
+  },
+  co2: {
+    label: 'CO2', axisLabel: 'CO2 (ppm)', color: '#7e57c2',
+    fill: 'rgba(126, 87, 194, 0.1)', gridTint: 'rgba(126, 87, 194, 0.08)',
+    defaultMin: 400, defaultMax: 1200, minPad: 25, clampMax: null, dashed: false,
+    metric: 'co2', scope: 'room',
+  },
+  pm25: {
+    label: 'PM2.5', axisLabel: 'PM2.5 (µg/m³)', color: '#78909c',
+    fill: 'rgba(120, 144, 156, 0.1)', gridTint: 'rgba(120, 144, 156, 0.08)',
+    defaultMin: 0, defaultMax: 35, minPad: 1, clampMax: null, dashed: false,
+    metric: 'pm25', scope: 'room',
   },
 };
 const SERIES = { ...VITAL_SERIES, ...ENV_SERIES };
@@ -160,12 +192,39 @@ const AdminV2MonitoringTimeline = () => {
 
   useEffect(() => { fetchTimeline(); }, [fetchTimeline]);
 
-  // Environmental overlay data for the selected day, keyed by metric.
+  // Rooms seen in the data (scope=room locations), for the room picker.
+  // "" is a legitimate location (unspecified room) and renders as such.
+  const [roomLocations, setRoomLocations] = useState([]);
+  const [roomLocation, setRoomLocation] = useState(null);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${config.apiUrl}/api/environment/locations`,
+                                { credentials: 'include' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const rows = await res.json();
+        const rooms = [...new Set(rows.filter((r) => r.scope === 'room')
+                                      .map((r) => r.location ?? ''))];
+        if (cancelled) return;
+        setRoomLocations(rooms);
+        // Default to the care area: prefer a bedroom-ish name, else first.
+        setRoomLocation((prev) => (prev !== null && rooms.includes(prev)) ? prev
+          : rooms.find((l) => /bed|care/i.test(l)) ?? rooms[0] ?? null);
+      } catch (err) {
+        console.error('Environment locations fetch failed:', err);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Environmental overlay data for the selected day, keyed by series key.
   // Home-level (not patient-scoped); failure degrades to an empty series and
   // never blocks the vitals chart.
   const [envData, setEnvData] = useState({});
   const activeEnvKeys = activeVitals.filter((k) => ENV_SERIES[k]);
   const activeEnvKeysStr = activeEnvKeys.join(',');
+  const roomSeriesActive = activeEnvKeys.some((k) => ENV_SERIES[k].scope === 'room');
   useEffect(() => {
     let cancelled = false;
     const keys = activeEnvKeysStr ? activeEnvKeysStr.split(',') : [];
@@ -180,10 +239,15 @@ const AdminV2MonitoringTimeline = () => {
       const next = {};
       await Promise.all(keys.map(async (key) => {
         try {
+          const cfg = ENV_SERIES[key];
           const params = new URLSearchParams({
-            metric: key, scope: 'outdoor', bucket: '15m', limit: '500',
+            metric: cfg.metric, scope: cfg.scope, bucket: '15m', limit: '500',
             from: dayStart.toISOString(), to: dayEnd.toISOString(),
           });
+          if (cfg.scope === 'room') {
+            if (roomLocation === null) { next[key] = []; return; }
+            params.set('location', roomLocation);
+          }
           const res = await fetch(
             `${config.apiUrl}/api/environment/observations?${params}`,
             { credentials: 'include' }
@@ -200,7 +264,7 @@ const AdminV2MonitoringTimeline = () => {
       if (!cancelled) setEnvData(next);
     })();
     return () => { cancelled = true; };
-  }, [selectedDate, activeEnvKeysStr]);
+  }, [selectedDate, activeEnvKeysStr, roomLocation]);
 
   // Build event marker label
   const getMarkerLabel = (type, item) => {
@@ -323,9 +387,11 @@ const AdminV2MonitoringTimeline = () => {
       const pad = Math.max((max - min) * 0.05, cfg.minPad);
       const axisId = `y_${key}`;
       const allowNegative = key === 'pressure_delta_6h';
+      const roomSuffix = ENV_SERIES[key]?.scope === 'room' && roomLocation
+        ? ` — ${roomLocation}` : '';
 
       vitalDatasets.push({
-        label: cfg.axisLabel,
+        label: cfg.axisLabel + roomSuffix,
         data,
         borderColor: cfg.color,
         backgroundColor: cfg.fill,
@@ -490,7 +556,7 @@ const AdminV2MonitoringTimeline = () => {
         chartInstance.current = null;
       }
     };
-  }, [timelineData, envData, visibleLayers, selectedDate, activeVitals, chart.grid, chart.axis, chart.foreground]);
+  }, [timelineData, envData, visibleLayers, selectedDate, activeVitals, roomLocation, chart.grid, chart.axis, chart.foreground]);
 
   const toggleLayer = (key) => {
     setVisibleLayers(prev => ({ ...prev, [key]: !prev[key] }));
@@ -564,6 +630,24 @@ const AdminV2MonitoringTimeline = () => {
                         active={activeVitals.includes(key)} onToggle={toggleVital}
                         noData={activeVitals.includes(key) && (envData[key] || []).length === 0} />
           ))}
+          {/* Room picker for room-scoped series; rooms come from observed data */}
+          {roomSeriesActive && roomLocations.length > 0 && (
+            <span className="tw">
+              <Select value={roomLocation === '' ? '__unspecified__' : (roomLocation ?? undefined)}
+                      onValueChange={(v) => setRoomLocation(v === '__unspecified__' ? '' : v)}>
+                <SelectTrigger className="h-7 w-auto min-w-[110px] text-xs">
+                  <SelectValue placeholder="Room…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {roomLocations.map((loc) => (
+                    <SelectItem key={loc || '__unspecified__'} value={loc || '__unspecified__'}>
+                      {loc || '(unspecified)'}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </span>
+          )}
 
           <span style={{ width: 1, height: 20, background: 'var(--border)', display: 'inline-block' }} />
 

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.test.jsx
@@ -83,16 +83,23 @@ const envRows = [
   { ts: '2026-07-14T10:00:00+00:00', metric: 'pressure_delta_6h', avg: -1.8, min: -2.0, max: -1.6, unit: 'hPa' },
 ];
 
-beforeEach(() => {
-  chartInstances.length = 0;
-  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({}));
+const stubFetch = ({ observations = [...envRows], locations = [] } = {}) => {
   vi.stubGlobal('fetch', vi.fn(async (url) => ({
     ok: true,
     status: 200,
-    json: async () => (String(url).includes('/api/environment/observations')
-      ? [...envRows]
-      : timelinePayload),
+    json: async () => {
+      const u = String(url);
+      if (u.includes('/api/environment/observations')) return observations;
+      if (u.includes('/api/environment/locations')) return locations;
+      return timelinePayload;
+    },
   })));
+};
+
+beforeEach(() => {
+  chartInstances.length = 0;
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({}));
+  stubFetch();
 });
 
 describe('AdminV2MonitoringTimeline vital series picker', () => {
@@ -144,7 +151,12 @@ describe('AdminV2MonitoringTimeline environmental overlays', () => {
   it('renders env chips alongside the vitals chips', async () => {
     await renderPage();
     expect(screen.getByRole('button', { name: /Pressure Δ6h/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Humidity/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Humidity \(out\)/ })).toBeInTheDocument();
+    // Room-scoped series chips
+    expect(screen.getByRole('button', { name: /Room temp/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Room humidity/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /CO2/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /PM2\.5/ })).toBeInTheDocument();
     expect(screen.getByText('Env:')).toBeInTheDocument();
   });
 
@@ -170,17 +182,47 @@ describe('AdminV2MonitoringTimeline environmental overlays', () => {
   });
 
   it('an empty env day still renders and marks the chip (no data)', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url) => ({
-      ok: true,
-      status: 200,
-      json: async () => (String(url).includes('/api/environment/observations')
-        ? [] : timelinePayload),
-    })));
+    stubFetch({ observations: [] });
     await renderPage();
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Humidity/ }));
+      fireEvent.click(screen.getByRole('button', { name: /Humidity \(out\)/ }));
     });
     expect(screen.getByText('(no data)')).toBeInTheDocument();
-    expect(datasetLabels()).toContain('Humidity (%)');
+    expect(datasetLabels()).toContain('Outdoor humidity (%)');
+  });
+
+  it('room series fetch scope=room with the default room and show the picker', async () => {
+    stubFetch({
+      observations: [
+        { ts: '2026-07-14T10:00:00+00:00', metric: 'co2', avg: 640, min: 620, max: 660, unit: 'ppm' },
+      ],
+      locations: [
+        { scope: 'room', location: 'Living Room', last_seen: null, metric_count: 2 },
+        { scope: 'room', location: 'Bedroom', last_seen: null, metric_count: 3 },
+        { scope: 'outdoor', location: '', last_seen: null, metric_count: 9 },
+      ],
+    });
+    await renderPage();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /CO2/ }));
+    });
+
+    // Default room prefers the bedroom-ish name; fetch is room-scoped.
+    const envCall = fetch.mock.calls
+      .map(c => String(c[0])).find(u => u.includes('metric=co2'));
+    expect(envCall).toContain('scope=room');
+    expect(envCall).toContain('location=Bedroom');
+    // Series label carries the room; the room picker combobox is rendered.
+    expect(datasetLabels()).toContain('CO2 (ppm) — Bedroom');
+    expect(screen.getByRole('combobox')).toHaveTextContent('Bedroom');
+  });
+
+  it('no room picker is shown when no room-scoped data exists', async () => {
+    await renderPage();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Room temp/ }));
+    });
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.getByText('(no data)')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.test.jsx
@@ -39,7 +39,10 @@ vi.mock('chart.js/auto', () => {
 vi.mock('chartjs-adapter-date-fns', () => ({}));
 vi.mock('chartjs-plugin-annotation', () => ({ default: {} }));
 vi.mock('chartjs-plugin-zoom', () => ({ default: {} }));
-vi.mock('../../config', () => ({ default: { apiUrl: '' } }));
+vi.mock('../../config', () => ({
+  default: { apiUrl: '' },
+  apiFetch: (...args) => fetch(...args),
+}));
 vi.mock('../../contexts/AdminPatientContext', () => {
   // Stable identity: a fresh object per render would retrigger the fetch
   // effect (selectedPatient is a useCallback dep) and loop forever.


### PR DESCRIPTION
Prep for adding room sensors (closes out the #49 room residuals; #48 HA-transport polish):

**HA rooms as SHH locations.** New `GET /api/integrations/home_assistant/areas` reads HA's area registry over the existing WS client (admin token or add-on Supervisor; degrades to an empty list otherwise). The mapping editor now prefills the location from the picked entity's HA area and offers HA area names + already-observed locations as suggestions — room names stay consistent between platforms while remaining free-text-editable.

**Room overlays on the patient timeline.** Monitoring → Timeline gains room-scoped series (room temperature, room humidity, CO2, PM2.5) alongside the outdoor ones, with a room picker sourced from observed `scope=room` locations (defaults to a bedroom/care-area-ish name), per-room axis labels, and the existing dashed-estimated convention untouched. `ENV_SERIES` entries carry explicit `metric`/`scope` now instead of assuming outdoor.

Docs updated (`docs/integrations/home-assistant.md`).

Testing: backend gate 549 green (+2 for /areas, incl. non-admin degradation); frontend 332 green (+3: room-scoped fetch with default room + picker rendering, no-picker-without-room-data, edit-dialog location suggestions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS8WMSAiMKmozbMuwbiocw