### PR TITLE
Care pages adopt the bedside-monitor aesthetic via a shared vocabulary skin

### DIFF
--- a/frontend/src/components/schedule/ScheduleList.jsx
+++ b/frontend/src/components/schedule/ScheduleList.jsx
@@ -64,38 +64,57 @@ const DEFAULT_FILTERS = {
   skipped: false,
 };
 
+// Status colors are applied as inline styles, so themes can't restyle them
+// with plain CSS overrides. Each value reads a --sched-* custom property with
+// the legacy bootstrap palette as the fallback: the light theme (which never
+// defines the vars) keeps today's look, while the vc dark skin defines them
+// from the shared tokens (see pages/admin-v2/vc-content.css).
+const themed = (group, fallback) => ({
+  bg: `var(--sched-${group}-bg, ${fallback.bg})`,
+  border: `var(--sched-${group}-border, ${fallback.border})`,
+  text: `var(--sched-${group}-text, ${fallback.text})`,
+});
+const STATUS_GROUPS = {
+  ontime: themed('ontime', { bg: '#d4edda', border: '#28a745', text: '#155724' }),
+  pending: themed('pending', { bg: '#d1ecf1', border: '#17a2b8', text: '#0c5460' }),
+  warning: themed('warning', { bg: '#fff3cd', border: '#ffc107', text: '#856404' }),
+  late: themed('late', { bg: '#f8d7da', border: '#dc3545', text: '#721c24' }),
+  completed: themed('completed', { bg: '#e8f5e8', border: '#28a745', text: '#155724' }),
+  skipped: themed('skipped', { bg: '#f8f9fa', border: '#6c757d', text: '#495057' }),
+};
+
 const FILTER_OPTIONS = [
-  { key: 'pending', label: 'Pending', color: '#17a2b8' },
-  { key: 'due_warning', label: 'Due Warning', color: '#ffc107' },
-  { key: 'due_on_time', label: 'Due On Time', color: '#28a745' },
-  { key: 'due_late', label: 'Due Late', color: '#dc3545' },
-  { key: 'upcoming', label: 'Upcoming', color: '#17a2b8' },
-  { key: 'missed', label: 'Missed', color: '#dc3545' },
-  { key: 'completed', label: 'Completed', color: '#28a745' },
-  { key: 'skipped', label: 'Skipped', color: '#6c757d' },
+  { key: 'pending', label: 'Pending', color: STATUS_GROUPS.pending.border },
+  { key: 'due_warning', label: 'Due Warning', color: STATUS_GROUPS.warning.border },
+  { key: 'due_on_time', label: 'Due On Time', color: STATUS_GROUPS.ontime.border },
+  { key: 'due_late', label: 'Due Late', color: STATUS_GROUPS.late.border },
+  { key: 'upcoming', label: 'Upcoming', color: STATUS_GROUPS.pending.border },
+  { key: 'missed', label: 'Missed', color: STATUS_GROUPS.late.border },
+  { key: 'completed', label: 'Completed', color: STATUS_GROUPS.completed.border },
+  { key: 'skipped', label: 'Skipped', color: STATUS_GROUPS.skipped.border },
 ];
 
 function getStatusColors(status) {
   switch (status) {
     case 'ready_to_take':
     case 'due_on_time':
-      return { bg: '#d4edda', border: '#28a745', text: '#155724' };
+      return STATUS_GROUPS.ontime;
     case 'upcoming':
     case 'pending':
-      return { bg: '#d1ecf1', border: '#17a2b8', text: '#0c5460' };
+      return STATUS_GROUPS.pending;
     case 'due_warning':
     case 'warning':
     case 'late_early':
-      return { bg: '#fff3cd', border: '#ffc107', text: '#856404' };
+      return STATUS_GROUPS.warning;
     case 'due_late':
     case 'missed':
-      return { bg: '#f8d7da', border: '#dc3545', text: '#721c24' };
+      return STATUS_GROUPS.late;
     case 'completed':
-      return { bg: '#e8f5e8', border: '#28a745', text: '#155724' };
+      return STATUS_GROUPS.completed;
     case 'skipped':
-      return { bg: '#f8f9fa', border: '#6c757d', text: '#495057' };
+      return STATUS_GROUPS.skipped;
     default:
-      return { bg: '#f8f9fa', border: '#6c757d', text: '#495057' };
+      return STATUS_GROUPS.skipped;
   }
 }
 
@@ -328,7 +347,8 @@ export default function ScheduleList({
                           }
                         }}
                         style={{
-                          background: '#007bff', color: '#fff', border: 'none',
+                          background: 'var(--sched-primary, #007bff)',
+                          color: 'var(--sched-primary-text, #fff)', border: 'none',
                           borderRadius: 12, padding: '8px 18px', fontWeight: 600,
                           fontSize: 14, cursor: 'pointer',
                         }}

--- a/frontend/src/pages/admin-v2/AdminV2CareTasksSchedule.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2CareTasksSchedule.jsx
@@ -142,13 +142,13 @@ const AdminV2CareTasksSchedule = () => {
   // Status helpers
   const getStatusInfo = (status) => {
     const statusMap = {
-      'pending': { label: 'Pending', color: '#1f6feb', bg: 'rgba(31, 111, 235, 0.15)', border: '#1f6feb' },
-      'due_warning': { label: 'Due Warning', color: '#9e6a03', bg: 'rgba(158, 106, 3, 0.15)', border: '#9e6a03' },
-      'due_on_time': { label: 'Due On Time', color: '#238636', bg: 'rgba(35, 134, 54, 0.15)', border: '#238636' },
-      'due_late': { label: 'Due Late', color: '#f85149', bg: 'rgba(248, 81, 73, 0.15)', border: '#f85149' },
-      'upcoming': { label: 'Upcoming', color: '#58a6ff', bg: 'rgba(88, 166, 255, 0.15)', border: '#58a6ff' },
-      'missed': { label: 'Missed', color: '#f85149', bg: 'rgba(248, 81, 73, 0.15)', border: '#f85149' },
-      'completed': { label: 'Completed', color: '#238636', bg: 'rgba(35, 134, 54, 0.15)', border: '#238636' },
+      'pending': { label: 'Pending', color: 'var(--sched-pending-border, #1f6feb)', bg: 'var(--sched-pending-chip, rgba(31, 111, 235, 0.15))', border: 'var(--sched-pending-border, #1f6feb)' },
+      'due_warning': { label: 'Due Warning', color: 'var(--sched-warning-border, #9e6a03)', bg: 'rgba(158, 106, 3, 0.15)', border: 'var(--sched-warning-border, #9e6a03)' },
+      'due_on_time': { label: 'Due On Time', color: 'var(--sched-completed-border, #238636)', bg: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))', border: 'var(--sched-completed-border, #238636)' },
+      'due_late': { label: 'Due Late', color: 'var(--sched-late-border, #f85149)', bg: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))', border: 'var(--sched-late-border, #f85149)' },
+      'upcoming': { label: 'Upcoming', color: 'var(--sched-ontime-border, #58a6ff)', bg: 'var(--sched-ontime-chip, rgba(88, 166, 255, 0.15))', border: 'var(--sched-ontime-border, #58a6ff)' },
+      'missed': { label: 'Missed', color: 'var(--sched-late-border, #f85149)', bg: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))', border: 'var(--sched-late-border, #f85149)' },
+      'completed': { label: 'Completed', color: 'var(--sched-completed-border, #238636)', bg: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))', border: 'var(--sched-completed-border, #238636)' },
       'skipped': { label: 'Skipped', color: 'var(--muted-foreground)', bg: 'rgba(139, 148, 158, 0.15)', border: 'var(--muted-foreground)' }
     };
     return statusMap[status] || statusMap.upcoming;
@@ -325,7 +325,7 @@ const AdminV2CareTasksSchedule = () => {
                 }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(35, 134, 54, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))' }}>
                   <ClockIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -342,7 +342,7 @@ const AdminV2CareTasksSchedule = () => {
                 }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(88, 166, 255, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-ontime-chip, rgba(88, 166, 255, 0.15))' }}>
                   <ClockIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -355,7 +355,7 @@ const AdminV2CareTasksSchedule = () => {
                 onClick={() => setStatusFilters(f => ({ ...f, missed: !f.missed }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(248, 81, 73, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))' }}>
                   <XIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -368,7 +368,7 @@ const AdminV2CareTasksSchedule = () => {
                 onClick={() => setStatusFilters(f => ({ ...f, completed: !f.completed }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(35, 134, 54, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))' }}>
                   <CheckIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -535,19 +535,19 @@ const AdminV2CareTasksSchedule = () => {
               <h4>Status Legend</h4>
               <div className="admin-v2-legend-items">
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#238636' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-completed-border, #238636)' }}></span>
                   <span>Due On Time</span>
                 </div>
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#9e6a03' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-warning-border, #9e6a03)' }}></span>
                   <span>Due Warning</span>
                 </div>
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#f85149' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-late-border, #f85149)' }}></span>
                   <span>Due Late / Missed</span>
                 </div>
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#58a6ff' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-ontime-border, #58a6ff)' }}></span>
                   <span>Upcoming</span>
                 </div>
                 <div className="admin-v2-legend-item">

--- a/frontend/src/pages/admin-v2/AdminV2CareTasksSchedule.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2CareTasksSchedule.jsx
@@ -143,13 +143,13 @@ const AdminV2CareTasksSchedule = () => {
   const getStatusInfo = (status) => {
     const statusMap = {
       'pending': { label: 'Pending', color: 'var(--sched-pending-border, #1f6feb)', bg: 'var(--sched-pending-chip, rgba(31, 111, 235, 0.15))', border: 'var(--sched-pending-border, #1f6feb)' },
-      'due_warning': { label: 'Due Warning', color: 'var(--sched-warning-border, #9e6a03)', bg: 'rgba(158, 106, 3, 0.15)', border: 'var(--sched-warning-border, #9e6a03)' },
-      'due_on_time': { label: 'Due On Time', color: 'var(--sched-completed-border, #238636)', bg: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))', border: 'var(--sched-completed-border, #238636)' },
+      'due_warning': { label: 'Due Warning', color: 'var(--sched-warning-border, #9e6a03)', bg: 'var(--sched-warning-chip, rgba(158, 106, 3, 0.15))', border: 'var(--sched-warning-border, #9e6a03)' },
+      'due_on_time': { label: 'Due On Time', color: 'var(--sched-ontime-border, #238636)', bg: 'var(--sched-ontime-chip, rgba(35, 134, 54, 0.15))', border: 'var(--sched-ontime-border, #238636)' },
       'due_late': { label: 'Due Late', color: 'var(--sched-late-border, #f85149)', bg: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))', border: 'var(--sched-late-border, #f85149)' },
-      'upcoming': { label: 'Upcoming', color: 'var(--sched-ontime-border, #58a6ff)', bg: 'var(--sched-ontime-chip, rgba(88, 166, 255, 0.15))', border: 'var(--sched-ontime-border, #58a6ff)' },
+      'upcoming': { label: 'Upcoming', color: 'var(--sched-pending-border, #58a6ff)', bg: 'var(--sched-pending-chip, rgba(88, 166, 255, 0.15))', border: 'var(--sched-pending-border, #58a6ff)' },
       'missed': { label: 'Missed', color: 'var(--sched-late-border, #f85149)', bg: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))', border: 'var(--sched-late-border, #f85149)' },
       'completed': { label: 'Completed', color: 'var(--sched-completed-border, #238636)', bg: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))', border: 'var(--sched-completed-border, #238636)' },
-      'skipped': { label: 'Skipped', color: 'var(--muted-foreground)', bg: 'rgba(139, 148, 158, 0.15)', border: 'var(--muted-foreground)' }
+      'skipped': { label: 'Skipped', color: 'var(--muted-foreground)', bg: 'var(--sched-skipped-chip, rgba(139, 148, 158, 0.15))', border: 'var(--muted-foreground)' }
     };
     return statusMap[status] || statusMap.upcoming;
   };
@@ -325,7 +325,7 @@ const AdminV2CareTasksSchedule = () => {
                 }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-ontime-chip, rgba(35, 134, 54, 0.15))' }}>
                   <ClockIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -535,7 +535,7 @@ const AdminV2CareTasksSchedule = () => {
               <h4>Status Legend</h4>
               <div className="admin-v2-legend-items">
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-completed-border, #238636)' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-ontime-border, #238636)' }}></span>
                   <span>Due On Time</span>
                 </div>
                 <div className="admin-v2-legend-item">

--- a/frontend/src/pages/admin-v2/AdminV2Layout.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Layout.jsx
@@ -59,6 +59,7 @@ import './AdminV2.css';
 // with the capture surface). Loaded after AdminV2.css so overrides win.
 import '../../styles/vcFonts';
 import './vc-shell.css';
+import './vc-content.css';
 
 // Side navigation items - main app sections
 const sideNavItems = [

--- a/frontend/src/pages/admin-v2/AdminV2MedicationsSchedule.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MedicationsSchedule.jsx
@@ -145,12 +145,12 @@ const AdminV2MedicationsSchedule = () => {
     const statusMap = {
       'on_time': { label: 'On Time', color: 'var(--sched-completed-border, #238636)', bg: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))', border: 'var(--sched-completed-border, #238636)' },
       'completed': { label: 'Completed', color: 'var(--sched-completed-border, #238636)', bg: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))', border: 'var(--sched-completed-border, #238636)' },
-      'warning': { label: 'Warning', color: 'var(--sched-warning-border, #9e6a03)', bg: 'rgba(158, 106, 3, 0.15)', border: 'var(--sched-warning-border, #9e6a03)' },
+      'warning': { label: 'Warning', color: 'var(--sched-warning-border, #9e6a03)', bg: 'var(--sched-warning-chip, rgba(158, 106, 3, 0.15))', border: 'var(--sched-warning-border, #9e6a03)' },
       'late_early': { label: 'Late/Early', color: 'var(--sched-late-border, #f85149)', bg: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))', border: 'var(--sched-late-border, #f85149)' },
       'missed': { label: 'Missed', color: 'var(--sched-late-border, #f85149)', bg: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))', border: 'var(--sched-late-border, #f85149)' },
       'upcoming': { label: 'Upcoming', color: 'var(--sched-pending-border, #1f6feb)', bg: 'var(--sched-pending-chip, rgba(31, 111, 235, 0.15))', border: 'var(--sched-pending-border, #1f6feb)' },
       'ready': { label: 'Ready', color: 'var(--sched-ontime-border, #58a6ff)', bg: 'var(--sched-ontime-chip, rgba(88, 166, 255, 0.15))', border: 'var(--sched-ontime-border, #58a6ff)' },
-      'skipped': { label: 'Skipped', color: 'var(--muted-foreground)', bg: 'rgba(139, 148, 158, 0.15)', border: 'var(--muted-foreground)' }
+      'skipped': { label: 'Skipped', color: 'var(--muted-foreground)', bg: 'var(--sched-skipped-chip, rgba(139, 148, 158, 0.15))', border: 'var(--muted-foreground)' }
     };
     return statusMap[status] || statusMap.upcoming;
   };

--- a/frontend/src/pages/admin-v2/AdminV2MedicationsSchedule.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MedicationsSchedule.jsx
@@ -143,13 +143,13 @@ const AdminV2MedicationsSchedule = () => {
   // Status helpers
   const getStatusInfo = (status) => {
     const statusMap = {
-      'on_time': { label: 'On Time', color: '#238636', bg: 'rgba(35, 134, 54, 0.15)', border: '#238636' },
-      'completed': { label: 'Completed', color: '#238636', bg: 'rgba(35, 134, 54, 0.15)', border: '#238636' },
-      'warning': { label: 'Warning', color: '#9e6a03', bg: 'rgba(158, 106, 3, 0.15)', border: '#9e6a03' },
-      'late_early': { label: 'Late/Early', color: '#f85149', bg: 'rgba(248, 81, 73, 0.15)', border: '#f85149' },
-      'missed': { label: 'Missed', color: '#f85149', bg: 'rgba(248, 81, 73, 0.15)', border: '#f85149' },
-      'upcoming': { label: 'Upcoming', color: '#1f6feb', bg: 'rgba(31, 111, 235, 0.15)', border: '#1f6feb' },
-      'ready': { label: 'Ready', color: '#58a6ff', bg: 'rgba(88, 166, 255, 0.15)', border: '#58a6ff' },
+      'on_time': { label: 'On Time', color: 'var(--sched-completed-border, #238636)', bg: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))', border: 'var(--sched-completed-border, #238636)' },
+      'completed': { label: 'Completed', color: 'var(--sched-completed-border, #238636)', bg: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))', border: 'var(--sched-completed-border, #238636)' },
+      'warning': { label: 'Warning', color: 'var(--sched-warning-border, #9e6a03)', bg: 'rgba(158, 106, 3, 0.15)', border: 'var(--sched-warning-border, #9e6a03)' },
+      'late_early': { label: 'Late/Early', color: 'var(--sched-late-border, #f85149)', bg: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))', border: 'var(--sched-late-border, #f85149)' },
+      'missed': { label: 'Missed', color: 'var(--sched-late-border, #f85149)', bg: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))', border: 'var(--sched-late-border, #f85149)' },
+      'upcoming': { label: 'Upcoming', color: 'var(--sched-pending-border, #1f6feb)', bg: 'var(--sched-pending-chip, rgba(31, 111, 235, 0.15))', border: 'var(--sched-pending-border, #1f6feb)' },
+      'ready': { label: 'Ready', color: 'var(--sched-ontime-border, #58a6ff)', bg: 'var(--sched-ontime-chip, rgba(88, 166, 255, 0.15))', border: 'var(--sched-ontime-border, #58a6ff)' },
       'skipped': { label: 'Skipped', color: 'var(--muted-foreground)', bg: 'rgba(139, 148, 158, 0.15)', border: 'var(--muted-foreground)' }
     };
     return statusMap[status] || statusMap.upcoming;
@@ -360,7 +360,7 @@ const AdminV2MedicationsSchedule = () => {
                 onClick={() => setStatusFilters(f => ({ ...f, ready: !f.ready }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(88, 166, 255, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-ontime-chip, rgba(88, 166, 255, 0.15))' }}>
                   <ClockIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -373,7 +373,7 @@ const AdminV2MedicationsSchedule = () => {
                 onClick={() => setStatusFilters(f => ({ ...f, upcoming: !f.upcoming }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(31, 111, 235, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-pending-chip, rgba(31, 111, 235, 0.15))' }}>
                   <ClockIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -386,7 +386,7 @@ const AdminV2MedicationsSchedule = () => {
                 onClick={() => setStatusFilters(f => ({ ...f, missed: !f.missed }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(248, 81, 73, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))' }}>
                   <XIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -399,7 +399,7 @@ const AdminV2MedicationsSchedule = () => {
                 onClick={() => setStatusFilters(f => ({ ...f, completed: !f.completed }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(35, 134, 54, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))' }}>
                   <CheckIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -545,19 +545,19 @@ const AdminV2MedicationsSchedule = () => {
               <h4>Status Legend</h4>
               <div className="admin-v2-legend-items">
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#58a6ff' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-ontime-border, #58a6ff)' }}></span>
                   <span>Ready to Take</span>
                 </div>
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#1f6feb' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-pending-border, #1f6feb)' }}></span>
                   <span>Upcoming</span>
                 </div>
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#f85149' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-late-border, #f85149)' }}></span>
                   <span>Missed</span>
                 </div>
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#238636' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-completed-border, #238636)' }}></span>
                   <span>Completed</span>
                 </div>
                 <div className="admin-v2-legend-item">

--- a/frontend/src/pages/admin-v2/AdminV2NutritionSchedule.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2NutritionSchedule.jsx
@@ -174,10 +174,10 @@ const AdminV2NutritionSchedule = () => {
   // Status display helpers (same palette as the meds schedule page)
   const getStatusInfo = (bucket) => {
     const statusMap = {
-      'completed': { label: 'Completed', color: '#238636', bg: 'rgba(35, 134, 54, 0.15)', border: '#238636' },
-      'missed': { label: 'Missed', color: '#f85149', bg: 'rgba(248, 81, 73, 0.15)', border: '#f85149' },
-      'upcoming': { label: 'Upcoming', color: '#1f6feb', bg: 'rgba(31, 111, 235, 0.15)', border: '#1f6feb' },
-      'ready': { label: 'Ready', color: '#58a6ff', bg: 'rgba(88, 166, 255, 0.15)', border: '#58a6ff' }
+      'completed': { label: 'Completed', color: 'var(--sched-completed-border, #238636)', bg: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))', border: 'var(--sched-completed-border, #238636)' },
+      'missed': { label: 'Missed', color: 'var(--sched-late-border, #f85149)', bg: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))', border: 'var(--sched-late-border, #f85149)' },
+      'upcoming': { label: 'Upcoming', color: 'var(--sched-pending-border, #1f6feb)', bg: 'var(--sched-pending-chip, rgba(31, 111, 235, 0.15))', border: 'var(--sched-pending-border, #1f6feb)' },
+      'ready': { label: 'Ready', color: 'var(--sched-ontime-border, #58a6ff)', bg: 'var(--sched-ontime-chip, rgba(88, 166, 255, 0.15))', border: 'var(--sched-ontime-border, #58a6ff)' }
     };
     return statusMap[bucket] || statusMap.upcoming;
   };
@@ -317,7 +317,7 @@ const AdminV2NutritionSchedule = () => {
                 onClick={() => setStatusFilters(f => ({ ...f, ready: !f.ready }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(88, 166, 255, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-ontime-chip, rgba(88, 166, 255, 0.15))' }}>
                   <ClockIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -330,7 +330,7 @@ const AdminV2NutritionSchedule = () => {
                 onClick={() => setStatusFilters(f => ({ ...f, upcoming: !f.upcoming }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(31, 111, 235, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-pending-chip, rgba(31, 111, 235, 0.15))' }}>
                   <ClockIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -343,7 +343,7 @@ const AdminV2NutritionSchedule = () => {
                 onClick={() => setStatusFilters(f => ({ ...f, missed: !f.missed }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(248, 81, 73, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-late-chip, rgba(248, 81, 73, 0.15))' }}>
                   <XIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -356,7 +356,7 @@ const AdminV2NutritionSchedule = () => {
                 onClick={() => setStatusFilters(f => ({ ...f, completed: !f.completed }))}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(35, 134, 54, 0.15)' }}>
+                <div className="admin-v2-stat-icon" style={{ background: 'var(--sched-completed-chip, rgba(35, 134, 54, 0.15))' }}>
                   <CheckIcon size={20} />
                 </div>
                 <div className="admin-v2-stat-info">
@@ -489,19 +489,19 @@ const AdminV2NutritionSchedule = () => {
               <h4>Status Legend</h4>
               <div className="admin-v2-legend-items">
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#58a6ff' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-ontime-border, #58a6ff)' }}></span>
                   <span>Ready</span>
                 </div>
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#1f6feb' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-pending-border, #1f6feb)' }}></span>
                   <span>Upcoming</span>
                 </div>
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#f85149' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-late-border, #f85149)' }}></span>
                   <span>Missed</span>
                 </div>
                 <div className="admin-v2-legend-item">
-                  <span className="admin-v2-legend-dot" style={{ backgroundColor: '#238636' }}></span>
+                  <span className="admin-v2-legend-dot" style={{ backgroundColor: 'var(--sched-completed-border, #238636)' }}></span>
                   <span>Completed</span>
                 </div>
               </div>

--- a/frontend/src/pages/admin-v2/vc-content.css
+++ b/frontend/src/pages/admin-v2/vc-content.css
@@ -97,8 +97,10 @@
 :root:not(.light) {
   --sched-ontime-chip: color-mix(in srgb, var(--vc-state-due) 15%, transparent);
   --sched-pending-chip: var(--vc-bg-raised);
+  --sched-warning-chip: color-mix(in srgb, var(--vc-state-due) 20%, transparent);
   --sched-late-chip: color-mix(in srgb, var(--vc-state-due) 25%, transparent);
   --sched-completed-chip: color-mix(in srgb, var(--vc-state-complete) 15%, transparent);
+  --sched-skipped-chip: var(--vc-bg-surface);
 }
 
 /* ---------- Page headers / sections ---------- */

--- a/frontend/src/pages/admin-v2/vc-content.css
+++ b/frontend/src/pages/admin-v2/vc-content.css
@@ -1,0 +1,365 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Bedside-monitor ("vc") skin for the SHARED admin content vocabulary:
+ * tables, stat/filter cards, action buttons, badges, list cards, day
+ * pickers, progress bars, page headers and the shared ScheduleList status
+ * palette. Loaded by AdminV2Layout, so every admin page using these
+ * classes picks it up — the medications / care-tasks / nutrition families
+ * are built almost entirely from them.
+ *
+ * DARK THEME ONLY (scoped :root:not(.light)). Tokens from
+ * src/styles/vc-tokens.css; no raw hex.
+ *
+ * Color roles: schedule adherence is NEVER red — due/late/missed are
+ * amber (--vc-state-due); green means done/active; cyan is the live or
+ * primary-action accent; red stays for clinical concern and destructive
+ * actions. */
+@import '../../styles/vc-tokens.css';
+
+/* ---------- ScheduleList status palette (consumed as inline-style vars) ---------- */
+:root:not(.light) {
+  --sched-ontime-bg: color-mix(in srgb, var(--vc-state-due) 8%, var(--vc-bg-raised));
+  --sched-ontime-border: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
+  --sched-ontime-text: var(--vc-text-primary);
+
+  --sched-pending-bg: var(--vc-bg-raised);
+  --sched-pending-border: var(--vc-line-strong);
+  --sched-pending-text: var(--vc-text-primary);
+
+  --sched-warning-bg: color-mix(in srgb, var(--vc-state-due) 12%, var(--vc-bg-raised));
+  --sched-warning-border: color-mix(in srgb, var(--vc-state-due) 70%, transparent);
+  --sched-warning-text: var(--vc-text-primary);
+
+  --sched-late-bg: color-mix(in srgb, var(--vc-state-due) 18%, var(--vc-bg-raised));
+  --sched-late-border: var(--vc-state-due);
+  --sched-late-text: var(--vc-text-primary);
+
+  --sched-completed-bg: color-mix(in srgb, var(--vc-state-complete) 10%, var(--vc-bg-raised));
+  --sched-completed-border: color-mix(in srgb, var(--vc-state-complete) 55%, transparent);
+  --sched-completed-text: var(--vc-text-secondary);
+
+  --sched-skipped-bg: var(--vc-bg-surface);
+  --sched-skipped-border: var(--vc-line-hairline);
+  --sched-skipped-text: var(--vc-text-tertiary);
+
+  --sched-primary: var(--vc-data-live);
+  --sched-primary-text: var(--vc-bg-base);
+}
+
+/* ---------- shadcn (.tw) island token remap ---------- */
+/* Everything built from the ui/ primitives — buttons, cards, dialogs,
+ * selects — re-reads its palette from the vc tokens in dark theme. Scoped
+ * to the islands and the Radix portal slots, NOT :root, so legacy CSS that
+ * reads the same var names keeps the old palette until its page is skinned. */
+:root:not(.light) .tw,
+:root:not(.light) [data-slot='dialog-content'],
+:root:not(.light) [data-slot='select-content'] {
+  --background: var(--vc-bg-base);
+  --foreground: var(--vc-text-primary);
+  --card: var(--vc-bg-surface);
+  --card-foreground: var(--vc-text-primary);
+  --popover: var(--vc-bg-raised);
+  --popover-foreground: var(--vc-text-primary);
+  --primary: var(--vc-data-live);
+  --primary-foreground: var(--vc-bg-base);
+  --secondary: var(--vc-bg-raised);
+  --secondary-foreground: var(--vc-text-primary);
+  --muted: var(--vc-bg-raised);
+  --muted-foreground: var(--vc-text-secondary);
+  --accent: var(--vc-bg-raised);
+  --accent-foreground: var(--vc-text-primary);
+  --success: var(--vc-state-complete);
+  --warning: var(--vc-state-due);
+  --warning-foreground: var(--vc-bg-base);
+  --border: var(--vc-line-strong);
+  --input: var(--vc-line-strong);
+  --ring: var(--vc-data-live);
+}
+
+/* Legend dots / stat-icon chips on the schedule pages consume these as
+ * inline-style vars (bootstrap-ish fallbacks keep the light theme). */
+:root:not(.light) {
+  --sched-ontime-chip: color-mix(in srgb, var(--vc-state-due) 15%, transparent);
+  --sched-pending-chip: var(--vc-bg-raised);
+  --sched-late-chip: color-mix(in srgb, var(--vc-state-due) 25%, transparent);
+  --sched-completed-chip: color-mix(in srgb, var(--vc-state-complete) 15%, transparent);
+}
+
+/* ---------- Page headers / sections ---------- */
+:root:not(.light) .admin-v2-page-header h1,
+:root:not(.light) .admin-v2-section-title {
+  font-family: var(--vc-font-mono);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-text-muted { color: var(--vc-text-secondary); }
+:root:not(.light) .admin-v2-loading,
+:root:not(.light) .admin-v2-empty-state,
+:root:not(.light) .admin-v2-no-patient { color: var(--vc-text-secondary); }
+
+/* ---------- Tables ---------- */
+:root:not(.light) .admin-v2-table-container {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  box-shadow: none;
+}
+:root:not(.light) .admin-v2-table th {
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--vc-line-strong);
+}
+:root:not(.light) .admin-v2-table td {
+  border-bottom: 1px solid var(--vc-line-hairline);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-table tr:hover { background: var(--vc-bg-raised); }
+:root:not(.light) .admin-v2-table tr.inactive-row td { color: var(--vc-text-tertiary); }
+
+/* ---------- Stat cards as filter chips ---------- */
+:root:not(.light) .admin-v2-stat-card.selected {
+  border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
+  box-shadow: inset 0 -2px 0 var(--vc-data-live);
+}
+:root:not(.light) .admin-v2-stat-card.selected .admin-v2-stat-info h4 {
+  color: var(--vc-data-live);
+}
+
+/* ---------- Action buttons (table row + card controls) ---------- */
+:root:not(.light) .admin-v2-action-btn {
+  background: transparent;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .admin-v2-action-btn:hover {
+  border-color: var(--vc-line-strong);
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-action-btn-delete:hover {
+  border-color: color-mix(in srgb, var(--vc-state-alert) 60%, transparent);
+  color: var(--vc-state-alert);
+}
+:root:not(.light) .admin-v2-action-btn-success:hover,
+:root:not(.light) .admin-v2-action-btn.resume:hover {
+  border-color: color-mix(in srgb, var(--vc-state-complete) 60%, transparent);
+  color: var(--vc-state-complete);
+}
+:root:not(.light) .admin-v2-action-btn-warning:hover,
+:root:not(.light) .admin-v2-action-btn.pause:hover {
+  border-color: color-mix(in srgb, var(--vc-state-due) 60%, transparent);
+  color: var(--vc-state-due);
+}
+
+/* ---------- Buttons ---------- */
+:root:not(.light) .admin-v2-btn {
+  border-radius: 8px;
+  font-family: var(--vc-font-mono);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+:root:not(.light) .admin-v2-btn-primary {
+  background: var(--vc-data-live);
+  border-color: transparent;
+  color: var(--vc-bg-base);
+}
+:root:not(.light) .admin-v2-btn-primary:hover {
+  background: color-mix(in srgb, var(--vc-data-live) 85%, var(--vc-text-primary));
+}
+:root:not(.light) .admin-v2-btn-secondary,
+:root:not(.light) .admin-v2-btn-ghost {
+  background: transparent;
+  border: 1px solid var(--vc-line-strong);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-btn-secondary:hover,
+:root:not(.light) .admin-v2-btn-ghost:hover { background: var(--vc-bg-raised); }
+:root:not(.light) .admin-v2-btn-danger {
+  background: var(--vc-state-alert);
+  border-color: transparent;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-btn-danger-ghost {
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
+  color: var(--vc-state-alert);
+}
+
+/* ---------- Badges: outline pills, roles not rainbow ---------- */
+:root:not(.light) .admin-v2-badge {
+  background: transparent;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 999px;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+:root:not(.light) .admin-v2-badge-success {
+  border-color: color-mix(in srgb, var(--vc-state-complete) 50%, transparent);
+  color: var(--vc-state-complete);
+}
+:root:not(.light) .admin-v2-badge-warning {
+  border-color: color-mix(in srgb, var(--vc-state-due) 50%, transparent);
+  color: var(--vc-state-due);
+}
+:root:not(.light) .admin-v2-badge-danger,
+:root:not(.light) .admin-v2-badge-critical {
+  border-color: color-mix(in srgb, var(--vc-state-alert) 50%, transparent);
+  color: var(--vc-state-alert);
+}
+:root:not(.light) .admin-v2-badge-info,
+:root:not(.light) .admin-v2-badge-primary {
+  border-color: color-mix(in srgb, var(--vc-data-live) 50%, transparent);
+  color: var(--vc-data-live);
+}
+:root:not(.light) .admin-v2-badge-secondary,
+:root:not(.light) .admin-v2-badge-muted {
+  border-color: var(--vc-line-hairline);
+  color: var(--vc-text-tertiary);
+}
+
+/* Active/inactive status pills (meds, schedules, tasks) — dot + outline */
+:root:not(.light) .admin-v2-status-badge {
+  background: transparent;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 999px;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+:root:not(.light) .admin-v2-status-badge::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+:root:not(.light) .admin-v2-status-badge.active {
+  color: var(--vc-state-complete);
+  border-color: color-mix(in srgb, var(--vc-state-complete) 45%, transparent);
+}
+:root:not(.light) .admin-v2-status-badge.inactive {
+  color: var(--vc-text-tertiary);
+  border-color: var(--vc-line-hairline);
+}
+
+/* History dose-status badges: 'danger' here means a LATE dose — schedule
+ * adherence, so amber, not red. */
+:root:not(.light) .history-status-badge {
+  border-radius: 999px;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+:root:not(.light) .history-status-badge.success {
+  background: color-mix(in srgb, var(--vc-state-complete) 14%, transparent);
+  color: var(--vc-state-complete);
+}
+:root:not(.light) .history-status-badge.warning {
+  background: color-mix(in srgb, var(--vc-state-due) 14%, transparent);
+  color: var(--vc-state-due);
+}
+:root:not(.light) .history-status-badge.danger {
+  background: color-mix(in srgb, var(--vc-state-due) 22%, transparent);
+  color: var(--vc-state-due);
+}
+:root:not(.light) .history-status-badge.muted {
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-tertiary);
+}
+
+/* ---------- List cards (manage pages) ---------- */
+:root:not(.light) .admin-v2-med-card {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  box-shadow: none;
+}
+:root:not(.light) .admin-v2-med-card-inactive { opacity: 0.65; }
+:root:not(.light) .admin-v2-med-card-label {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* ---------- Filters / day picker ---------- */
+:root:not(.light) .admin-v2-filter-card {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+}
+:root:not(.light) .admin-v2-day-btn {
+  background: transparent;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+}
+:root:not(.light) .admin-v2-day-btn:hover { border-color: var(--vc-line-strong); }
+:root:not(.light) .admin-v2-day-btn.selected {
+  background: color-mix(in srgb, var(--vc-data-live) 15%, transparent);
+  border-color: var(--vc-data-live);
+  color: var(--vc-data-live);
+}
+
+/* ---------- Schedule summary cards + legend + progress ---------- */
+:root:not(.light) .admin-v2-schedule-summary-card {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+}
+:root:not(.light) .admin-v2-schedule-summary-title {
+  font-family: var(--vc-font-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-schedule-summary-detail { color: var(--vc-text-secondary); }
+:root:not(.light) .admin-v2-schedule-legend {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+}
+:root:not(.light) .admin-v2-legend-item { color: var(--vc-text-secondary); }
+:root:not(.light) .admin-v2-schedule-progress-bar.success { background: var(--vc-state-complete); }
+:root:not(.light) .admin-v2-schedule-progress-bar.good { background: var(--vc-data-live); }
+:root:not(.light) .admin-v2-schedule-progress-bar.warning { background: var(--vc-state-due); }


### PR DESCRIPTION
Fourth slice of epic #100, covering the medications / care-tasks / nutrition families by skinning what they share instead of page-by-page:

- **`vc-content.css`** (loaded by the layout, so all admin pages benefit): tables, stat/filter cards, action buttons, badges and active/inactive status pills (outline + dot), med list cards, day picker, schedule summary cards/legend/progress bars, page headers and empty states. Dark-theme scoped as always.
- **shadcn `.tw` island token remap** (the epic's blanket item): `--primary` & co. re-read from vc tokens inside the islands and Radix portals — every ui/ Button/Card/Dialog/Select goes cyan-primary in dark theme in one move. Scoped to the islands, NOT `:root`, so legacy CSS reading the same var names is unaffected.
- **ScheduleList made themeable**: its status colors were hardcoded bootstrap pastels in inline styles (unreachable by CSS). They now read `--sched-*` vars with the legacy palette as fallback — light theme byte-identical, dark theme maps adherence to roles: due/late/missed = amber (never red), completed = green, pending = idle. Same var()-with-fallback treatment for the schedule pages' inline legend dots and stat chips.
- History dose badges: `danger` there means a **Late** dose — adherence, so amber.

Verified live (Elijah, dark, 1380/390): manage table, filter chips, legend/stat chips, buttons; ScheduleList palette exercised via the legend vars. Tests 353 green, lint and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS8WMSAiMKmozbMuwbiocw