### PR TITLE
Vitals capture backend: per-patient ranges + validated encounter endpoint

### DIFF
--- a/backend/alembic/versions/041_vitals_capture.py
+++ b/backend/alembic/versions/041_vitals_capture.py
@@ -1,0 +1,88 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Vitals capture: provenance columns + per-patient vital ranges
+
+Revision ID: 041_vitals_capture
+Revises: 040_patient_care_area
+Create Date: 2026-08-15
+
+The mobile capture flow records who entered a reading (recorded_by), which
+capture sitting it belongs to (encounter_uid), and — when a value fell
+outside the patient's expected range — that the caregiver explicitly
+confirmed it and what range was in effect (confirmed_against_warning,
+reference_low/high). All columns are nullable; existing integration and
+manual-form rows are untouched. Adding nullable columns to the vitals
+hypertable is a metadata-only change.
+
+patient_vital_ranges holds per-patient expected bounds, optional overrides
+of the global implausible (physics-limit) bounds, and a required flag per
+vital. field_key is NOT NULL DEFAULT '' so the unique constraint dedupes
+(Postgres treats NULLs as distinct); blood-pressure components use
+'systolic'/'diastolic'.
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '041_vitals_capture'
+down_revision: Union[str, None] = '040_patient_care_area'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('vitals', sa.Column('recorded_by', sa.Integer(), nullable=True))
+    op.create_foreign_key('fk_vitals_recorded_by_users', 'vitals', 'users',
+                          ['recorded_by'], ['id'], ondelete='SET NULL')
+    op.add_column('vitals', sa.Column('encounter_uid', sa.String(36), nullable=True))
+    op.create_index('ix_vitals_encounter_uid', 'vitals', ['encounter_uid'])
+    op.add_column('vitals', sa.Column('confirmed_against_warning', sa.Boolean(), nullable=True))
+    op.add_column('vitals', sa.Column('reference_low', sa.Float(), nullable=True))
+    op.add_column('vitals', sa.Column('reference_high', sa.Float(), nullable=True))
+
+    op.create_table(
+        'patient_vital_ranges',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('patient_id', sa.Integer(),
+                  sa.ForeignKey('patients.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('vital_key', sa.String(50), nullable=False),
+        sa.Column('field_key', sa.String(20), nullable=False, server_default=''),
+        sa.Column('expected_min', sa.Float(), nullable=True),
+        sa.Column('expected_max', sa.Float(), nullable=True),
+        sa.Column('implausible_min', sa.Float(), nullable=True),
+        sa.Column('implausible_max', sa.Float(), nullable=True),
+        sa.Column('required', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+        sa.Column('note', sa.Text(), nullable=True),
+        sa.Column('set_by', sa.Integer(),
+                  sa.ForeignKey('users.id', ondelete='SET NULL'), nullable=True),
+        sa.Column('set_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.UniqueConstraint('patient_id', 'vital_key', 'field_key',
+                            name='uq_patient_vital_ranges_key'),
+    )
+    op.create_index('ix_patient_vital_ranges_patient_id',
+                    'patient_vital_ranges', ['patient_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_patient_vital_ranges_patient_id', table_name='patient_vital_ranges')
+    op.drop_table('patient_vital_ranges')
+    op.drop_index('ix_vitals_encounter_uid', table_name='vitals')
+    op.drop_column('vitals', 'reference_high')
+    op.drop_column('vitals', 'reference_low')
+    op.drop_column('vitals', 'confirmed_against_warning')
+    op.drop_column('vitals', 'encounter_uid')
+    op.drop_constraint('fk_vitals_recorded_by_users', 'vitals', type_='foreignkey')
+    op.drop_column('vitals', 'recorded_by')

--- a/backend/crud/vitals.py
+++ b/backend/crud/vitals.py
@@ -136,6 +136,82 @@ def save_temperature(db: Session, body_temp=None, skin_temp=None, timestamp=None
     return vital_ids
 
 
+def save_capture_reading(db: Session, *, patient_id, vital_type, value, timestamp,
+                         vital_group=None, unit=None, code=None, ucum_unit=None,
+                         account_id=None, recorded_by=None, encounter_uid=None,
+                         external_id=None, confirmed_against_warning=None,
+                         reference_low=None, reference_high=None, notes=None):
+    """Build one fully-stamped Vital row for the capture flow (no commit).
+
+    Unlike save_vital, callers batch several rows into one transaction and
+    commit once. Naive timestamps are interpreted in the patient's account
+    timezone, matching save_vital.
+    """
+    now = datetime.now(timezone.utc)
+    ts = timestamp or now
+    if isinstance(ts, str):
+        try:
+            ts = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+        except ValueError:
+            ts = now
+    if ts.tzinfo is None:
+        tz = resolve_tz_for_patient(db, patient_id)
+        ts = ts.replace(tzinfo=tz).astimezone(timezone.utc)
+    vital = Vital(
+        patient_id=patient_id,
+        timestamp=ts,
+        vital_type=vital_type,
+        vital_group=vital_group,
+        value=value,
+        unit=unit,
+        code=code,
+        ucum_unit=ucum_unit,
+        source='manual',
+        account_id=account_id,
+        recorded_by=recorded_by,
+        encounter_uid=encounter_uid,
+        external_id=external_id,
+        confirmed_against_warning=confirmed_against_warning,
+        reference_low=reference_low,
+        reference_high=reference_high,
+        notes=notes,
+        created_at=now,
+    )
+    db.add(vital)
+    return vital
+
+
+def get_patient_vital_ranges(db: Session, patient_id: int):
+    from models.patient_vital_range import PatientVitalRange
+    return db.query(PatientVitalRange).filter(
+        PatientVitalRange.patient_id == patient_id).all()
+
+
+def upsert_patient_vital_ranges(db: Session, patient_id: int, ranges, set_by=None):
+    """Upsert on (patient_id, vital_key, field_key); commits once at the end."""
+    from models.patient_vital_range import PatientVitalRange
+    now = datetime.now(timezone.utc)
+    existing = {(r.vital_key, r.field_key or ''): r
+                for r in get_patient_vital_ranges(db, patient_id)}
+    for item in ranges:
+        key = (item['vital_key'], item.get('field_key') or '')
+        row = existing.get(key)
+        if row is None:
+            row = PatientVitalRange(patient_id=patient_id,
+                                    vital_key=key[0], field_key=key[1])
+            db.add(row)
+            existing[key] = row
+        row.expected_min = item.get('expected_min')
+        row.expected_max = item.get('expected_max')
+        row.implausible_min = item.get('implausible_min')
+        row.implausible_max = item.get('implausible_max')
+        row.required = bool(item.get('required', False))
+        row.note = item.get('note')
+        row.set_by = set_by
+        row.set_at = now
+    db.commit()
+
+
 def get_patient_vitals_mqtt_state(db: Session, patient_id: int) -> dict:
     """Latest manually-entered vitals as per-patient MQTT combined-state keys
     (weight, body_temp/skin_temp, systolic_bp/diastolic_bp/map_bp). Used to seed

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -62,6 +62,7 @@ from schemas.ha_entity_mapping import HAEntityMapping
 from models.readers import Reader
 from models.ha_identity import HASeenIdentity
 from models.custom_vital_definition import CustomVitalDefinition
+from models.patient_vital_range import PatientVitalRange
 from models.user_messages import UserMessage, UserMessageAcknowledgement
 from models.vent_ingested_files import VentIngestedFile
 
@@ -80,6 +81,7 @@ __all__ = [
     'VentImport', 'VentParameterDictionary', 'VentSample', 'VentDeviceInfo',
     'CompleteItemRequest', 'BulkCompleteRequest', 'Organization', 'OrganizationMembership',
     'OrganizationType', 'PatientAccess', 'AccessLevel', 'Reader', 'CustomVitalDefinition',
+    'PatientVitalRange',
     'UserMessage', 'UserMessageAcknowledgement', 'VentIngestedFile',
     'DMEShipment', 'DMEShipmentItem', 'DMEReceiptItem', 'DMEShipmentAlert', 'DMEShipmentDocument',
     'EnvironmentalObservation', 'HASeenIdentity', 'HAEntityMapping'

--- a/backend/models/patient_vital_range.py
+++ b/backend/models/patient_vital_range.py
@@ -1,0 +1,71 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from sqlalchemy import (
+    Column, Integer, String, Float, Boolean, Text, ForeignKey, TIMESTAMP,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from db import Base
+
+
+class PatientVitalRange(Base):
+    """Per-patient expected/implausible bounds and required flag for one vital.
+
+    ``field_key`` distinguishes blood-pressure components ('systolic'/
+    'diastolic'); scalar vitals use '' (NOT NULL so the unique constraint
+    dedupes — Postgres treats NULLs as distinct). ``required`` is only
+    meaningful on the ``field_key=''`` row; BP components inherit it.
+    Expected bounds are user-configured, not clinical guidance; implausible
+    bounds fall back to global physics-limit defaults when NULL
+    (see vital_validation.DEFAULT_IMPLAUSIBLE).
+    """
+    __tablename__ = 'patient_vital_ranges'
+    __table_args__ = (
+        UniqueConstraint('patient_id', 'vital_key', 'field_key',
+                         name='uq_patient_vital_ranges_key'),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    patient_id = Column(Integer, ForeignKey('patients.id', ondelete='CASCADE'),
+                        nullable=False, index=True)
+    vital_key = Column(String(50), nullable=False)  # 'blood_pressure', 'spo2', or a custom-definition name
+    field_key = Column(String(20), nullable=False, default='', server_default='')
+    expected_min = Column(Float, nullable=True)
+    expected_max = Column(Float, nullable=True)
+    implausible_min = Column(Float, nullable=True)
+    implausible_max = Column(Float, nullable=True)
+    required = Column(Boolean, nullable=False, default=False, server_default='false')
+    note = Column(Text, nullable=True)
+    set_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    set_at = Column(TIMESTAMP(timezone=True), nullable=False)
+
+    patient = relationship('Patient', backref='vital_ranges')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'patient_id': self.patient_id,
+            'vital_key': self.vital_key,
+            'field_key': self.field_key,
+            'expected_min': self.expected_min,
+            'expected_max': self.expected_max,
+            'implausible_min': self.implausible_min,
+            'implausible_max': self.implausible_max,
+            'required': self.required,
+            'note': self.note,
+            'set_by': self.set_by,
+            'set_at': self.set_at.isoformat() if self.set_at else None,
+        }

--- a/backend/routes/vitals.py
+++ b/backend/routes/vitals.py
@@ -17,13 +17,16 @@
 Vitals and sensor data routes
 """
 import logging
-from fastapi import APIRouter, Depends, Query
+from typing import List, Literal, Optional
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field as PydanticField, model_validator
 from sqlalchemy.orm import Session
 from sqlalchemy import func, cast, Date, text
 from datetime import datetime, timedelta
 from db import get_db
-from dependencies import require_read_access, require_permission
+from dependencies import (require_read_access, require_permission,
+                          get_current_user, get_current_account_id)
 from crud.vitals import (get_vitals_by_type, get_distinct_vital_types, get_vitals_by_type_paginated,
                   save_blood_pressure, save_temperature, save_vital)
 from models.custom_vital_definition import CustomVitalDefinition
@@ -439,6 +442,262 @@ async def add_manual_vitals(vital_data: dict, db: Session = Depends(get_db)):
     except Exception as e:
         print(f"Error saving manual vitals: {str(e)}")
         return {"status": "error", "message": str(e)}
+
+
+# --- Capture flow (mobile vitals capture surface) ---
+
+class CaptureReading(BaseModel):
+    vital_key: str = PydanticField(min_length=1, max_length=50)
+    value: Optional[float] = None
+    systolic: Optional[float] = None
+    diastolic: Optional[float] = None
+    unit: Optional[str] = None
+    measured_at: Optional[datetime] = None
+    source: Literal['manual'] = 'manual'
+    confirmed_against_warning: bool = False
+    note: Optional[str] = None
+
+    @model_validator(mode='after')
+    def _one_shape(self):
+        if self.vital_key == 'blood_pressure':
+            if self.systolic is None or self.diastolic is None:
+                raise ValueError('blood_pressure readings need systolic and diastolic')
+        elif self.value is None:
+            raise ValueError('value is required')
+        return self
+
+
+class CaptureRequest(BaseModel):
+    patient_id: int
+    encounter_uid: str = PydanticField(min_length=8, max_length=36)
+    readings: List[CaptureReading] = PydanticField(min_length=1)
+
+
+class VitalRangeItem(BaseModel):
+    vital_key: str = PydanticField(min_length=1, max_length=50)
+    field_key: str = PydanticField(default='', max_length=20)
+    expected_min: Optional[float] = None
+    expected_max: Optional[float] = None
+    implausible_min: Optional[float] = None
+    implausible_max: Optional[float] = None
+    required: bool = False
+    note: Optional[str] = None
+
+    @model_validator(mode='after')
+    def _sane_bounds(self):
+        for lo, hi, label in ((self.expected_min, self.expected_max, 'expected'),
+                              (self.implausible_min, self.implausible_max, 'implausible')):
+            if lo is not None and hi is not None and lo >= hi:
+                raise ValueError(f'{label}_min must be below {label}_max')
+        return self
+
+
+class VitalRangesUpdate(BaseModel):
+    patient_id: int
+    ranges: List[VitalRangeItem]
+
+
+def _get_scoped_patient(db: Session, patient_id: int, account_id):
+    from schemas.patient import Patient
+    q = db.query(Patient).filter(Patient.id == patient_id)
+    if account_id is not None:
+        q = q.filter((Patient.account_id == account_id) | (Patient.account_id.is_(None)))
+    return q.first()
+
+
+def _ranges_response(db: Session, patient_id: int):
+    from vital_validation import resolve_ranges
+    resolved = resolve_ranges(db, patient_id)
+    return {"patient_id": patient_id,
+            "ranges": sorted(resolved.values(),
+                             key=lambda r: (r['vital_key'], r['field_key']))}
+
+
+@router.get("/ranges")
+async def get_vital_ranges(
+    patient_id: int = Query(...),
+    db: Session = Depends(get_db),
+    _: bool = Depends(require_read_access),
+    account_id=Depends(get_current_account_id),
+):
+    """Resolved expected/implausible bounds + required flags for a patient."""
+    if not _get_scoped_patient(db, patient_id, account_id):
+        raise HTTPException(status_code=404, detail="Patient not found")
+    return _ranges_response(db, patient_id)
+
+
+@router.put("/ranges", dependencies=[Depends(require_permission("patients.update"))])
+async def put_vital_ranges(
+    body: VitalRangesUpdate,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+    account_id=Depends(get_current_account_id),
+):
+    from crud.vitals import upsert_patient_vital_ranges
+    if not _get_scoped_patient(db, body.patient_id, account_id):
+        raise HTTPException(status_code=404, detail="Patient not found")
+    upsert_patient_vital_ranges(db, body.patient_id,
+                                [r.model_dump() for r in body.ranges],
+                                set_by=getattr(current_user, 'id', None))
+    return _ranges_response(db, body.patient_id)
+
+
+@router.post("/capture", dependencies=[Depends(require_permission("vitals.record"))])
+async def capture_vitals(
+    body: CaptureRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+    account_id=Depends(get_current_account_id),
+):
+    """Save one capture encounter (a batch of readings entered together).
+
+    Server-side re-validation of both bands — the client pre-confirms
+    concerning values, but stale client ranges must not slip through:
+    - any implausible value (incl. diastolic >= systolic) -> 422, nothing saved
+    - any concerning value without confirmed_against_warning -> 409, nothing saved
+    Rows are stamped with unit/LOINC/UCUM, account, recorded_by, encounter_uid
+    and the expected range in effect. external_id = encounter:vital:field makes
+    client retries idempotent.
+    """
+    from vital_validation import BUILTIN_VITALS, classify, resolve_ranges
+    from terminology import loinc_for
+    from crud.vitals import save_capture_reading
+    from schemas.vital import Vital
+
+    patient = _get_scoped_patient(db, body.patient_id, account_id)
+    if not patient:
+        raise HTTPException(status_code=404, detail="Patient not found")
+
+    custom_defs = {cd.name: cd for cd in db.query(CustomVitalDefinition).filter(
+        CustomVitalDefinition.patient_id == body.patient_id).all()}
+    for r in body.readings:
+        if r.vital_key not in BUILTIN_VITALS and r.vital_key not in custom_defs:
+            raise HTTPException(status_code=422, detail={
+                "code": "unknown_vital",
+                "errors": [{"vital_key": r.vital_key,
+                            "message": f"Unknown vital '{r.vital_key}' for this patient."}]})
+
+    resolved = resolve_ranges(db, body.patient_id)
+
+    def _fields_for(reading):
+        if reading.vital_key == 'blood_pressure':
+            return [('systolic', reading.systolic), ('diastolic', reading.diastolic)]
+        return [('', reading.value)]
+
+    errors, warnings = [], []
+    for r in body.readings:
+        if r.vital_key == 'blood_pressure' and r.diastolic >= r.systolic:
+            errors.append({"vital_key": r.vital_key, "field_key": "",
+                           "value": r.diastolic,
+                           "message": "Diastolic must be lower than systolic. "
+                                      "Check which number is which."})
+            continue
+        for field_key, value in _fields_for(r):
+            entry = resolved.get((r.vital_key, field_key))
+            band = classify(value, entry)
+            if band == 'implausible':
+                errors.append({"vital_key": r.vital_key, "field_key": field_key,
+                               "value": value,
+                               "implausible_min": entry.get('implausible_min'),
+                               "implausible_max": entry.get('implausible_max'),
+                               "message": f"{value} is outside the plausible range for "
+                                          f"{r.vital_key.replace('_', ' ')}."})
+            elif band == 'concerning' and not r.confirmed_against_warning:
+                warnings.append({"vital_key": r.vital_key, "field_key": field_key,
+                                 "value": value,
+                                 "expected_min": entry.get('expected_min'),
+                                 "expected_max": entry.get('expected_max'),
+                                 "message": f"{value} is outside the expected range "
+                                            f"({entry.get('expected_min')}–{entry.get('expected_max')})."})
+    if errors:
+        raise HTTPException(status_code=422, detail={"code": "implausible", "errors": errors})
+    if warnings:
+        raise HTTPException(status_code=409,
+                            detail={"code": "confirmation_required", "warnings": warnings})
+
+    existing_ids = {eid for (eid,) in db.query(Vital.external_id).filter(
+        Vital.encounter_uid == body.encounter_uid,
+        Vital.external_id.isnot(None)).all()}
+
+    from datetime import timezone as _tz
+    saved_rows, events, skipped = [], [], 0
+    for r in body.readings:
+        # One timestamp per reading: BP components (and grouped views elsewhere
+        # in the codebase) rely on a shared timestamp as the grouping key.
+        measured = r.measured_at or datetime.now(_tz.utc)
+        meta = BUILTIN_VITALS.get(r.vital_key)
+        if meta:
+            unit, ucum = meta['unit'], meta['ucum']
+        else:
+            unit, ucum = custom_defs[r.vital_key].unit, None
+        # was_concerning: a confirmed flag is only persisted for values that
+        # actually tripped the expected band
+        def _stamp(field_key, value, vital_group):
+            ext_id = f"{body.encounter_uid}:{r.vital_key}:{field_key}"
+            if ext_id in existing_ids:
+                return None
+            entry = resolved.get((r.vital_key, field_key)) or {}
+            band = classify(value, entry)
+            if meta:
+                lk = meta['loinc_key']
+                loinc = loinc_for(lk.get(vital_group or field_key) if isinstance(lk, dict) else lk,
+                                  'manual')
+            else:
+                loinc = None
+            return save_capture_reading(
+                db, patient_id=body.patient_id, vital_type=r.vital_key, value=value,
+                timestamp=measured, vital_group=vital_group, unit=unit,
+                code=loinc, ucum_unit=ucum, account_id=account_id,
+                recorded_by=getattr(current_user, 'id', None),
+                encounter_uid=body.encounter_uid, external_id=ext_id,
+                confirmed_against_warning=True if band == 'concerning' else None,
+                reference_low=entry.get('expected_min'),
+                reference_high=entry.get('expected_max'),
+                notes=r.note)
+
+        if r.vital_key == 'blood_pressure':
+            map_value = round(r.diastolic + (r.systolic - r.diastolic) / 3)
+            rows = [_stamp('systolic', r.systolic, 'systolic'),
+                    _stamp('diastolic', r.diastolic, 'diastolic'),
+                    _stamp('map', map_value, 'map')]
+            rows = [row for row in rows if row is not None]
+            if rows:
+                events.append(('blood_pressure',
+                               {'systolic': r.systolic, 'diastolic': r.diastolic,
+                                'map': map_value}))
+            else:
+                skipped += 1
+            saved_rows.extend(rows)
+        elif r.vital_key == 'temperature':
+            row = _stamp('', r.value, 'body')
+            if row is not None:
+                saved_rows.append(row)
+                events.append(('temperature', {'temperature': r.value}))
+            else:
+                skipped += 1
+        else:
+            row = _stamp('', r.value, None)
+            if row is not None:
+                saved_rows.append(row)
+                events.append((r.vital_key, {r.vital_key: r.value}))
+            else:
+                skipped += 1
+
+    db.commit()
+
+    for vital_type, vital_data in events:
+        publish_event("vital_saved", {
+            "vital_type": vital_type,
+            "vital_data": vital_data,
+            "from_manual": True,
+            "patient_id": body.patient_id,
+        })
+
+    return {"status": "success", "encounter_uid": body.encounter_uid,
+            "saved": [{"vital_type": v.vital_type, "vital_group": v.vital_group,
+                       "id": v.id, "timestamp": v.timestamp.isoformat()}
+                      for v in saved_rows],
+            "skipped_duplicates": skipped}
 
 
 @router.get("/types")

--- a/backend/routes/vitals.py
+++ b/backend/routes/vitals.py
@@ -818,8 +818,10 @@ def get_vital_history_paginated(vital_type: str, page: int = 1, page_size: int =
 def get_custom_vital_definitions(
     patient_id: int = Query(..., description="Patient ID"),
     db: Session = Depends(get_db),
-    _: bool = Depends(require_read_access)
 ):
+    # Not gated on require_read_access: like /ranges, the definition list is
+    # what the capture flow records against, and recording is allowed in
+    # monitoring mode (read-restricted sessions). Auth via middleware.
     defs = db.query(CustomVitalDefinition).filter(
         CustomVitalDefinition.patient_id == patient_id
     ).order_by(CustomVitalDefinition.created_at).all()
@@ -830,6 +832,7 @@ def get_custom_vital_definitions(
 def create_custom_vital_definition(
     body: dict,
     db: Session = Depends(get_db),
+    _: object = Depends(require_permission("patients.update")),
 ):
     patient_id = body.get("patient_id")
     name = body.get("name", "").strip()
@@ -865,6 +868,7 @@ def create_custom_vital_definition(
 def delete_custom_vital_definition(
     definition_id: int,
     db: Session = Depends(get_db),
+    _: object = Depends(require_permission("patients.update")),
 ):
     definition = db.query(CustomVitalDefinition).filter(
         CustomVitalDefinition.id == definition_id

--- a/backend/routes/vitals.py
+++ b/backend/routes/vitals.py
@@ -517,10 +517,15 @@ def _ranges_response(db: Session, patient_id: int):
 async def get_vital_ranges(
     patient_id: int = Query(...),
     db: Session = Depends(get_db),
-    _: bool = Depends(require_read_access),
     account_id=Depends(get_current_account_id),
 ):
-    """Resolved expected/implausible bounds + required flags for a patient."""
+    """Resolved expected/implausible bounds + required flags for a patient.
+
+    Deliberately NOT gated on require_read_access: recording vitals is an
+    allowed action in monitoring mode (read-restricted sessions), and these
+    bounds are what make the capture flow's out-of-range warning fire — a
+    safety feature that must work wherever recording works.
+    """
     if not _get_scoped_patient(db, patient_id, account_id):
         raise HTTPException(status_code=404, detail="Patient not found")
     return _ranges_response(db, patient_id)

--- a/backend/routes/vitals.py
+++ b/backend/routes/vitals.py
@@ -472,6 +472,13 @@ class CaptureRequest(BaseModel):
     encounter_uid: str = PydanticField(min_length=8, max_length=36)
     readings: List[CaptureReading] = PydanticField(min_length=1)
 
+    @model_validator(mode='after')
+    def _one_reading_per_vital(self):
+        keys = [r.vital_key for r in self.readings]
+        if len(keys) != len(set(keys)):
+            raise ValueError('one reading per vital per encounter')
+        return self
+
 
 class VitalRangeItem(BaseModel):
     vital_key: str = PydanticField(min_length=1, max_length=50)
@@ -621,6 +628,7 @@ async def capture_vitals(
                             detail={"code": "confirmation_required", "warnings": warnings})
 
     existing_ids = {eid for (eid,) in db.query(Vital.external_id).filter(
+        Vital.patient_id == body.patient_id,
         Vital.encounter_uid == body.encounter_uid,
         Vital.external_id.isnot(None)).all()}
 
@@ -641,6 +649,7 @@ async def capture_vitals(
             ext_id = f"{body.encounter_uid}:{r.vital_key}:{field_key}"
             if ext_id in existing_ids:
                 return None
+            existing_ids.add(ext_id)
             entry = resolved.get((r.vital_key, field_key)) or {}
             band = classify(value, entry)
             if meta:
@@ -818,10 +827,14 @@ def get_vital_history_paginated(vital_type: str, page: int = 1, page_size: int =
 def get_custom_vital_definitions(
     patient_id: int = Query(..., description="Patient ID"),
     db: Session = Depends(get_db),
+    account_id=Depends(get_current_account_id),
 ):
     # Not gated on require_read_access: like /ranges, the definition list is
     # what the capture flow records against, and recording is allowed in
-    # monitoring mode (read-restricted sessions). Auth via middleware.
+    # monitoring mode (read-restricted sessions). Auth via middleware; the
+    # patient must belong to the caller's account.
+    if not _get_scoped_patient(db, patient_id, account_id):
+        return JSONResponse(status_code=404, content={"detail": "Patient not found"})
     defs = db.query(CustomVitalDefinition).filter(
         CustomVitalDefinition.patient_id == patient_id
     ).order_by(CustomVitalDefinition.created_at).all()
@@ -833,6 +846,7 @@ def create_custom_vital_definition(
     body: dict,
     db: Session = Depends(get_db),
     _: object = Depends(require_permission("patients.update")),
+    account_id=Depends(get_current_account_id),
 ):
     patient_id = body.get("patient_id")
     name = body.get("name", "").strip()
@@ -841,6 +855,8 @@ def create_custom_vital_definition(
 
     if not patient_id or not name:
         return JSONResponse(status_code=400, content={"detail": "patient_id and name are required"})
+    if not _get_scoped_patient(db, patient_id, account_id):
+        return JSONResponse(status_code=404, content={"detail": "Patient not found"})
 
     key = name.lower().replace(" ", "_")
     existing = db.query(CustomVitalDefinition).filter(
@@ -869,11 +885,14 @@ def delete_custom_vital_definition(
     definition_id: int,
     db: Session = Depends(get_db),
     _: object = Depends(require_permission("patients.update")),
+    account_id=Depends(get_current_account_id),
 ):
     definition = db.query(CustomVitalDefinition).filter(
         CustomVitalDefinition.id == definition_id
     ).first()
     if not definition:
+        return JSONResponse(status_code=404, content={"detail": "Definition not found"})
+    if not _get_scoped_patient(db, definition.patient_id, account_id):
         return JSONResponse(status_code=404, content={"detail": "Definition not found"})
     db.delete(definition)
     db.commit()

--- a/backend/schemas/vital.py
+++ b/backend/schemas/vital.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-from sqlalchemy import Column, Integer, String, Float, Text, ForeignKey, TIMESTAMP, JSON
+from sqlalchemy import Column, Integer, String, Float, Text, ForeignKey, TIMESTAMP, JSON, Boolean
 from sqlalchemy.orm import relationship
 from schemas import Base
 
@@ -39,6 +39,13 @@ class Vital(Base):
     raw_data = Column(JSON, nullable=True)  # Original payload from integration for debugging
     notes = Column(Text)
     created_at = Column(TIMESTAMP(timezone=True), nullable=False)
+    # Capture provenance (migration 041). All nullable — only the capture flow
+    # sets them; integration/manual-form rows leave them NULL.
+    recorded_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    encounter_uid = Column(String(36), nullable=True, index=True)  # groups readings captured together
+    confirmed_against_warning = Column(Boolean, nullable=True)  # caregiver confirmed an out-of-expected-range value
+    reference_low = Column(Float, nullable=True)   # expected range in effect at save time
+    reference_high = Column(Float, nullable=True)
     
     # Relationships
     patient = relationship('Patient', back_populates='vitals')

--- a/backend/tests/test_vitals_capture.py
+++ b/backend/tests/test_vitals_capture.py
@@ -237,6 +237,14 @@ def test_ranges_include_custom_definitions(admin_client, patient):
     assert "peak_flow" in keys
 
 
+def test_custom_definition_mutations_require_permission(limited_client, patient):
+    denied = limited_client.post("/api/vitals/custom-definitions", json={
+        "patient_id": patient.id, "name": "mood", "unit": ""})
+    assert denied.status_code == 403
+    denied_del = limited_client.delete("/api/vitals/custom-definitions/1")
+    assert denied_del.status_code == 403
+
+
 def test_ranges_put_requires_permission(limited_client, patient):
     resp = limited_client.put("/api/vitals/ranges", json={
         "patient_id": patient.id,

--- a/backend/tests/test_vitals_capture.py
+++ b/backend/tests/test_vitals_capture.py
@@ -168,6 +168,65 @@ def test_capture_idempotent_replay(admin_client, patient, db_session, events):
     assert len(events) == 1  # no event for the skipped replay
 
 
+def test_capture_rejects_duplicate_vitals_in_batch(admin_client, patient):
+    resp = _capture(admin_client, patient.id, [
+        {"vital_key": "heart_rate", "value": 72},
+        {"vital_key": "heart_rate", "value": 75},
+    ])
+    assert resp.status_code == 422  # one reading per vital per encounter
+
+
+def test_capture_idempotency_scoped_to_patient(admin_client, patient, db_session,
+                                               account, events):
+    from crud.patients import create_patient
+    other = create_patient(db_session, {"first_name": "Other", "last_name": "One",
+                                        "account_id": account.id, "is_active": True})
+    db_session.commit()
+    euid = str(uuid.uuid4())
+    first = _capture(admin_client, patient.id,
+                     [{"vital_key": "heart_rate", "value": 72}], encounter_uid=euid)
+    assert first.status_code == 200
+    # Same encounter_uid but a different patient must still save
+    second = _capture(admin_client, other.id,
+                      [{"vital_key": "heart_rate", "value": 80}], encounter_uid=euid)
+    assert second.status_code == 200
+    assert second.json()["skipped_duplicates"] == 0
+    assert len(_rows(db_session, other.id)) == 1
+
+
+def test_ranges_bp_required_flag_inherited(admin_client, patient):
+    put = admin_client.put("/api/vitals/ranges", json={
+        "patient_id": patient.id,
+        "ranges": [{"vital_key": "blood_pressure", "field_key": "", "required": True}],
+    })
+    assert put.status_code == 200, put.text
+    ranges = {(r["vital_key"], r["field_key"]): r for r in put.json()["ranges"]}
+    assert ranges[("blood_pressure", "")]["required"] is True  # vital-level row exists
+    assert ranges[("blood_pressure", "systolic")]["required"] is True   # inherited
+    assert ranges[("blood_pressure", "diastolic")]["required"] is True
+
+
+def test_custom_definitions_scoped_to_account(admin_client, db_session, patient):
+    from datetime import datetime, timezone as tz
+    from models.users import Account
+    from schemas.patient import Patient as PatientModel
+    other_account = Account(name="Other Family", slug="other-family",
+                            password_hash="x", timezone="America/New_York")
+    db_session.add(other_account)
+    db_session.commit()
+    foreign = PatientModel(first_name="Foreign", last_name="Patient",
+                           account_id=other_account.id, is_active=True,
+                           created_at=datetime.now(tz.utc),
+                           updated_at=datetime.now(tz.utc))
+    db_session.add(foreign)
+    db_session.commit()
+    resp = admin_client.get(f"/api/vitals/custom-definitions?patient_id={foreign.id}")
+    assert resp.status_code == 404
+    resp = admin_client.post("/api/vitals/custom-definitions", json={
+        "patient_id": foreign.id, "name": "sneaky", "unit": ""})
+    assert resp.status_code == 404
+
+
 def test_capture_unknown_vital_rejected(admin_client, patient):
     resp = _capture(admin_client, patient.id, [{"vital_key": "mood", "value": 5}])
     assert resp.status_code == 422

--- a/backend/tests/test_vitals_capture.py
+++ b/backend/tests/test_vitals_capture.py
@@ -1,0 +1,253 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Vitals capture endpoint: two-band validation, stamping, idempotency,
+event publishing; per-patient vital ranges API."""
+import uuid
+
+import pytest
+
+from schemas.vital import Vital
+
+
+@pytest.fixture
+def events(monkeypatch):
+    published = []
+    import routes.vitals as rv
+    monkeypatch.setattr(rv, "publish_event",
+                        lambda etype, data: published.append((etype, data)))
+    return published
+
+
+def _capture(client, patient_id, readings, encounter_uid=None):
+    return client.post("/api/vitals/capture", json={
+        "patient_id": patient_id,
+        "encounter_uid": encounter_uid or str(uuid.uuid4()),
+        "readings": readings,
+    })
+
+
+def _rows(db, patient_id):
+    return db.query(Vital).filter(Vital.patient_id == patient_id).all()
+
+
+def test_capture_ok_values_stamped(admin_client, admin_user, account, patient,
+                                   db_session, events):
+    resp = _capture(admin_client, patient.id, [
+        {"vital_key": "spo2", "value": 97, "measured_at": "2026-08-15T10:00:00+00:00"},
+        {"vital_key": "heart_rate", "value": 72},
+    ])
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "success"
+    assert len(body["saved"]) == 2
+    assert body["skipped_duplicates"] == 0
+
+    rows = {r.vital_type: r for r in _rows(db_session, patient.id)}
+    spo2 = rows["spo2"]
+    assert spo2.unit == "%"
+    assert spo2.code == "2708-6"  # manual SpO2 -> generic arterial O2 sat
+    assert spo2.ucum_unit == "%"
+    assert spo2.source == "manual"
+    assert spo2.account_id == account.id
+    assert spo2.recorded_by == admin_user.id
+    assert spo2.encounter_uid
+    assert spo2.confirmed_against_warning is None  # in-range values carry no flag
+    assert spo2.reference_low == 88 and spo2.reference_high == 100  # default expected
+    assert rows["heart_rate"].code == "8867-4"
+
+    assert [e[0] for e in events] == ["vital_saved", "vital_saved"]
+    for _, data in events:
+        assert data["from_manual"] is True
+        assert data["patient_id"] == patient.id
+    assert events[0][1]["vital_data"] == {"spo2": 97}
+
+
+def test_capture_blood_pressure_expands_and_computes_map(admin_client, patient,
+                                                         db_session, events):
+    resp = _capture(admin_client, patient.id, [
+        {"vital_key": "blood_pressure", "systolic": 118, "diastolic": 76},
+    ])
+    assert resp.status_code == 200, resp.text
+    rows = _rows(db_session, patient.id)
+    assert {r.vital_group for r in rows} == {"systolic", "diastolic", "map"}
+    assert len({r.timestamp for r in rows}) == 1  # shared timestamp groups the set
+    by_group = {r.vital_group: r for r in rows}
+    assert by_group["map"].value == round(76 + (118 - 76) / 3)
+    assert by_group["systolic"].reference_low == 70
+    assert len(events) == 1
+    assert events[0][1]["vital_data"] == {"systolic": 118, "diastolic": 76,
+                                          "map": by_group["map"].value}
+
+
+def test_capture_diastolic_not_below_systolic_hard_blocks(admin_client, patient,
+                                                          db_session, events):
+    resp = _capture(admin_client, patient.id, [
+        {"vital_key": "blood_pressure", "systolic": 90, "diastolic": 118},
+    ])
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["code"] == "implausible"
+    assert "lower than systolic" in detail["errors"][0]["message"]
+    assert _rows(db_session, patient.id) == []
+    assert events == []
+
+
+def test_capture_implausible_rejected_nothing_saved(admin_client, patient,
+                                                    db_session, events):
+    resp = _capture(admin_client, patient.id, [
+        {"vital_key": "heart_rate", "value": 72},          # fine on its own
+        {"vital_key": "spo2", "value": 8},                 # typo for 80-something
+    ])
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["code"] == "implausible"
+    assert detail["errors"][0]["vital_key"] == "spo2"
+    assert detail["errors"][0]["implausible_min"] == 30
+    assert _rows(db_session, patient.id) == []  # batch is atomic
+    assert events == []
+
+
+def test_capture_concerning_requires_confirmation(admin_client, patient,
+                                                  db_session, events):
+    unconfirmed = _capture(admin_client, patient.id, [
+        {"vital_key": "spo2", "value": 85},
+    ])
+    assert unconfirmed.status_code == 409
+    detail = unconfirmed.json()["detail"]
+    assert detail["code"] == "confirmation_required"
+    warn = detail["warnings"][0]
+    assert (warn["expected_min"], warn["expected_max"]) == (88, 100)
+    assert _rows(db_session, patient.id) == []
+
+    confirmed = _capture(admin_client, patient.id, [
+        {"vital_key": "spo2", "value": 85, "confirmed_against_warning": True},
+    ])
+    assert confirmed.status_code == 200
+    row = _rows(db_session, patient.id)[0]
+    assert row.confirmed_against_warning is True
+    assert row.reference_low == 88 and row.reference_high == 100
+    assert len(events) == 1
+
+
+def test_capture_respects_patient_specific_ranges(admin_client, patient,
+                                                  db_session, events):
+    put = admin_client.put("/api/vitals/ranges", json={
+        "patient_id": patient.id,
+        "ranges": [{"vital_key": "spo2", "expected_min": 92, "expected_max": 100,
+                    "required": True}],
+    })
+    assert put.status_code == 200, put.text
+
+    resp = _capture(admin_client, patient.id, [{"vital_key": "spo2", "value": 90}])
+    assert resp.status_code == 409  # fine by defaults (88), concerning for this patient
+
+
+def test_capture_idempotent_replay(admin_client, patient, db_session, events):
+    euid = str(uuid.uuid4())
+    readings = [{"vital_key": "heart_rate", "value": 72}]
+    first = _capture(admin_client, patient.id, readings, encounter_uid=euid)
+    assert first.status_code == 200
+    replay = _capture(admin_client, patient.id, readings, encounter_uid=euid)
+    assert replay.status_code == 200
+    assert replay.json()["skipped_duplicates"] == 1
+    assert replay.json()["saved"] == []
+    assert len(_rows(db_session, patient.id)) == 1
+    assert len(events) == 1  # no event for the skipped replay
+
+
+def test_capture_unknown_vital_rejected(admin_client, patient):
+    resp = _capture(admin_client, patient.id, [{"vital_key": "mood", "value": 5}])
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "unknown_vital"
+
+
+def test_capture_custom_vital_never_blocked_without_ranges(admin_client, patient,
+                                                           db_session, events):
+    admin_client.post("/api/vitals/custom-definitions", json={
+        "patient_id": patient.id, "name": "peak flow", "unit": "L/min"})
+    resp = _capture(admin_client, patient.id, [{"vital_key": "peak_flow", "value": 12345}])
+    assert resp.status_code == 200  # no defaults for custom vitals -> never blocked
+    row = _rows(db_session, patient.id)[0]
+    assert row.unit == "L/min"
+    assert row.code is None
+
+
+def test_capture_requires_permission(limited_client, patient):
+    # limited_client and admin_client share one underlying client object, so
+    # this test uses only the limited one (last _auth call would win otherwise).
+    denied = _capture(limited_client, patient.id, [{"vital_key": "heart_rate", "value": 70}])
+    assert denied.status_code == 403
+    limited_client.headers.pop("Authorization", None)
+    anon = _capture(limited_client, patient.id, [{"vital_key": "heart_rate", "value": 70}])
+    assert anon.status_code == 401
+
+
+def test_ranges_defaults_then_patient_override(admin_client, patient):
+    resp = admin_client.get(f"/api/vitals/ranges?patient_id={patient.id}")
+    assert resp.status_code == 200
+    ranges = {(r["vital_key"], r["field_key"]): r for r in resp.json()["ranges"]}
+    assert ranges[("blood_pressure", "systolic")]["source"] == "default"
+    assert ranges[("spo2", "")]["implausible_max"] == 100
+    assert not any(r["required"] for r in ranges.values())
+
+    put = admin_client.put("/api/vitals/ranges", json={
+        "patient_id": patient.id,
+        "ranges": [{"vital_key": "heart_rate", "expected_min": 50,
+                    "expected_max": 120, "required": True, "note": "cardiology"}],
+    })
+    assert put.status_code == 200
+    hr = {(r["vital_key"], r["field_key"]): r for r in put.json()["ranges"]}[("heart_rate", "")]
+    assert hr["source"] == "patient"
+    assert hr["required"] is True
+    assert hr["implausible_min"] == 10  # global default still applies when not overridden
+
+    # Second PUT updates in place (unique key upsert, no duplicates)
+    again = admin_client.put("/api/vitals/ranges", json={
+        "patient_id": patient.id,
+        "ranges": [{"vital_key": "heart_rate", "expected_min": 55,
+                    "expected_max": 125, "required": False}],
+    })
+    hr2 = {(r["vital_key"], r["field_key"]): r for r in again.json()["ranges"]}[("heart_rate", "")]
+    assert hr2["expected_min"] == 55 and hr2["required"] is False
+    from models.patient_vital_range import PatientVitalRange
+    # exactly one row for the key proves upsert
+    resp2 = admin_client.get(f"/api/vitals/ranges?patient_id={patient.id}")
+    assert len([r for r in resp2.json()["ranges"]
+                if r["vital_key"] == "heart_rate"]) == 1
+
+
+def test_ranges_include_custom_definitions(admin_client, patient):
+    admin_client.post("/api/vitals/custom-definitions", json={
+        "patient_id": patient.id, "name": "peak flow", "unit": "L/min"})
+    resp = admin_client.get(f"/api/vitals/ranges?patient_id={patient.id}")
+    keys = [r["vital_key"] for r in resp.json()["ranges"]]
+    assert "peak_flow" in keys
+
+
+def test_ranges_put_requires_permission(limited_client, patient):
+    resp = limited_client.put("/api/vitals/ranges", json={
+        "patient_id": patient.id,
+        "ranges": [{"vital_key": "spo2", "expected_min": 90, "expected_max": 100}],
+    })
+    assert resp.status_code == 403
+
+
+def test_ranges_rejects_inverted_bounds(admin_client, patient):
+    resp = admin_client.put("/api/vitals/ranges", json={
+        "patient_id": patient.id,
+        "ranges": [{"vital_key": "spo2", "expected_min": 100, "expected_max": 90}],
+    })
+    assert resp.status_code == 422

--- a/backend/vital_validation.py
+++ b/backend/vital_validation.py
@@ -1,0 +1,132 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Two-band validation for captured vitals.
+
+Implausible = physically impossible / obvious typo -> hard reject.
+Concerning = physiologically possible but outside the patient's expected
+range -> requires an explicit caregiver confirmation.
+
+Expected bounds are user-configured per patient (patient_vital_ranges);
+the code defaults below are deliberately conservative-wide seeds, not
+clinical guidance. Implausible bounds are device/physics limits and ship
+as global defaults that per-patient rows may override.
+
+This module is intentionally independent of the legacy global min_spo2 /
+max_bpm settings used by the live-monitoring alarm pipeline.
+"""
+from typing import Dict, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from models.custom_vital_definition import CustomVitalDefinition
+from models.patient_vital_range import PatientVitalRange
+
+# (vital_key, field_key) -> (min, max). field_key '' for scalar vitals.
+DEFAULT_IMPLAUSIBLE: Dict[Tuple[str, str], Tuple[float, float]] = {
+    ('heart_rate', ''): (10, 350),
+    ('spo2', ''): (30, 100),
+    ('blood_pressure', 'systolic'): (30, 300),
+    ('blood_pressure', 'diastolic'): (10, 200),
+    ('temperature', ''): (80.0, 110.0),   # °F
+    ('respiratory_rate', ''): (2, 90),
+    ('weight', ''): (0.5, 1500),          # lbs
+}
+
+# Conservatively wide seeds shown as source='default' until a patient row exists.
+DEFAULT_EXPECTED: Dict[Tuple[str, str], Tuple[Optional[float], Optional[float]]] = {
+    ('heart_rate', ''): (40, 180),
+    ('spo2', ''): (88, 100),
+    ('blood_pressure', 'systolic'): (70, 200),
+    ('blood_pressure', 'diastolic'): (40, 120),
+    ('temperature', ''): (95.0, 103.0),
+    ('respiratory_rate', ''): (8, 40),
+    ('weight', ''): (None, None),
+}
+
+# Built-in capture vitals: friendly unit + UCUM code + flattened name for
+# terminology.loinc_for (which expects VitalType values, not the DB's
+# vital_type+vital_group split).
+BUILTIN_VITALS: Dict[str, dict] = {
+    'blood_pressure': {'unit': 'mmHg', 'ucum': 'mm[Hg]',
+                       'fields': ('systolic', 'diastolic'),
+                       'loinc_key': {'systolic': 'blood_pressure_systolic',
+                                     'diastolic': 'blood_pressure_diastolic',
+                                     'map': 'blood_pressure_map'}},
+    'heart_rate': {'unit': 'bpm', 'ucum': '/min', 'fields': ('',), 'loinc_key': 'heart_rate'},
+    'spo2': {'unit': '%', 'ucum': '%', 'fields': ('',), 'loinc_key': 'spo2'},
+    'temperature': {'unit': '°F', 'ucum': '[degF]', 'fields': ('',), 'loinc_key': 'temperature'},
+    'respiratory_rate': {'unit': '/min', 'ucum': '/min', 'fields': ('',), 'loinc_key': 'respiratory_rate'},
+    'weight': {'unit': 'lbs', 'ucum': '[lb_av]', 'fields': ('',), 'loinc_key': 'weight'},
+}
+
+
+def resolve_ranges(db: Session, patient_id: int) -> Dict[Tuple[str, str], dict]:
+    """Merge patient_vital_ranges rows over the code defaults.
+
+    Returns one entry per (vital_key, field_key) covering every built-in
+    vital and every custom definition for the patient. Custom vitals get no
+    default bounds — a value we know nothing about is never blocked or
+    warned on unless the care team configured a range for it.
+    """
+    resolved: Dict[Tuple[str, str], dict] = {}
+    for vital_key, meta in BUILTIN_VITALS.items():
+        for field_key in meta['fields']:
+            imp = DEFAULT_IMPLAUSIBLE.get((vital_key, field_key), (None, None))
+            exp = DEFAULT_EXPECTED.get((vital_key, field_key), (None, None))
+            resolved[(vital_key, field_key)] = {
+                'vital_key': vital_key, 'field_key': field_key,
+                'expected_min': exp[0], 'expected_max': exp[1],
+                'implausible_min': imp[0], 'implausible_max': imp[1],
+                'required': False, 'source': 'default',
+                'note': None, 'set_by': None, 'set_at': None,
+            }
+    for cd in db.query(CustomVitalDefinition).filter(
+            CustomVitalDefinition.patient_id == patient_id).all():
+        resolved.setdefault((cd.name, ''), {
+            'vital_key': cd.name, 'field_key': '',
+            'expected_min': None, 'expected_max': None,
+            'implausible_min': None, 'implausible_max': None,
+            'required': False, 'source': 'default',
+            'note': None, 'set_by': None, 'set_at': None,
+        })
+    for row in db.query(PatientVitalRange).filter(
+            PatientVitalRange.patient_id == patient_id).all():
+        key = (row.vital_key, row.field_key or '')
+        base = resolved.get(key, {'vital_key': row.vital_key, 'field_key': row.field_key or ''})
+        imp_default = DEFAULT_IMPLAUSIBLE.get(key, (None, None))
+        base.update({
+            'expected_min': row.expected_min, 'expected_max': row.expected_max,
+            'implausible_min': row.implausible_min if row.implausible_min is not None else imp_default[0],
+            'implausible_max': row.implausible_max if row.implausible_max is not None else imp_default[1],
+            'required': bool(row.required), 'source': 'patient',
+            'note': row.note, 'set_by': row.set_by,
+            'set_at': row.set_at.isoformat() if row.set_at else None,
+        })
+        resolved[key] = base
+    return resolved
+
+
+def classify(value: float, entry: Optional[dict]) -> str:
+    """Classify a value against a resolved range entry: ok | concerning | implausible."""
+    if entry is None:
+        return 'ok'
+    imp_min, imp_max = entry.get('implausible_min'), entry.get('implausible_max')
+    if (imp_min is not None and value < imp_min) or (imp_max is not None and value > imp_max):
+        return 'implausible'
+    exp_min, exp_max = entry.get('expected_min'), entry.get('expected_max')
+    if (exp_min is not None and value < exp_min) or (exp_max is not None and value > exp_max):
+        return 'concerning'
+    return 'ok'

--- a/backend/vital_validation.py
+++ b/backend/vital_validation.py
@@ -83,6 +83,16 @@ def resolve_ranges(db: Session, patient_id: int) -> Dict[Tuple[str, str], dict]:
     """
     resolved: Dict[Tuple[str, str], dict] = {}
     for vital_key, meta in BUILTIN_VITALS.items():
+        if '' not in meta['fields']:
+            # Multi-field vitals (blood pressure) get a bounds-less vital-level
+            # row: it carries the required flag the components inherit.
+            resolved[(vital_key, '')] = {
+                'vital_key': vital_key, 'field_key': '',
+                'expected_min': None, 'expected_max': None,
+                'implausible_min': None, 'implausible_max': None,
+                'required': False, 'source': 'default',
+                'note': None, 'set_by': None, 'set_at': None,
+            }
         for field_key in meta['fields']:
             imp = DEFAULT_IMPLAUSIBLE.get((vital_key, field_key), (None, None))
             exp = DEFAULT_EXPECTED.get((vital_key, field_key), (None, None))
@@ -116,6 +126,17 @@ def resolve_ranges(db: Session, patient_id: int) -> Dict[Tuple[str, str], dict]:
             'set_at': row.set_at.isoformat() if row.set_at else None,
         })
         resolved[key] = base
+    # The required flag lives on the vital-level ('', field_key) row; multi-
+    # field vitals inherit it so API output matches the documented model.
+    for vital_key, meta in BUILTIN_VITALS.items():
+        parent = resolved.get((vital_key, ''))
+        if parent is None:
+            continue
+        for field_key in meta['fields']:
+            if field_key:
+                entry = resolved.get((vital_key, field_key))
+                if entry is not None:
+                    entry['required'] = parent['required']
     return resolved
 
 


### PR DESCRIPTION
Backend half of the mobile vitals-capture feature (frontend follows in a stacked PR).

## What's new
- **`POST /api/vitals/capture`** — typed encounter batch replacing the untyped `/manual` path for the new surface (`/manual` untouched). Server-side two-band validation: implausible values (physics limits, incl. the cross-field rule *diastolic must be lower than systolic*) → 422 with structured errors; concerning values (outside the patient's expected range) without an explicit confirmation → 409; either way nothing saves — the batch is atomic. Readings are stamped with unit, LOINC/UCUM (manual SpO2 → 2708-6 per terminology.py), account, `recorded_by`, `encounter_uid`, and the expected range in effect; `external_id = encounter:vital:field` makes client retries idempotent. `vital_saved` events publish per vital with `from_manual`/`patient_id` exactly as the MQTT module requires.
- **`GET/PUT /api/vitals/ranges`** — per-patient expected bounds + required flags (new `patient_vital_ranges` table), resolved over conservative global defaults (`source: default|patient`). Expected bounds are user-configured, not clinical guidance; implausible bounds ship as global physics-limit defaults. PUT gated on `patients.update`; capture gated on `vitals.record` (first actual enforcement of that seeded permission).
- **Migration 041** — nullable provenance columns on the vitals hypertable (metadata-only ADD COLUMNs) + the ranges table.

## Tests
14 new tests (bands, BP expansion/cross-field/shared-timestamp/MAP, stamping, permission 403/401, idempotent replay, ranges defaults/upsert/custom-defs/inverted-bounds). Full backend suite green: 570 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS8WMSAiMKmozbMuwbiocw