### PR TITLE
Admin shell adopts the bedside-monitor aesthetic (dark theme)

### DIFF
--- a/frontend/src/pages/admin-v2/AdminV2Layout.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Layout.jsx
@@ -55,6 +55,14 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Alert } from '@/components/ui/alert';
 import './AdminV2.css';
+// Bedside-monitor skin (dark theme only) + the fonts it uses. Loaded after
+// AdminV2.css so its scoped overrides win.
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@fontsource/ibm-plex-mono/600.css';
+import '@fontsource/ibm-plex-sans/400.css';
+import '@fontsource/ibm-plex-sans/500.css';
+import './vc-shell.css';
 
 // Side navigation items - main app sections
 const sideNavItems = [

--- a/frontend/src/pages/admin-v2/AdminV2Layout.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Layout.jsx
@@ -55,13 +55,9 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Alert } from '@/components/ui/alert';
 import './AdminV2.css';
-// Bedside-monitor skin (dark theme only) + the fonts it uses. Loaded after
-// AdminV2.css so its scoped overrides win.
-import '@fontsource/ibm-plex-mono/400.css';
-import '@fontsource/ibm-plex-mono/500.css';
-import '@fontsource/ibm-plex-mono/600.css';
-import '@fontsource/ibm-plex-sans/400.css';
-import '@fontsource/ibm-plex-sans/500.css';
+// Bedside-monitor skin (dark theme only) + its fonts (shared entry, deduped
+// with the capture surface). Loaded after AdminV2.css so overrides win.
+import '../../styles/vcFonts';
 import './vc-shell.css';
 
 // Side navigation items - main app sections

--- a/frontend/src/pages/admin-v2/vc-shell.css
+++ b/frontend/src/pages/admin-v2/vc-shell.css
@@ -1,0 +1,178 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Bedside-monitor ("vc") skin for the admin shell: sidebar, hamburger
+ * header, sub-nav strip. DARK THEME ONLY — every rule is scoped to
+ * :root:not(.light), so users on the light theme keep the existing look
+ * until the aesthetic gets a designed light variant. Tokens come from
+ * src/styles/vc-tokens.css. Page CONTENT is untouched here; pages migrate
+ * to the aesthetic individually. */
+@import '../../styles/vc-tokens.css';
+
+/* ---------- Sidebar ---------- */
+:root:not(.light) .admin-v2-sidebar {
+  background: var(--vc-bg-base);
+  border-right: 1px solid var(--vc-line-hairline);
+}
+
+:root:not(.light) .admin-v2-logo-text {
+  font-family: var(--vc-font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+  white-space: nowrap;
+}
+
+:root:not(.light) .admin-v2-sidebar-header {
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+
+:root:not(.light) .admin-v2-sidebar-toggle {
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .admin-v2-sidebar-link {
+  font-family: var(--vc-font-sans);
+  color: var(--vc-text-secondary);
+  border-radius: 8px;
+}
+:root:not(.light) .admin-v2-sidebar-link:hover {
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-sidebar-link.active {
+  background: var(--vc-bg-surface);
+  color: var(--vc-data-live);
+  box-shadow: inset 2px 0 0 var(--vc-data-live);
+}
+
+:root:not(.light) .admin-v2-sidebar-footer {
+  border-top: 1px solid var(--vc-line-hairline);
+}
+:root:not(.light) .admin-v2-back-link {
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .admin-v2-back-link:hover {
+  color: var(--vc-text-primary);
+}
+
+/* ---------- Patient selector ---------- */
+:root:not(.light) .admin-v2-patient-selector-btn {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+}
+:root:not(.light) .admin-v2-patient-selector-btn:hover {
+  border-color: var(--vc-line-strong);
+  background: var(--vc-bg-surface);
+}
+:root:not(.light) .admin-v2-patient-selector-name {
+  font-family: var(--vc-font-mono);
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-patient-selector-meta {
+  color: var(--vc-text-tertiary);
+}
+:root:not(.light) .admin-v2-patient-selector-avatar {
+  background: var(--vc-bg-raised);
+  color: var(--vc-data-live);
+  font-family: var(--vc-font-mono);
+}
+:root:not(.light) .admin-v2-patient-dropdown {
+  background: var(--vc-bg-raised);
+  border: 1px solid var(--vc-line-strong);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+:root:not(.light) .admin-v2-patient-dropdown-item:hover {
+  background: var(--vc-bg-surface);
+}
+:root:not(.light) .admin-v2-patient-dropdown-item.selected {
+  color: var(--vc-data-live);
+}
+
+/* ---------- Mobile header (hamburger) ---------- */
+:root:not(.light) .admin-v2-mobile-header {
+  background: var(--vc-bg-surface);
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+:root:not(.light) .admin-v2-mobile-menu-btn {
+  background: transparent;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-mobile-header-title {
+  font-family: var(--vc-font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-sidebar-overlay {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+/* ---------- Sub-nav strip (Record | History …) ---------- */
+:root:not(.light) .admin-v2-topnav {
+  background: var(--vc-bg-base);
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+:root:not(.light) .admin-v2-topnav-link {
+  font-family: var(--vc-font-mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .admin-v2-topnav-link:hover {
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-topnav-link.active {
+  color: var(--vc-data-live);
+  border-bottom-color: var(--vc-data-live);
+}
+
+/* ---------- Restricted-mode banner ---------- */
+:root:not(.light) .admin-v2-restricted-banner {
+  background: transparent;
+  border-bottom: 1px solid var(--vc-line-hairline);
+  color: var(--vc-state-due);
+}
+:root:not(.light) .admin-v2-unlock-btn {
+  background: var(--vc-state-due);
+  border: none;
+  border-radius: 8px;
+  color: var(--vc-bg-base);
+  font-family: var(--vc-font-mono);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ---------- Content ground ---------- */
+:root:not(.light) .admin-v2-content {
+  background: var(--vc-bg-base);
+}

--- a/frontend/src/pages/capture/CaptureVitalsPanel.jsx
+++ b/frontend/src/pages/capture/CaptureVitalsPanel.jsx
@@ -18,12 +18,7 @@
 // The capture experience itself (grid, sheet, draft, save), shared by two
 // shells: the standalone phone surface at /capture and the embedded
 // admin-v2 vitals page at /care/vitals (inside the hamburger layout).
-import '@fontsource/ibm-plex-mono/300.css';
-import '@fontsource/ibm-plex-mono/400.css';
-import '@fontsource/ibm-plex-mono/500.css';
-import '@fontsource/ibm-plex-mono/600.css';
-import '@fontsource/ibm-plex-sans/400.css';
-import '@fontsource/ibm-plex-sans/500.css';
+import '../../styles/vcFonts';
 import './capture.css';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/frontend/src/pages/capture/capture.css
+++ b/frontend/src/pages/capture/capture.css
@@ -16,37 +16,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/* Vitals Capture design tokens. Every capture component reads from these;
- * no raw hex below the token block. Dark-only by design (bedside-monitor
- * surface) — the page root carries .vitals-capture. */
+/* Component styles for the vitals capture surface. The --vc-* tokens live in
+ * src/styles/vc-tokens.css (shared with the admin shell skin); nothing below
+ * uses raw hex. */
+@import '../../styles/vc-tokens.css';
+
 .vitals-capture,
 .vc-sheet,
 .vc-toast {
-  /* Surfaces */
-  --vc-bg-base: #0a0e14;
-  --vc-bg-surface: #131a24;
-  --vc-bg-raised: #1b242f;
-  --vc-bg-sheet: #161e29;
-
-  /* Lines */
-  --vc-line-hairline: rgba(255, 255, 255, 0.1);
-  --vc-line-strong: rgba(255, 255, 255, 0.2);
-
-  /* Text */
-  --vc-text-primary: #e8edf3;
-  --vc-text-secondary: #9aa8b8;
-  --vc-text-tertiary: #6b7987; /* decorative only — never sole carrier of meaning */
-
-  /* Semantic state — roles, not colors */
-  --vc-data-live: #2fc2e8;   /* live data, active focus, primary action */
-  --vc-state-complete: #3fbf6a;
-  --vc-state-due: #f0a52e;   /* needs confirmation */
-  --vc-state-alert: #f0563c; /* clinical concern only */
-  --vc-state-idle: #6b7987;
-
-  --vc-font-mono: 'IBM Plex Mono', ui-monospace, monospace;
-  --vc-font-sans: 'IBM Plex Sans', system-ui, sans-serif;
-
   font-family: var(--vc-font-sans);
   font-variant-numeric: tabular-nums;
   font-feature-settings: 'tnum';

--- a/frontend/src/styles/vc-tokens.css
+++ b/frontend/src/styles/vc-tokens.css
@@ -1,0 +1,48 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Bedside-monitor design tokens (the "vc" aesthetic), shared by the vitals
+ * capture surface and the admin shell skin — the app-wide look pages migrate
+ * toward. Dark-only by design; consumers scope themselves to the dark theme.
+ * No raw hex outside token files. */
+:root {
+  /* Surfaces */
+  --vc-bg-base: #0a0e14;
+  --vc-bg-surface: #131a24;
+  --vc-bg-raised: #1b242f;
+  --vc-bg-sheet: #161e29;
+
+  /* Lines */
+  --vc-line-hairline: rgba(255, 255, 255, 0.1);
+  --vc-line-strong: rgba(255, 255, 255, 0.2);
+
+  /* Text */
+  --vc-text-primary: #e8edf3;
+  --vc-text-secondary: #9aa8b8;
+  --vc-text-tertiary: #6b7987; /* decorative only — never sole carrier of meaning */
+
+  /* Semantic state — roles, not colors */
+  --vc-data-live: #2fc2e8;   /* live data, active focus, primary action */
+  --vc-state-complete: #3fbf6a;
+  --vc-state-due: #f0a52e;   /* needs confirmation / attention */
+  --vc-state-alert: #f0563c; /* clinical concern only */
+  --vc-state-idle: #6b7987;
+
+  --vc-font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+  --vc-font-sans: 'IBM Plex Sans', system-ui, sans-serif;
+}

--- a/frontend/src/styles/vcFonts.js
+++ b/frontend/src/styles/vcFonts.js
@@ -1,0 +1,28 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Single entry for the vc-aesthetic fonts (IBM Plex, self-hosted via
+// fontsource — no CDN). Import this module from any surface that uses the
+// --vc-* tokens; Vite dedupes it to one inclusion. Loaded unconditionally
+// on purpose: the capture surface is dark-only in BOTH app themes, so the
+// fonts are needed regardless, and woff2 subsets are small and cached.
+import '@fontsource/ibm-plex-mono/300.css';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@fontsource/ibm-plex-mono/600.css';
+import '@fontsource/ibm-plex-sans/400.css';
+import '@fontsource/ibm-plex-sans/500.css';


### PR DESCRIPTION
First step of moving the whole app to the capture surface's aesthetic:

- `--vc-*` tokens promoted to a shared `src/styles/vc-tokens.css` — capture components and the shell now read one palette
- New `vc-shell.css` skins the sidebar, hamburger header, patient selector, sub-nav strip, restricted banner, and content ground: hairline dividers instead of solid borders, IBM Plex Mono caps for the brand/page titles/tab strip, cyan active states with a left accent bar, vc surfaces throughout
- **Dark theme only**: every rule is scoped `:root:not(.light)`, so light-theme users see zero change until the aesthetic gets a designed light variant
- Page *content* is deliberately untouched — pages migrate individually (tracked in the follow-up epic)

Verified live on the dev stack at 390×844 (hamburger + drawer) and 1280×850 (sidebar); tests 353 green, lint (`--max-warnings 0`) and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS8WMSAiMKmozbMuwbiocw