### PR TITLE
Schedule adopts the bedside-monitor aesthetic (dark theme)

### DIFF
--- a/frontend/src/pages/admin-v2/AdminV2Schedule.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Schedule.jsx
@@ -56,6 +56,7 @@ import { Field, FormRow } from '@/components/ui/field';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import './AdminV2.css';
+import './vc-schedule.css'; // bedside-monitor skin (dark theme only)
 
 const AdminV2Schedule = () => {
   const { user } = useAuth();

--- a/frontend/src/pages/admin-v2/vc-schedule.css
+++ b/frontend/src/pages/admin-v2/vc-schedule.css
@@ -32,6 +32,7 @@
 }
 :root:not(.light) .admin-v2-schedule-date {
   font-family: var(--vc-font-mono);
+  font-variant-numeric: tabular-nums;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -49,6 +50,7 @@
   text-transform: uppercase;
 }
 :root:not(.light) .admin-v2-date-picker {
+  font-variant-numeric: tabular-nums;
   background: var(--vc-bg-raised);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 8px;

--- a/frontend/src/pages/admin-v2/vc-schedule.css
+++ b/frontend/src/pages/admin-v2/vc-schedule.css
@@ -1,0 +1,254 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Bedside-monitor ("vc") skin for the Schedule page. DARK THEME ONLY —
+ * scoped :root:not(.light), same convention as vc-shell/vc-dashboard.
+ *
+ * Semantics: in the 3-column grid the COLUMN identifies the category, so the
+ * per-type rainbow (salmon meds / green nutrition / purple tasks) neutralizes
+ * to state roles — complete green, NOW marker cyan, idle grays. Green stays
+ * the "done" signal only. */
+@import '../../styles/vc-tokens.css';
+
+/* ---------- Date nav ---------- */
+:root:not(.light) .admin-v2-schedule-nav {
+  background: var(--vc-bg-surface);
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+:root:not(.light) .admin-v2-schedule-date {
+  font-family: var(--vc-font-mono);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-today-badge {
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--vc-data-live) 45%, transparent);
+  border-radius: 999px;
+  color: var(--vc-data-live);
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+:root:not(.light) .admin-v2-date-picker {
+  background: var(--vc-bg-raised);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+}
+
+/* ---------- Stats row / mobile tabs ---------- */
+:root:not(.light) .admin-v2-schedule-stat-card {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  box-shadow: none;
+}
+:root:not(.light) .admin-v2-schedule-stat-card.active {
+  border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
+  box-shadow: inset 0 -2px 0 var(--vc-data-live);
+}
+:root:not(.light) .admin-v2-schedule-stat-card.active .admin-v2-stat-info h4 {
+  color: var(--vc-data-live);
+}
+
+/* ---------- Grid header ---------- */
+:root:not(.light) .admin-v2-schedule-header {
+  background: var(--vc-bg-surface);
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+:root:not(.light) .admin-v2-schedule-header .admin-v2-schedule-col,
+:root:not(.light) .admin-v2-schedule-header .admin-v2-schedule-col.medications,
+:root:not(.light) .admin-v2-schedule-header .admin-v2-schedule-col.nutrition,
+:root:not(.light) .admin-v2-schedule-header .admin-v2-schedule-col.tasks {
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+}
+:root:not(.light) .admin-v2-schedule-header .admin-v2-schedule-col-clickable:hover {
+  color: var(--vc-text-primary);
+}
+
+/* ---------- Hour rows ---------- */
+:root:not(.light) .admin-v2-schedule-row:hover {
+  background: var(--vc-bg-surface);
+}
+:root:not(.light) .admin-v2-schedule-time-col {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-left: 3px solid var(--vc-line-hairline);
+}
+:root:not(.light) .admin-v2-hour-label {
+  font-family: var(--vc-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--vc-text-tertiary);
+}
+:root:not(.light) .admin-v2-schedule-divider {
+  background: var(--vc-line-hairline);
+}
+
+/* NOW marker: live-cyan accent bar + tinted hour cell */
+:root:not(.light) .admin-v2-schedule-row.current-hour::before {
+  background: var(--vc-data-live);
+}
+:root:not(.light) .admin-v2-schedule-row.current-hour .admin-v2-schedule-time-col {
+  background: color-mix(in srgb, var(--vc-data-live) 10%, transparent);
+  border-left-color: var(--vc-data-live);
+}
+:root:not(.light) .admin-v2-schedule-row.current-hour .admin-v2-hour-label {
+  color: var(--vc-data-live);
+}
+
+/* ---------- Item groups: column position carries the category ---------- */
+:root:not(.light) .admin-v2-schedule-group,
+:root:not(.light) .admin-v2-schedule-group.medication,
+:root:not(.light) .admin-v2-schedule-group.nutrition,
+:root:not(.light) .admin-v2-schedule-group.care-task {
+  background: var(--vc-bg-raised);
+  border: 1px solid var(--vc-line-hairline);
+  border-left: 3px solid var(--vc-line-strong);
+  border-radius: 8px;
+}
+
+/* ---------- Items ---------- */
+:root:not(.light) .admin-v2-schedule-item.clickable:hover {
+  background: var(--vc-bg-surface);
+}
+:root:not(.light) .admin-v2-schedule-item-name {
+  font-family: var(--vc-font-sans);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-schedule-item-time {
+  font-family: var(--vc-font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .admin-v2-schedule-item-dose {
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .admin-v2-schedule-item-category {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Completed: green is the done-signal (tint + check), name dims */
+:root:not(.light) .admin-v2-schedule-item.completed {
+  background: color-mix(in srgb, var(--vc-state-complete) 10%, transparent);
+}
+:root:not(.light) .admin-v2-schedule-item.completed .admin-v2-schedule-item-name {
+  color: var(--vc-text-secondary);
+}
+
+/* Check control: dotted ring (not done) -> solid green (done) — the same
+ * shape+color signal as the capture tiles */
+:root:not(.light) .admin-v2-schedule-item-check {
+  border-radius: 50%;
+  border: 1.5px dotted var(--vc-state-idle);
+  background: transparent;
+}
+:root:not(.light) .admin-v2-schedule-item.clickable:hover .admin-v2-schedule-item-check {
+  border-style: solid;
+  border-color: var(--vc-state-complete);
+  color: color-mix(in srgb, var(--vc-state-complete) 55%, transparent);
+}
+:root:not(.light) .admin-v2-schedule-item-check.checked {
+  border-style: solid;
+  background: var(--vc-state-complete);
+  border-color: var(--vc-state-complete);
+  color: var(--vc-bg-base);
+}
+
+:root:not(.light) .admin-v2-schedule-item-undo {
+  background: transparent;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 6px;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .admin-v2-schedule-item-undo:hover {
+  border-color: var(--vc-line-strong);
+  color: var(--vc-text-primary);
+}
+
+/* ---------- PRN badge + buttons ---------- */
+:root:not(.light) .admin-v2-badge-prn {
+  background: transparent;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 999px;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+:root:not(.light) .admin-v2-schedule-prn-add {
+  background: transparent;
+  border: 1px dashed var(--vc-line-strong);
+  border-radius: 8px;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .admin-v2-schedule-prn-add:hover {
+  border-color: var(--vc-data-live);
+  color: var(--vc-data-live);
+}
+/* Floating "complete all in this hour" badge: neutral until hovered — a
+ * solid green circle on a pending group would read as already-done. */
+:root:not(.light) .admin-v2-schedule-complete-all {
+  background: var(--vc-bg-raised);
+  border: 1px solid var(--vc-line-strong);
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .admin-v2-schedule-complete-all:hover {
+  background: var(--vc-state-complete);
+  border-color: var(--vc-state-complete);
+  color: var(--vc-bg-base);
+}
+
+:root:not(.light) .admin-v2-schedule-complete-all .admin-v2-btn-primary,
+:root:not(.light) .admin-v2-schedule-nav .admin-v2-btn-primary {
+  background: var(--vc-data-live);
+  border-color: transparent;
+  color: var(--vc-bg-base);
+  font-family: var(--vc-font-mono);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 8px;
+}
+:root:not(.light) .admin-v2-schedule-nav .admin-v2-btn:not(.admin-v2-btn-primary) {
+  background: transparent;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-schedule-nav .admin-v2-btn:not(.admin-v2-btn-primary):hover {
+  border-color: var(--vc-line-strong);
+  background: var(--vc-bg-raised);
+}


### PR DESCRIPTION
Third slice of epic #100 (shell #99, dashboard #101): the Schedule page.

- Date nav, TODAY badge, stat/mobile tabs, grid headers, hour rows, item groups/items, PRN affordances and the undo control restyled from the shared `--vc-*` tokens (`vc-schedule.css`, scoped `:root:not(.light)` — light theme unchanged)
- **Semantics:** in the 3-column grid the column already identifies the category, so the per-type rainbow (salmon meds / green nutrition / purple tasks) neutralizes to state roles. User-configured care-task category colors are kept — that's data, not palette.
- NOW marker is live-cyan (accent bar, tinted hour cell, cyan hour label) — same role as the capture surface's live elements
- Completion follows the capture pattern: dotted ring = not done, solid green check = done, green tint on completed rows; the floating complete-all-in-hour badge is neutral until hovered (a solid green circle on a pending group read as already-done)

Verified live on the dev stack at 390 and 1380 widths with mocked /api/schedule/daily data exercising pending/completed across all three columns and the NOW hour. Tests 353 green, lint and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS8WMSAiMKmozbMuwbiocw