### PR TITLE
HA polish: alarm wiring, un-discovery, device classes, reader connectivity, patient care area

### DIFF
--- a/backend/alembic/versions/040_patient_care_area.py
+++ b/backend/alembic/versions/040_patient_care_area.py
@@ -1,0 +1,43 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Patient care area (room)
+
+Revision ID: 040_patient_care_area
+Revises: 039_ha_entity_mappings
+Create Date: 2026-08-15
+
+patients.care_area names the room the patient is cared for in, matching a
+Home Assistant area / environmental-observation location. Used to default
+room-scoped timeline overlays and to suggest the HA area for the patient's
+device (MQTT discovery suggested_area).
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '040_patient_care_area'
+down_revision: Union[str, None] = '039_ha_entity_mappings'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('patients', sa.Column('care_area', sa.String(length=100), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('patients', 'care_area')

--- a/backend/models/patients.py
+++ b/backend/models/patients.py
@@ -26,6 +26,8 @@ class PatientBase(BaseModel):
     medical_record_number: Optional[str] = Field(None, max_length=50)
     is_active: bool = True
     notes: Optional[str] = None
+    # Room the patient is cared for in (HA area / environment location name).
+    care_area: Optional[str] = Field(None, max_length=100)
     # HA login this record represents (32-hex HA user id). Set when creating
     # a patient from the HA user directory; one patient per HA login.
     ha_user_id: Optional[str] = Field(None, min_length=32, max_length=32)
@@ -42,6 +44,7 @@ class PatientUpdate(BaseModel):
     medical_record_number: Optional[str] = Field(None, max_length=50)
     is_active: Optional[bool] = None
     notes: Optional[str] = None
+    care_area: Optional[str] = Field(None, max_length=100)
     ha_user_id: Optional[str] = Field(None, min_length=32, max_length=32)
 
 

--- a/backend/modules/mqtt_module.py
+++ b/backend/modules/mqtt_module.py
@@ -24,7 +24,7 @@ from typing import Optional, Dict, Any
 import logging
 
 from bus import EventBus
-from events import SensorUpdate, MQTTConnectionEvent, VitalSignRecorded, EventSource, NutritionSensorUpdate, DueCountsChanged
+from events import SensorUpdate, MQTTConnectionEvent, VitalSignRecorded, EventSource, NutritionSensorUpdate, DueCountsChanged, AlarmPanelState
 
 logger = logging.getLogger("mqtt_module")
 
@@ -60,6 +60,8 @@ class MQTTModule:
         asyncio.create_task(self._subscribe_to_sensor_updates())
         # Subscribe to SensorUpdate for per-patient combined state publishing
         asyncio.create_task(self._subscribe_to_sensor_updates_patient_state())
+
+        asyncio.create_task(self._subscribe_to_alarm_panel_state())
         # Subscribe to DueCountsChanged so badge-count sensors update instantly
         asyncio.create_task(self._subscribe_to_due_counts_changed())
         # Periodically recompute badge counts so they "age in" over time
@@ -125,6 +127,26 @@ class MQTTModule:
                 await self._publish_patient_state_with_alarms(patient_id)
             except Exception as e:
                 logger.error(f"Error publishing patient state to MQTT: {e}")
+
+    async def _subscribe_to_alarm_panel_state(self):
+        """AlarmPanelState (reader GPIO alarm lines) → alarm1/alarm2 keys in the
+        per-patient combined state, so the discovery-created 'GPIO Alarm 1/2'
+        binary sensors stop sitting at Unknown (mqtt-known-gaps §1)."""
+        logger.info("Starting subscription to AlarmPanelState for per-patient MQTT state")
+        async for event in self.event_bus.subscribe_to_type(AlarmPanelState):
+            try:
+                patient_id = getattr(event, "patient_id", None)
+                if patient_id is None:
+                    continue
+                if patient_id not in self._patient_state_cache:
+                    self._patient_state_cache[patient_id] = await self._seed_patient_state(patient_id)
+                self._patient_state_cache[patient_id].update({
+                    "alarm1": "ON" if event.alarm1 else "OFF",
+                    "alarm2": "ON" if event.alarm2 else "OFF",
+                })
+                await self._publish_patient_state_with_alarms(patient_id)
+            except Exception as e:
+                logger.error(f"Error publishing alarm panel state to MQTT: {e}")
 
     async def _subscribe_to_due_counts_changed(self):
         """Refresh a patient's MQTT badge counts the moment a due item is logged /

--- a/backend/mqtt/discovery.py
+++ b/backend/mqtt/discovery.py
@@ -39,7 +39,9 @@ SECTION_DISCOVERY: Dict[str, Tuple[str, str, str, str]] = {
     "perfusion": ("{{ value_json.perfusion }}", "PI", "Perfusion", "sensor"),
     "temperature": ("{{ value_json.body_temp | default(value_json.skin_temp) }}", "°F", "Temperature", "sensor"),
     "blood_pressure": ("{{ value_json.map_bp | default(value_json.systolic_bp) }}", "mmHg", "Blood Pressure", "sensor"),
-    "weight": ("{{ value_json.weight }}", "lbs", "Weight", "sensor"),
+    # "lb" (not "lbs"): the HA weight device_class only accepts lb, and gets
+    # us unit conversion + long-term statistics.
+    "weight": ("{{ value_json.weight }}", "lb", "Weight", "sensor"),
     "bathroom": ("{{ value_json.bathroom }}", "", "Bathroom Activity", "sensor"),
     "spo2_alarm": ("{{ value_json.spo2_alarm }}", "", "SpO₂ Alarm", "binary_sensor"),
     "bpm_alarm": ("{{ value_json.bpm_alarm }}", "", "Heart Rate Alarm", "binary_sensor"),
@@ -50,6 +52,20 @@ SECTION_DISCOVERY: Dict[str, Tuple[str, str, str, str]] = {
 # Sections whose value is categorical text, not a numeric measurement — these
 # must NOT get state_class=measurement (HA would mark them Unavailable).
 TEXT_SECTIONS = {"bathroom"}
+
+# HA device_class per section, only where the section's published unit is one
+# the class accepts (a mismatched unit makes HA reject the entity). SpO₂/BPM/
+# perfusion have no fitting HA class and stay classless on purpose.
+SECTION_DEVICE_CLASS = {
+    "temperature": "temperature",  # °F accepted
+    "weight": "weight",            # lb accepted
+    "blood_pressure": "pressure",  # mmHg accepted
+}
+# Water nutrition sensors publish mL, which the volume class accepts. The
+# calorie sensors stay classless (kcal support for the energy class varies
+# with HA version).
+NUTRITION_DEVICE_CLASS = {"water_last": "volume", "water_intake": "volume",
+                          "water_target": "volume"}
 
 # Blood pressure: three sensors per patient (systolic, diastolic, MAP) on same state_topic
 BLOOD_PRESSURE_SENSORS: List[Tuple[str, str, str]] = [
@@ -93,6 +109,56 @@ BADGE_SENSORS: Dict[str, List[Tuple[str, str, str]]] = {
 }
 
 
+def _all_section_entities() -> List[Tuple[str, str, str]]:
+    """
+    Every (section_key, sensor_type, entity_suffix) this module can ever
+    publish for a patient — the inventory un-discovery prunes against.
+    """
+    entities: List[Tuple[str, str, str]] = []
+    for section_key, (_tpl, _unit, _name, sensor_type) in SECTION_DISCOVERY.items():
+        entities.append((section_key, sensor_type, section_key))
+    for component in ("systolic", "diastolic", "map"):
+        entities.append(("blood_pressure", "sensor", f"blood_pressure_{component}"))
+    for _tpl, _unit, _name, suffix in NUTRITION_SENSORS:
+        entities.append(("nutrition", "sensor", f"nutrition_{suffix}"))
+    for section_key, sensors in BADGE_SENSORS.items():
+        for _tpl, _name, suffix in sensors:
+            entities.append((section_key, "sensor", suffix))
+    return entities
+
+
+def _remove_entity(mqtt_client, discovery_prefix: str, sensor_type: str,
+                   sensor_id: str) -> None:
+    """Publish an empty retained config — HA deletes the entity on receipt."""
+    try:
+        mqtt_client.publish(f"{discovery_prefix}/{sensor_type}/{sensor_id}/config",
+                            "", retain=True)
+    except Exception as e:
+        logger.error(f"Error removing discovery for {sensor_id}: {e}")
+
+
+def remove_mqtt_discovery_for_patient(mqtt_client, patient_id: int,
+                                      patient_name: str,
+                                      reader_ids: Optional[List[int]] = None) -> None:
+    """
+    Delete every HA entity this module could have published for a patient
+    (all sections + reader availability). Used when the patient's MQTT is
+    disabled so entities don't linger as stuck "Unknown".
+    """
+    if not mqtt_client or not mqtt_client.is_connected():
+        logger.warning("MQTT client not available for discovery removal")
+        return
+    discovery_prefix = "homeassistant"
+    device_ident = _safe_device_id(patient_name, patient_id)
+    for _section, sensor_type, suffix in _all_section_entities():
+        _remove_entity(mqtt_client, discovery_prefix, sensor_type,
+                       f"{device_ident}_{suffix}")
+    for reader_id in reader_ids or []:
+        _remove_entity(mqtt_client, discovery_prefix, "binary_sensor",
+                       f"{device_ident}_reader_{reader_id}")
+    logger.info(f"Removed MQTT discovery entities for patient {patient_id}")
+
+
 def _safe_device_id(name: str, patient_id: int) -> str:
     """HA-friendly device identifier: lowercase alphanumeric + underscores, fallback to patient id."""
     if not name:
@@ -118,6 +184,9 @@ def _publish_discovery(
         "dev": device_info,
         **extra,
     }
+    # A None in extra deletes the default (e.g. reader sensors publish a bare
+    # string, not the patient JSON, so json_attr_t must go).
+    config = {k: v for k, v in config.items() if v is not None}
     if unit:
         config["unit_of_meas"] = unit
     discovery_topic = f"{discovery_prefix}/{sensor_type}/{sensor_id}/config"
@@ -184,6 +253,9 @@ def send_mqtt_discovery(mqtt_client, patient_id: Optional[int] = None) -> bool:
             "mf": "Smart Home Health",
             "mdl": "Smart Healthcare Hub",
         }
+        # Land the device in the patient's HA room automatically.
+        if entry.get("care_area"):
+            device_info["sa"] = entry["care_area"]
 
         # One sensor per section that allows get or both.
         # blood_pressure → three sensors (systolic, diastolic, MAP).
@@ -202,7 +274,7 @@ def send_mqtt_discovery(mqtt_client, patient_id: Optional[int] = None) -> bool:
                         f"{base_topic}_patient_{pid}_{safe_section}",
                         f"{patient_name} {display_name}",
                         state_topic, val_tpl, unit, device_info,
-                        stat_cla="measurement",
+                        stat_cla="measurement", dev_cla="pressure",
                     )
                 continue
 
@@ -210,13 +282,16 @@ def send_mqtt_discovery(mqtt_client, patient_id: Optional[int] = None) -> bool:
             if section_key == "nutrition":
                 for val_tpl, unit, display_name, suffix in NUTRITION_SENSORS:
                     safe_section = f"nutrition_{suffix}"
+                    extra = {"stat_cla": "measurement"}
+                    if suffix in NUTRITION_DEVICE_CLASS:
+                        extra["dev_cla"] = NUTRITION_DEVICE_CLASS[suffix]
                     success_count += _publish_discovery(
                         mqtt_client, discovery_prefix, "sensor",
                         f"{device_ident}_{safe_section}",
                         f"{base_topic}_patient_{pid}_{safe_section}",
                         f"{patient_name} {display_name}",
                         state_topic, val_tpl, unit, device_info,
-                        stat_cla="measurement",
+                        **extra,
                     )
                 continue
 
@@ -251,6 +326,8 @@ def send_mqtt_discovery(mqtt_client, patient_id: Optional[int] = None) -> bool:
                 # text sensors (e.g. bathroom: urine/bowel/both) must omit it or
                 # HA marks them Unavailable on a non-numeric value.
                 extra["stat_cla"] = "measurement"
+                if section_key in SECTION_DEVICE_CLASS:
+                    extra["dev_cla"] = SECTION_DEVICE_CLASS[section_key]
 
             success_count += _publish_discovery(
                 mqtt_client, discovery_prefix, sensor_type,
@@ -259,6 +336,31 @@ def send_mqtt_discovery(mqtt_client, patient_id: Optional[int] = None) -> bool:
                 f"{patient_name} {display_name}",
                 state_topic, val_tpl, unit, device_info,
                 **extra,
+            )
+
+        # --- Un-discovery: delete entities for sections that are off, so a
+        # toggled-off section doesn't linger in HA as a stuck "Unknown" entity
+        # (its discovery config is retained on the broker otherwise). ---
+        for section_key, sensor_type, suffix in _all_section_entities():
+            if sections.get(section_key) in ("get", "both"):
+                continue
+            _remove_entity(mqtt_client, discovery_prefix, sensor_type,
+                           f"{device_ident}_{suffix}")
+
+        # --- Reader connectivity: one binary sensor per active reader, on its
+        # own retained availability topic (published by the reader WS path) so
+        # HA can tell "device offline" from "value stale". ---
+        for reader in entry.get("readers") or []:
+            reader_label = reader.get("name") or f"Reader {reader['id']}"
+            success_count += _publish_discovery(
+                mqtt_client, discovery_prefix, "binary_sensor",
+                f"{device_ident}_reader_{reader['id']}",
+                f"{base_topic}_reader_{reader['id']}_online",
+                f"{patient_name} {reader_label} Online",
+                f"{base_topic}/reader/{reader['id']}/availability",
+                "{{ value }}", "", device_info,
+                pl_on="online", pl_off="offline", dev_cla="connectivity",
+                avty_t=f"{base_topic}/availability", json_attr_t=None,
             )
 
     logger.info(f"Sent {success_count} MQTT Discovery messages (per-vital per patient)")

--- a/backend/mqtt/publisher.py
+++ b/backend/mqtt/publisher.py
@@ -50,6 +50,24 @@ class MQTTPublisher:
         except Exception:
             return False
             
+    def publish_reader_availability(self, reader_id: int, online: bool) -> bool:
+        """
+        Retained per-reader connectivity flag on {base}/reader/{id}/availability,
+        consumed by the HA discovery connectivity binary sensor. Called from the
+        reader WebSocket connect/disconnect path and the startup snapshot.
+        """
+        if not self.is_available():
+            return False
+        base = get_mqtt_settings().get('base_topic', 'shh')
+        try:
+            result = self.mqtt_client.publish(
+                f"{base}/reader/{reader_id}/availability",
+                "online" if online else "offline", retain=True)
+            return result.rc == 0
+        except Exception as e:
+            logger.error(f"Error publishing reader {reader_id} availability: {e}")
+            return False
+
     def publish_sensor_state(self, sensor_state: Dict[str, Any]) -> bool:
         """
         Publish current sensor state to configured MQTT topics based on database settings.

--- a/backend/mqtt/service.py
+++ b/backend/mqtt/service.py
@@ -75,7 +75,11 @@ class MQTTService:
                     
                     # Set availability to online
                     self._publish_availability_status("online")
-                    
+
+                    # Seed per-reader connectivity flags (retained values from
+                    # before a restart may claim online for a dead socket).
+                    self._publish_reader_availability_snapshot()
+
                     return self.mqtt_manager, self.mqtt_publisher
                 else:
                     logger.error("[mqtt.service] Failed to connect to MQTT broker")
@@ -118,6 +122,26 @@ class MQTTService:
         finally:
             db.close()
             
+    def _publish_reader_availability_snapshot(self):
+        """Publish each active reader's current connectivity, retained."""
+        try:
+            # Late imports: routes.readers owns the live-connection registry.
+            from routes.readers import connection_manager
+            from models.readers import Reader
+            base_topic = get_mqtt_settings().get('base_topic', 'shh')
+            db = next(get_db())
+            try:
+                reader_ids = [r.id for r in db.query(Reader).filter(
+                    Reader.is_active == True).all()]  # noqa: E712
+            finally:
+                db.close()
+            for reader_id in reader_ids:
+                status = "online" if connection_manager.is_connected(reader_id) else "offline"
+                self.mqtt_client.publish(f"{base_topic}/reader/{reader_id}/availability",
+                                         status, retain=True)
+        except Exception as e:
+            logger.error(f"[mqtt.service] Failed to publish reader availability snapshot: {e}")
+
     def _publish_availability_status(self, status: str):
         """Publish availability status (online/offline) to MQTT"""
         try:

--- a/backend/mqtt/settings.py
+++ b/backend/mqtt/settings.py
@@ -61,21 +61,30 @@ def get_patients_with_mqtt_enabled() -> List[Dict[str, Any]]:
             .all()
         )
         from models.readers import Reader
+        enabled = [pi for pi in rows if (pi.settings or {}).get("enabled", True)]
+        patient_ids = [pi.patient_id for pi in enabled]
+        # Batch lookups (one query each), not per-patient — this runs on every
+        # discovery emission.
+        patients_by_id = {
+            p.id: p for p in db.query(Patient).filter(Patient.id.in_(patient_ids)).all()
+        } if patient_ids else {}
+        readers_by_patient: Dict[int, List[Dict[str, Any]]] = {}
+        if patient_ids:
+            for r in db.query(Reader).filter(Reader.patient_id.in_(patient_ids),
+                                             Reader.is_active == True).all():  # noqa: E712
+                readers_by_patient.setdefault(r.patient_id, []).append(
+                    {"id": r.id, "name": r.name})
+
         out = []
-        for pi in rows:
-            settings = pi.settings or {}
-            if not settings.get("enabled", True):
-                continue
-            patient = db.query(Patient).filter(Patient.id == pi.patient_id).first()
+        for pi in enabled:
+            patient = patients_by_id.get(pi.patient_id)
             patient_name = (f"{patient.first_name} {patient.last_name}".strip() if patient else "") or f"Patient {pi.patient_id}"
-            readers = db.query(Reader).filter(Reader.patient_id == pi.patient_id,
-                                              Reader.is_active == True).all()  # noqa: E712
             out.append({
                 "patient_id": pi.patient_id,
                 "patient_name": patient_name,
                 "care_area": getattr(patient, "care_area", None) if patient else None,
-                "settings": settings,
-                "readers": [{"id": r.id, "name": r.name} for r in readers],
+                "settings": pi.settings or {},
+                "readers": readers_by_patient.get(pi.patient_id, []),
             })
         return out
     finally:

--- a/backend/mqtt/settings.py
+++ b/backend/mqtt/settings.py
@@ -60,6 +60,7 @@ def get_patients_with_mqtt_enabled() -> List[Dict[str, Any]]:
             )
             .all()
         )
+        from models.readers import Reader
         out = []
         for pi in rows:
             settings = pi.settings or {}
@@ -67,7 +68,15 @@ def get_patients_with_mqtt_enabled() -> List[Dict[str, Any]]:
                 continue
             patient = db.query(Patient).filter(Patient.id == pi.patient_id).first()
             patient_name = (f"{patient.first_name} {patient.last_name}".strip() if patient else "") or f"Patient {pi.patient_id}"
-            out.append({"patient_id": pi.patient_id, "patient_name": patient_name, "settings": settings})
+            readers = db.query(Reader).filter(Reader.patient_id == pi.patient_id,
+                                              Reader.is_active == True).all()  # noqa: E712
+            out.append({
+                "patient_id": pi.patient_id,
+                "patient_name": patient_name,
+                "care_area": getattr(patient, "care_area", None) if patient else None,
+                "settings": settings,
+                "readers": [{"id": r.id, "name": r.name} for r in readers],
+            })
         return out
     finally:
         db.close()

--- a/backend/routes/mqtt.py
+++ b/backend/routes/mqtt.py
@@ -414,6 +414,26 @@ async def update_mqtt_patient_config(
         pi.updated_at = now
     db.commit()
     db.refresh(pi)
+    # Keep HA in sync without the manual "send discovery" step: re-announce
+    # enabled sections and delete entities for sections that were turned off
+    # (or the whole device when the patient's MQTT is disabled). Best-effort —
+    # a broker hiccup must not fail the save.
+    try:
+        from main import get_modules
+        from mqtt.discovery import remove_mqtt_discovery_for_patient
+        mqtt_module = get_modules().get("mqtt")
+        if mqtt_module and mqtt_module.mqtt_manager and mqtt_module.mqtt_manager.is_connected():
+            client = mqtt_module.mqtt_manager.client
+            if body.enabled:
+                send_mqtt_discovery(client, patient_id=patient_id)
+            else:
+                from models.readers import Reader
+                reader_ids = [r.id for r in db.query(Reader).filter(
+                    Reader.patient_id == patient_id).all()]
+                patient_name = f"{patient.first_name} {patient.last_name}".strip() or f"Patient {patient_id}"
+                remove_mqtt_discovery_for_patient(client, patient_id, patient_name, reader_ids)
+    except Exception as e:
+        logger.warning(f"Post-save MQTT discovery sync skipped: {e}")
     return MQTTPatientConfigResponse(
         patient_id=patient_id,
         patient_name=f"{patient.first_name} {patient.last_name}".strip() or None,

--- a/backend/routes/readers.py
+++ b/backend/routes/readers.py
@@ -564,6 +564,20 @@ async def start_reader_activity_subscriber(event_bus) -> None:
             logger.error(f"Error updating reader activity from MQTT: {e}")
 
 
+def _publish_reader_availability(reader_id: int, online: bool) -> None:
+    """Best-effort retained online/offline flag for the reader's HA
+    connectivity sensor. Never raises — MQTT being down must not affect the
+    reader WebSocket."""
+    try:
+        from main import get_modules
+        mqtt_module = get_modules().get("mqtt")
+        publisher = getattr(mqtt_module, "mqtt_publisher", None)
+        if publisher:
+            publisher.publish_reader_availability(reader_id, online)
+    except Exception as e:
+        logger.debug(f"Reader {reader_id} availability publish skipped: {e}")
+
+
 @router.websocket("/ws/{reader_id}")
 async def reader_websocket(websocket: WebSocket, reader_id: int):
     """
@@ -626,6 +640,7 @@ async def reader_websocket(websocket: WebSocket, reader_id: int):
     else:
         await connection_manager.connect(reader_id, websocket, encryption_key)
     _update_reader_activity(reader_id)
+    _publish_reader_availability(reader_id, online=True)
 
     try:
         while True:
@@ -712,3 +727,7 @@ async def reader_websocket(websocket: WebSocket, reader_id: int):
     finally:
         # Socket-aware: an evicted handler must not deregister its successor.
         connection_manager.disconnect(reader_id, websocket)
+        # Only flag offline if the slot is actually empty now (an evicted
+        # handler's cleanup must not mark its live successor offline).
+        if not connection_manager.is_connected(reader_id):
+            _publish_reader_availability(reader_id, online=False)

--- a/backend/schemas/patient.py
+++ b/backend/schemas/patient.py
@@ -35,6 +35,9 @@ class Patient(Base):
     last_name = Column(String, nullable=False)
     date_of_birth = Column(DateTime, nullable=True)
     medical_record_number = Column(String, nullable=True, unique=True)
+    # The room this patient is cared for in — matches an HA area / environment
+    # location so room-scoped environmental data can be associated per patient.
+    care_area = Column(String(100), nullable=True)
     is_active = Column(Boolean, default=True, nullable=False)
     notes = Column(Text, nullable=True)
     # HA user this patient record was created from (uuid4().hex) — provenance

--- a/backend/tests/test_mqtt_discovery.py
+++ b/backend/tests/test_mqtt_discovery.py
@@ -1,0 +1,197 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+MQTT → HA discovery hardening: device_class enrichment, suggested_area,
+section un-discovery (empty retained configs), per-reader connectivity
+sensors, the reader availability publisher, and the alarm1/alarm2 wiring.
+All broker traffic goes through a fake client — no sockets.
+"""
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from mqtt import discovery as disc
+from mqtt.publisher import MQTTPublisher
+
+
+class FakeMqttClient:
+    def __init__(self):
+        self.published = []  # (topic, payload, retain)
+
+    def is_connected(self):
+        return True
+
+    def publish(self, topic, payload=None, retain=False):
+        self.published.append((topic, payload, retain))
+        return SimpleNamespace(rc=0)
+
+
+PATIENT_ENTRY = {
+    "patient_id": 5,
+    "patient_name": "Pat Ient",
+    "care_area": "Bedroom",
+    "settings": {"enabled": True, "sections": {
+        "spo2": "get", "temperature": "get", "weight": "get",
+        "blood_pressure": "get", "nutrition": "get", "alarm1": "get",
+        "bathroom": "off", "bpm": "off",
+    }},
+    "readers": [{"id": 7, "name": "Pulse Ox"}],
+}
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    client = FakeMqttClient()
+    monkeypatch.setattr(disc, "get_mqtt_settings",
+                        lambda: {"enabled": True, "base_topic": "shh"})
+    monkeypatch.setattr(disc, "get_patients_with_mqtt_enabled",
+                        lambda: [dict(PATIENT_ENTRY)])
+    return client
+
+
+def _configs(client):
+    """topic -> decoded config dict (or None for removal payloads)."""
+    out = {}
+    for topic, payload, retain in client.published:
+        assert retain is True
+        out[topic] = json.loads(payload) if payload else None
+    return out
+
+
+def test_discovery_device_classes_and_suggested_area(fake_client):
+    assert disc.send_mqtt_discovery(fake_client)
+    configs = _configs(fake_client)
+
+    weight = configs["homeassistant/sensor/shh_pat_ient_weight/config"]
+    assert weight["dev_cla"] == "weight"
+    assert weight["unit_of_meas"] == "lb"
+    assert weight["dev"]["sa"] == "Bedroom"
+
+    temp = configs["homeassistant/sensor/shh_pat_ient_temperature/config"]
+    assert temp["dev_cla"] == "temperature"
+
+    systolic = configs["homeassistant/sensor/shh_pat_ient_blood_pressure_systolic/config"]
+    assert systolic["dev_cla"] == "pressure"
+
+    water = configs["homeassistant/sensor/shh_pat_ient_nutrition_water_intake/config"]
+    assert water["dev_cla"] == "volume"
+    calories = configs["homeassistant/sensor/shh_pat_ient_nutrition_calories_intake/config"]
+    assert "dev_cla" not in calories
+
+    # SpO2 has no fitting HA class — must stay classless.
+    spo2 = configs["homeassistant/sensor/shh_pat_ient_spo2/config"]
+    assert "dev_cla" not in spo2
+
+
+def test_discovery_prunes_disabled_sections(fake_client):
+    disc.send_mqtt_discovery(fake_client)
+    configs = _configs(fake_client)
+
+    # Off/unset sections get empty retained payloads (HA deletes the entity).
+    assert configs["homeassistant/sensor/shh_pat_ient_bathroom/config"] is None
+    assert configs["homeassistant/sensor/shh_pat_ient_bpm/config"] is None
+    assert configs["homeassistant/sensor/shh_pat_ient_meds_due_now/config"] is None
+    assert configs["homeassistant/binary_sensor/shh_pat_ient_alarm2/config"] is None
+    # Enabled ones are real configs.
+    assert configs["homeassistant/binary_sensor/shh_pat_ient_alarm1/config"] is not None
+
+
+def test_discovery_reader_connectivity_sensor(fake_client):
+    disc.send_mqtt_discovery(fake_client)
+    configs = _configs(fake_client)
+
+    reader = configs["homeassistant/binary_sensor/shh_pat_ient_reader_7/config"]
+    assert reader["stat_t"] == "shh/reader/7/availability"
+    assert reader["pl_on"] == "online"
+    assert reader["pl_off"] == "offline"
+    assert reader["dev_cla"] == "connectivity"
+    assert reader["avty_t"] == "shh/availability"
+    assert "json_attr_t" not in reader  # bare-string payload, not patient JSON
+
+
+def test_remove_discovery_for_patient(monkeypatch):
+    client = FakeMqttClient()
+    disc.remove_mqtt_discovery_for_patient(client, 5, "Pat Ient", reader_ids=[7])
+    topics = {t for t, payload, _ in client.published}
+    payloads = {p for _, p, _ in client.published}
+    assert payloads == {""}  # removals only
+    assert "homeassistant/sensor/shh_pat_ient_weight/config" in topics
+    assert "homeassistant/sensor/shh_pat_ient_nutrition_water_target/config" in topics
+    assert "homeassistant/binary_sensor/shh_pat_ient_alarm1/config" in topics
+    assert "homeassistant/binary_sensor/shh_pat_ient_reader_7/config" in topics
+
+
+def test_publish_reader_availability(monkeypatch):
+    import mqtt.publisher as publisher_mod
+    monkeypatch.setattr(publisher_mod, "get_mqtt_settings",
+                        lambda: {"enabled": True, "base_topic": "shh"})
+    client = FakeMqttClient()
+    pub = MQTTPublisher(client)
+    assert pub.publish_reader_availability(7, online=True)
+    assert pub.publish_reader_availability(7, online=False)
+    assert client.published == [
+        ("shh/reader/7/availability", "online", True),
+        ("shh/reader/7/availability", "offline", True),
+    ]
+
+
+def test_alarm_panel_state_reaches_patient_state(monkeypatch):
+    """AlarmPanelState events land in the combined state as alarm1/alarm2."""
+    from datetime import datetime
+    from bus import EventBus
+    from events import AlarmPanelState, EventSource
+    from modules.mqtt_module import MQTTModule
+
+    bus = EventBus()
+    module = MQTTModule(bus)
+    published = []
+
+    async def fake_publish(patient_id):
+        published.append((patient_id, dict(module._patient_state_cache[patient_id])))
+        return True
+
+    async def fake_seed(patient_id):
+        return {}
+
+    monkeypatch.setattr(module, "_publish_patient_state_with_alarms", fake_publish)
+    monkeypatch.setattr(module, "_seed_patient_state", fake_seed)
+
+    async def run():
+        task = asyncio.create_task(module._subscribe_to_alarm_panel_state())
+        await asyncio.sleep(0)  # let the subscriber attach
+        await bus.publish(AlarmPanelState(ts=datetime.utcnow(), alarm1=True,
+                                          alarm2=False, source=EventSource.READER,
+                                          patient_id=5))
+        # patient-less events are ignored
+        await bus.publish(AlarmPanelState(ts=datetime.utcnow(), alarm1=True,
+                                          alarm2=True, source=EventSource.READER,
+                                          patient_id=None))
+        await asyncio.sleep(0.05)
+        task.cancel()
+
+    asyncio.run(run())
+    assert published == [(5, {"alarm1": "ON", "alarm2": "OFF"})]
+
+
+def test_patient_care_area_roundtrip(admin_client, patient):
+    resp = admin_client.put(f"/api/patients/{patient.id}",
+                            json={"care_area": "Bedroom"})
+    assert resp.status_code == 200
+    assert resp.json()["care_area"] == "Bedroom"
+    resp = admin_client.get(f"/api/patients/{patient.id}")
+    assert resp.json()["care_area"] == "Bedroom"

--- a/frontend/src/components/PatientFormFields.jsx
+++ b/frontend/src/components/PatientFormFields.jsx
@@ -15,16 +15,36 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Field, FormRow } from '@/components/ui/field';
+import config, { apiFetch } from '../config';
 
 // Shared create/edit fields for a patient. Used by the Patients list (create
 // dialog) and the patient detail page (edit). `idPrefix` keeps field ids unique
 // when more than one instance could mount.
 export default function PatientFormFields({ formData, setFormData, idPrefix = 'pf' }) {
+  // Care-area suggestions: the user's HA areas (rooms) + rooms already seen
+  // in environmental data. Best-effort; the field stays free text.
+  const [careAreaOptions, setCareAreaOptions] = useState([]);
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      apiFetch(`${config.apiUrl}/api/integrations/home_assistant/areas`)
+        .then((res) => (res.ok ? res.json() : [])),
+      apiFetch(`${config.apiUrl}/api/environment/locations`)
+        .then((res) => (res.ok ? res.json() : [])),
+    ]).then(([areas, locations]) => {
+      if (cancelled) return;
+      const seen = locations.filter((l) => l.scope !== 'outdoor' && l.location)
+                            .map((l) => l.location);
+      setCareAreaOptions([...new Set([...areas, ...seen])]);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
   return (
     <>
       <FormRow>
@@ -66,6 +86,25 @@ export default function PatientFormFields({ formData, setFormData, idPrefix = 'p
           />
         </Field>
       </FormRow>
+
+      <Field label="Care area (room)" htmlFor={`${idPrefix}-care-area`}>
+        <Input
+          id={`${idPrefix}-care-area`}
+          list={`${idPrefix}-care-area-options`}
+          value={formData.care_area || ''}
+          onChange={(e) => setFormData({ ...formData, care_area: e.target.value })}
+          placeholder="e.g. Bedroom"
+        />
+        <datalist id={`${idPrefix}-care-area-options`}>
+          {careAreaOptions.map((area) => (
+            <option key={area} value={area} />
+          ))}
+        </datalist>
+        <p className="text-xs text-muted-foreground">
+          The room this patient is cared for in — used to match room sensors
+          and Home Assistant areas.
+        </p>
+      </Field>
 
       <Field label="Notes" htmlFor={`${idPrefix}-notes`}>
         <Textarea

--- a/frontend/src/pages/admin-v2/AdminV2.css
+++ b/frontend/src/pages/admin-v2/AdminV2.css
@@ -567,6 +567,9 @@
 .admin-v2-topnav-links {
   display: flex;
   gap: 0.25rem;
+  /* One-line scrollable strip at every width; the layout auto-centers the
+     active link on navigation. */
+  overflow-x: auto;
 }
 
 .admin-v2-topnav-link {
@@ -578,6 +581,9 @@
   border-bottom: 2px solid transparent;
   transition: all 0.2s ease;
   margin-bottom: -1px;
+  /* Multi-word sections ("Home Assistant") must not wrap and stretch the bar. */
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .admin-v2-topnav-link:hover {
@@ -1278,6 +1284,11 @@
   .admin-v2-topnav-links {
     overflow-x: auto;
     padding-bottom: 0.25rem;
+    /* Edge fade as a "more tabs this way" scroll hint. */
+    mask-image: linear-gradient(to right,
+      transparent, black 16px, black calc(100% - 16px), transparent);
+    -webkit-mask-image: linear-gradient(to right,
+      transparent, black 16px, black calc(100% - 16px), transparent);
   }
 
   /* Section header: wrap so "Add Patient" is full width on small screens */

--- a/frontend/src/pages/admin-v2/AdminV2.css
+++ b/frontend/src/pages/admin-v2/AdminV2.css
@@ -562,6 +562,37 @@
   background: var(--card);
   border-bottom: 1px solid var(--border);
   padding: 0 1.5rem;
+  position: relative; /* anchors the scroll-hint chevrons */
+}
+
+/* Chevron shown at an edge with more tabs off-screen; tap scrolls the strip. */
+.admin-v2-topnav-scroll-hint {
+  position: absolute;
+  top: 0;
+  bottom: 1px; /* keep the header's bottom border visible */
+  width: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  padding: 0;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  z-index: 1;
+}
+
+.admin-v2-topnav-scroll-hint.left {
+  left: 0;
+  background: linear-gradient(to right, var(--card) 60%, transparent);
+}
+
+.admin-v2-topnav-scroll-hint.right {
+  right: 0;
+  background: linear-gradient(to left, var(--card) 60%, transparent);
+}
+
+.admin-v2-topnav-scroll-hint:hover {
+  color: var(--foreground);
 }
 
 .admin-v2-topnav-links {

--- a/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2HomeAssistant.jsx
@@ -432,7 +432,49 @@ const AdminV2HomeAssistant = () => {
                   No entities mapped yet. Add a mapping to start ingesting data.
                 </p>
               ) : (
-                <div className="overflow-x-auto">
+                <>
+                {/* Phone layout: stacked cards (the table needs sideways
+                    scrolling on narrow screens). */}
+                <div className="space-y-3 md:hidden">
+                  {mappings.map((m) => (
+                    <div key={m.id} className="space-y-2 rounded-lg border border-border p-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 overflow-hidden">
+                          <div className="truncate font-medium text-foreground">
+                            {m.friendly_name || m.entity_id}
+                          </div>
+                          <div className="break-all text-xs text-muted-foreground">{m.entity_id}</div>
+                        </div>
+                        <Checkbox checked={m.enabled} className="mt-1 shrink-0"
+                                  aria-label={`Toggle ${m.entity_id}`}
+                                  onCheckedChange={() => toggleMapping(m)} />
+                      </div>
+                      <div className="text-sm">{describeTarget(m)}</div>
+                      <div className="text-xs text-muted-foreground">
+                        Last seen {formatWhen(m.last_seen_at)}
+                        {m.last_value != null
+                          ? ` · ${m.last_value}${m.source_unit ? ` ${m.source_unit}` : ''}`
+                          : ''}
+                      </div>
+                      {m.last_error && (
+                        <div className="text-xs text-destructive">{m.last_error}</div>
+                      )}
+                      <div className="flex justify-end gap-2">
+                        <Button variant="secondary" size="sm" className="gap-1.5"
+                                aria-label={`Edit ${m.entity_id}`}
+                                onClick={() => openDialog(m)}>
+                          <EditIcon size={14} /> Edit
+                        </Button>
+                        <Button variant="secondary" size="sm" className="gap-1.5"
+                                aria-label={`Delete ${m.entity_id}`}
+                                onClick={() => deleteMapping(m)}>
+                          <TrashIcon size={14} /> Delete
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="hidden overflow-x-auto md:block">
                   <table className="w-full text-sm">
                     <thead>
                       <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
@@ -485,6 +527,7 @@ const AdminV2HomeAssistant = () => {
                     </tbody>
                   </table>
                 </div>
+                </>
               )}
             </CardContent>
           </Card>

--- a/frontend/src/pages/admin-v2/AdminV2HomeAssistant.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2HomeAssistant.test.jsx
@@ -126,9 +126,12 @@ describe('AdminV2HomeAssistant', () => {
     routeFetches({ mappings: [sampleMapping] });
     await renderPage();
 
-    expect(screen.getByText('SpO2 Ring')).toBeInTheDocument();
-    expect(screen.getByText('Vital: spo2')).toBeInTheDocument();
-    expect(screen.getByText('97 %')).toBeInTheDocument();
+    // Both the desktop table and the phone card list render (CSS decides
+    // which is visible), so mapping details appear twice.
+    expect(screen.getAllByText('SpO2 Ring')).toHaveLength(2);
+    expect(screen.getAllByText('Vital: spo2')).toHaveLength(2);
+    expect(screen.getByText('97 %')).toBeInTheDocument();        // table cell
+    expect(screen.getByText(/Last seen .* · 97 %/)).toBeInTheDocument(); // card
   });
 
   it('opens the add-mapping dialog and lists pickable entities', async () => {
@@ -177,7 +180,8 @@ describe('AdminV2HomeAssistant', () => {
     await renderPage();
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Edit sensor.bedroom_co2' }));
+      // Two edit buttons exist (table + phone card); either opens the dialog.
+      fireEvent.click(screen.getAllByRole('button', { name: 'Edit sensor.bedroom_co2' })[0]);
     });
 
     expect(screen.getByLabelText('Location')).toHaveValue('Bedroom');

--- a/frontend/src/pages/admin-v2/AdminV2Layout.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Layout.jsx
@@ -34,6 +34,7 @@ import {
   BackArrowIcon,
   UsersIcon,
   CalendarIcon,
+  ChevronLeftIcon,
   ChevronRightIcon,
   XIcon,
   ClipboardListIcon,
@@ -317,6 +318,30 @@ const AdminV2Layout = ({ children }) => {
     nav.scrollBy({ left: delta, behavior: 'smooth' });
   }, [location.pathname, topNavItems.length]);
 
+  // Chevron scroll hints: shown at whichever edge has more tabs off-screen.
+  const [navScroll, setNavScroll] = useState({ left: false, right: false });
+  useEffect(() => {
+    const nav = topNavRef.current;
+    if (!nav) return undefined;
+    const update = () => setNavScroll({
+      left: nav.scrollLeft > 2,
+      right: nav.scrollLeft + nav.clientWidth < nav.scrollWidth - 2,
+    });
+    update();
+    nav.addEventListener('scroll', update, { passive: true });
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(nav);
+    return () => {
+      nav.removeEventListener('scroll', update);
+      resizeObserver.disconnect();
+    };
+  }, [topNavItems.length]);
+
+  const nudgeTopNav = (direction) => {
+    const nav = topNavRef.current;
+    if (nav) nav.scrollBy({ left: direction * nav.clientWidth * 0.6, behavior: 'smooth' });
+  };
+
   // Get URL with preserved query params for certain sections
   const getNavUrl = (path) => {
     // For medications, care-tasks, and equipment sections, preserve patient param
@@ -567,6 +592,12 @@ const AdminV2Layout = ({ children }) => {
           {/* Top Navigation - only show if section has sub-navigation */}
           {topNavItems.length > 0 && (
             <header className="admin-v2-topnav">
+              {navScroll.left && (
+                <button type="button" className="admin-v2-topnav-scroll-hint left"
+                        aria-label="Scroll sections left" onClick={() => nudgeTopNav(-1)}>
+                  <ChevronLeftIcon size={16} />
+                </button>
+              )}
               <nav className="admin-v2-topnav-links" ref={topNavRef}>
                 {topNavItems.map((item) => (
                   <Link
@@ -578,6 +609,12 @@ const AdminV2Layout = ({ children }) => {
                   </Link>
                 ))}
               </nav>
+              {navScroll.right && (
+                <button type="button" className="admin-v2-topnav-scroll-hint right"
+                        aria-label="Scroll sections right" onClick={() => nudgeTopNav(1)}>
+                  <ChevronRightIcon size={16} />
+                </button>
+              )}
             </header>
           )}
         </div>

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
@@ -206,15 +206,21 @@ const AdminV2MonitoringTimeline = () => {
                                       .map((r) => r.location ?? ''))];
         if (cancelled) return;
         setRoomLocations(rooms);
-        // Default to the care area: prefer a bedroom-ish name, else first.
-        setRoomLocation((prev) => (prev !== null && rooms.includes(prev)) ? prev
-          : rooms.find((l) => /bed|care/i.test(l)) ?? rooms[0] ?? null);
+        // Default to the patient's configured care area when it has data,
+        // else keep a valid manual choice, else prefer a bedroom-ish name.
+        const careArea = selectedPatient?.care_area;
+        setRoomLocation((prev) => {
+          if (careArea && rooms.includes(careArea)) return careArea;
+          if (prev !== null && rooms.includes(prev)) return prev;
+          return rooms.find((l) => /bed|care/i.test(l)) ?? rooms[0] ?? null;
+        });
       } catch (err) {
         console.error('Environment locations fetch failed:', err);
       }
     })();
     return () => { cancelled = true; };
-  }, []);
+    // Re-run on patient switch so the default room follows their care area.
+  }, [selectedPatient?.care_area]);
 
   // Environmental overlay data for the selected day, keyed by series key.
   // Home-level (not patient-scoped); failure degrades to an empty series and

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
@@ -219,8 +219,10 @@ const AdminV2MonitoringTimeline = () => {
       }
     })();
     return () => { cancelled = true; };
-    // Re-run on patient switch so the default room follows their care area.
-  }, [selectedPatient?.care_area]);
+    // Re-run on patient switch (id, not just care_area — two patients can
+    // share a room name or both have none) so the default follows the
+    // newly selected patient instead of the previous one's manual choice.
+  }, [selectedPatient?.id, selectedPatient?.care_area]);
 
   // Environmental overlay data for the selected day, keyed by series key.
   // Home-level (not patient-scoped); failure degrades to an empty series and

--- a/frontend/src/pages/admin-v2/AdminV2PatientDetail.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2PatientDetail.jsx
@@ -43,7 +43,7 @@ const PATIENT_MODULES = [
 
 const emptyForm = {
   first_name: '', last_name: '', date_of_birth: '',
-  medical_record_number: '', notes: '', is_active: true,
+  medical_record_number: '', notes: '', is_active: true, care_area: '',
 };
 
 export default function AdminV2PatientDetail() {
@@ -91,6 +91,7 @@ export default function AdminV2PatientDetail() {
         medical_record_number: p.medical_record_number || '',
         notes: p.notes || '',
         is_active: p.is_active,
+        care_area: p.care_area || '',
       });
 
       if (sRes.ok) {
@@ -131,6 +132,7 @@ export default function AdminV2PatientDetail() {
         last_name: formData.last_name,
         is_active: formData.is_active,
         notes: formData.notes || null,
+        care_area: formData.care_area || null,
       };
       if (formData.date_of_birth) payload.date_of_birth = formData.date_of_birth;
       if (formData.medical_record_number) payload.medical_record_number = formData.medical_record_number;

--- a/frontend/src/pages/admin-v2/AdminV2Patients.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Patients.jsx
@@ -35,7 +35,7 @@ import './AdminV2.css';
 
 const emptyForm = {
   first_name: '', last_name: '', date_of_birth: '',
-  medical_record_number: '', notes: '', is_active: true,
+  medical_record_number: '', notes: '', is_active: true, care_area: '',
 };
 
 const getInitials = (f, l) => `${f?.[0] || ''}${l?.[0] || ''}`.toUpperCase();
@@ -107,6 +107,7 @@ const AdminV2Patients = () => {
       if (formData.date_of_birth) payload.date_of_birth = formData.date_of_birth;
       if (formData.medical_record_number) payload.medical_record_number = formData.medical_record_number;
       if (formData.notes) payload.notes = formData.notes;
+      if (formData.care_area) payload.care_area = formData.care_area;
       const res = await fetch(`${config.apiUrl}/api/patients`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Stacked on #89 (retarget to dev/main after it merges). The agreed pre-release HA finish-line set:

1. **GPIO alarms wired** (known-gaps §1): `MQTTModule` now subscribes to `AlarmPanelState` (reader alarm lines) and merges `alarm1`/`alarm2` ON/OFF into the per-patient combined state — the discovery-created "GPIO Alarm 1/2" binary sensors finally track reality. (Per-patient thresholds remain the one open item in §1.)
2. **Un-discovery** (known-gaps §3): `send_mqtt_discovery` prunes disabled sections with empty retained configs so toggled-off sections disappear from HA instead of lingering as stuck "Unknown"; disabling a patient's MQTT removes the whole device (`remove_mqtt_discovery_for_patient`). Both fire automatically on the per-patient MQTT save — the manual "send discovery" button is no longer needed for section changes.
3. **device_class enrichment**: temperature/weight/pressure/volume added where the published unit is HA-valid (weight unit corrected `lbs` → `lb`), enabling long-term statistics, unit conversion, and correct icons. SpO2/BPM/perfusion deliberately stay classless (no fitting HA class).
4. **Reader connectivity sensors**: one `connectivity` binary sensor per active reader on a retained `{base}/reader/{id}/availability` topic — published on reader WS connect/disconnect (evicted-handler safe: only flags offline when the slot is truly empty) and re-seeded by a snapshot at MQTT init so stale retained values don't survive restarts. HA can now tell "device offline" from "value stale".
5. **Patient ↔ room association**: new `patients.care_area` (migration 040), edited in the patient form with suggestions from HA areas + observed locations. It drives the timeline room-picker default for that patient and sets discovery `suggested_area` so the patient's SHH device lands in the correct HA room automatically — and it's the prerequisite for the analysis epic's per-patient environment joins (#53).

`docs/mqtt-known-gaps.md` updated to reflect §1/§3 status.

Testing: backend gate 556 green (+7 in `tests/test_mqtt_discovery.py`: device classes/suggested_area, section pruning, patient removal, reader sensor config, availability publisher, alarm event → combined state, care_area roundtrip); frontend 332 green; migration exercised by the upgrade walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS8WMSAiMKmozbMuwbiocw