### PR TITLE
Grouped navigation: full-viewport mobile drawer + sectioned sidebar

### DIFF
--- a/frontend/src/components/ConnectionChip.jsx
+++ b/frontend/src/components/ConnectionChip.jsx
@@ -1,0 +1,35 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// CONNECTED · SYNCED status chip (honest: green only while the hub answers
+// the liveness probe). Pairs with src/hooks/useConnectionStatus.
+import './connection-chip.css';
+
+export default function ConnectionChip({ connection }) {
+  const { connected, lastSuccess } = connection;
+  const stamp = lastSuccess
+    ? lastSuccess.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    : null;
+  return (
+    <span className={`vc-chip ${connected ? '' : 'offline'}`}>
+      <span className="vc-chip-dot" aria-hidden="true" />
+      {connected
+        ? `Connected${stamp ? ` · Synced ${stamp}` : ''}`
+        : `Offline${stamp ? ` · Last synced ${stamp}` : ''}`}
+    </span>
+  );
+}

--- a/frontend/src/components/ConnectionChip.jsx
+++ b/frontend/src/components/ConnectionChip.jsx
@@ -19,17 +19,24 @@
 // the liveness probe). Pairs with src/hooks/useConnectionStatus.
 import './connection-chip.css';
 
-export default function ConnectionChip({ connection }) {
+export default function ConnectionChip({ connection, stacked = false }) {
   const { connected, lastSuccess } = connection;
   const stamp = lastSuccess
     ? lastSuccess.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
     : null;
+  const stateWord = connected ? 'Connected' : 'Offline';
+  const syncLine = stamp ? `${connected ? 'Synced' : 'Last synced'} ${stamp}` : null;
   return (
-    <span className={`vc-chip ${connected ? '' : 'offline'}`}>
+    <span className={`vc-chip ${connected ? '' : 'offline'} ${stacked ? 'stacked' : ''}`}>
       <span className="vc-chip-dot" aria-hidden="true" />
-      {connected
-        ? `Connected${stamp ? ` · Synced ${stamp}` : ''}`
-        : `Offline${stamp ? ` · Last synced ${stamp}` : ''}`}
+      {stacked ? (
+        <span className="vc-chip-lines">
+          <span>{stateWord}</span>
+          {syncLine && <span>{syncLine}</span>}
+        </span>
+      ) : (
+        `${stateWord}${syncLine ? ` · ${syncLine}` : ''}`
+      )}
     </span>
   );
 }

--- a/frontend/src/components/connection-chip.css
+++ b/frontend/src/components/connection-chip.css
@@ -1,0 +1,39 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+@import '../styles/vc-tokens.css';
+
+.vc-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  white-space: nowrap;
+}
+.vc-chip-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--vc-state-complete);
+  flex-shrink: 0;
+}
+.vc-chip.offline { color: var(--vc-state-due); }
+.vc-chip.offline .vc-chip-dot { background: var(--vc-state-due); }

--- a/frontend/src/components/connection-chip.css
+++ b/frontend/src/components/connection-chip.css
@@ -37,3 +37,12 @@
 }
 .vc-chip.offline { color: var(--vc-state-due); }
 .vc-chip.offline .vc-chip-dot { background: var(--vc-state-due); }
+
+/* Stacked variant (tight headers): state on one row, sync time below */
+.vc-chip.stacked { align-items: flex-start; }
+.vc-chip.stacked .vc-chip-dot { margin-top: 3px; }
+.vc-chip-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}

--- a/frontend/src/hooks/useConnectionStatus.js
+++ b/frontend/src/hooks/useConnectionStatus.js
@@ -19,7 +19,7 @@
 // public liveness probe. There is no offline write queue (v1), so OFFLINE
 // disables saving rather than pretending to sync.
 import { useCallback, useEffect, useRef, useState } from 'react';
-import config, { apiFetch } from '../../config';
+import config, { apiFetch } from '../config';
 
 const POLL_MS = 30000;
 

--- a/frontend/src/pages/admin-v2/AdminV2Layout.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Layout.jsx
@@ -595,7 +595,7 @@ const AdminV2Layout = ({ children }) => {
                   return (
                     <Link
                       key={item.path}
-                      to={item.path}
+                      to={getNavUrl(item.path)}
                       className={`admin-v2-sidebar-link ${isActiveLink(item.path) ? 'active' : ''}`}
                       onClick={closeMobileMenu}
                     >

--- a/frontend/src/pages/admin-v2/AdminV2Layout.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Layout.jsx
@@ -661,7 +661,7 @@ const AdminV2Layout = ({ children }) => {
                 </span>
               )}
             </div>
-            <ConnectionChip connection={connection} />
+            <ConnectionChip connection={connection} stacked />
           </header>
 
           {/* Restricted mode banner */}

--- a/frontend/src/pages/admin-v2/AdminV2Layout.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Layout.jsx
@@ -55,28 +55,59 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Alert } from '@/components/ui/alert';
 import './AdminV2.css';
+import './admin-nav.css'; // grouped-nav structure (both themes)
 // Bedside-monitor skin (dark theme only) + its fonts (shared entry, deduped
 // with the capture surface). Loaded after AdminV2.css so overrides win.
 import '../../styles/vcFonts';
 import './vc-shell.css';
 import './vc-content.css';
+import ConnectionChip from '../../components/ConnectionChip';
+import useConnectionStatus from '../../hooks/useConnectionStatus';
 
-// Side navigation items - main app sections
-const sideNavItems = [
-  { path: '/care', label: 'Dashboard', Icon: DashboardIcon },
-  { path: '/care/schedule', label: 'Schedule', Icon: CalendarIcon, requiredPermissions: ['medications.read', 'care_tasks.read'] },
-  { path: '/care/vitals', label: 'Vitals', Icon: ClipboardListIcon, requiredPermissions: ['vitals.read', 'vitals.create'] },
-  { path: '/care/symptoms', label: 'Symptoms', Icon: VirusIcon, requiredPermissions: ['vitals.read', 'vitals.create'] },
-  { path: '/care/monitoring', label: 'Monitoring', Icon: MonitoringIcon, requiredPermissions: ['monitoring.read', 'monitoring.create', 'monitoring.update', 'monitoring.delete'] },
-  { path: '/care/messages', label: 'Messages', Icon: MessagesIcon },
-  { path: '/care/reports', label: 'Reports', Icon: BarChartIcon, requiredPermissions: ['vitals.read'] },
-  { path: '/care/medications', label: 'Medications', Icon: MedicationsIcon, requiredPermissions: ['medications.read', 'medications.create', 'medications.update', 'medications.delete'] },
-  { path: '/care/care-tasks', label: 'Care Tasks', Icon: TasksIcon, requiredPermissions: ['care_tasks.read', 'care_tasks.create', 'care_tasks.update', 'care_tasks.delete'] },
-  { path: '/care/equipment', label: 'Equipment & Supplies', Icon: EquipmentIcon, requiredPermissions: ['equipment.read', 'equipment.create', 'equipment.update', 'equipment.delete'] },
-  { path: '/care/nutrition', label: 'Nutrition', Icon: NutritionIcon, requiredPermissions: ['nutrition.read', 'nutrition.create', 'nutrition.update', 'nutrition.delete'] },
-  { path: '/care/profile', label: 'Profile', Icon: ProfileIcon },
-  { path: '/care/configuration', label: 'Configuration', Icon: ConfigIcon, systemAdminOnly: true },
+// Side navigation, grouped into labeled sections (mockup: Overview /
+// Clinical / Care / Records / Account). The flat list is derived below for
+// active-label and permission-filtering logic.
+const sideNavGroups = [
+  {
+    label: 'Overview',
+    items: [
+      { path: '/care', label: 'Dashboard', Icon: DashboardIcon },
+      { path: '/care/schedule', label: 'Schedule', Icon: CalendarIcon, requiredPermissions: ['medications.read', 'care_tasks.read'] },
+    ],
+  },
+  {
+    label: 'Clinical',
+    items: [
+      { path: '/care/vitals', label: 'Vitals', Icon: ClipboardListIcon, requiredPermissions: ['vitals.read', 'vitals.create'] },
+      { path: '/care/symptoms', label: 'Symptoms', Icon: VirusIcon, requiredPermissions: ['vitals.read', 'vitals.create'] },
+      { path: '/care/monitoring', label: 'Monitoring', Icon: MonitoringIcon, requiredPermissions: ['monitoring.read', 'monitoring.create', 'monitoring.update', 'monitoring.delete'] },
+    ],
+  },
+  {
+    label: 'Care',
+    items: [
+      { path: '/care/medications', label: 'Medications', Icon: MedicationsIcon, requiredPermissions: ['medications.read', 'medications.create', 'medications.update', 'medications.delete'] },
+      { path: '/care/nutrition', label: 'Nutrition', Icon: NutritionIcon, requiredPermissions: ['nutrition.read', 'nutrition.create', 'nutrition.update', 'nutrition.delete'] },
+      { path: '/care/care-tasks', label: 'Care Tasks', Icon: TasksIcon, requiredPermissions: ['care_tasks.read', 'care_tasks.create', 'care_tasks.update', 'care_tasks.delete'] },
+      { path: '/care/equipment', label: 'Equipment', Icon: EquipmentIcon, requiredPermissions: ['equipment.read', 'equipment.create', 'equipment.update', 'equipment.delete'] },
+    ],
+  },
+  {
+    label: 'Records',
+    items: [
+      { path: '/care/messages', label: 'Messages', Icon: MessagesIcon },
+      { path: '/care/reports', label: 'Reports', Icon: BarChartIcon, requiredPermissions: ['vitals.read'] },
+    ],
+  },
+  {
+    label: 'Account',
+    items: [
+      { path: '/care/profile', label: 'Profile', Icon: ProfileIcon },
+      { path: '/care/configuration', label: 'Configuration', Icon: ConfigIcon, systemAdminOnly: true },
+    ],
+  },
 ];
+const sideNavItems = sideNavGroups.flatMap((g) => g.items);
 
 // Get top nav items based on current section, permissions, and read access (restricted mode hides History/Active)
 const getTopNavItems = (section, hasAnyPermission, hasReadAccess, isSystemAdmin) => {
@@ -201,6 +232,7 @@ const AdminV2Layout = ({ children }) => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { user, logout, switchUser, hasReadAccess, unlockWithAccountPassword } = useAuth();
+  const connection = useConnectionStatus();
   const [showUnlockModal, setShowUnlockModal] = useState(false);
   const [unlockPassword, setUnlockPassword] = useState('');
   const [unlockError, setUnlockError] = useState('');
@@ -382,6 +414,14 @@ const AdminV2Layout = ({ children }) => {
         })
   ).filter(item => !item.systemAdminOnly || user?.is_system_admin);
 
+  // Grouped view of the same visible set; groups with no visible items vanish.
+  const visibleNavGroups = sideNavGroups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => visibleNavItems.includes(item)),
+    }))
+    .filter((group) => group.items.length > 0);
+
   const handleUnlockSubmit = async (e) => {
     e.preventDefault();
     setUnlockError('');
@@ -397,6 +437,7 @@ const AdminV2Layout = ({ children }) => {
   };
 
   const activeNavLabel = visibleNavItems.find((item) => isActiveLink(item.path))?.label || 'Dashboard';
+  const activeSubNavLabel = topNavItems.find((item) => isExactMatch(item.path))?.label || null;
 
   return (
     <div className={`admin-v2-layout ${sidebarCollapsed ? 'sidebar-collapsed' : ''} ${mobileMenuOpen ? 'mobile-menu-open' : ''}`}>
@@ -409,6 +450,22 @@ const AdminV2Layout = ({ children }) => {
 
       {/* Side Navigation - drawer on mobile, sidebar on desktop */}
       <aside className={`admin-v2-sidebar ${sidebarCollapsed ? 'collapsed' : ''}`}>
+        {/* Mobile drawer header (hidden on desktop): labeled CLOSE + breadcrumb */}
+        <div className="admin-v2-drawer-header">
+          <button
+            type="button"
+            className="admin-v2-drawer-close"
+            onClick={closeMobileMenu}
+            aria-label="Close navigation"
+          >
+            <XIcon size={20} />
+            <span className="admin-v2-drawer-close-caption">Close</span>
+          </button>
+          <span className="admin-v2-drawer-title">
+            SHH <span className="admin-v2-drawer-title-sep">/</span> Navigation
+          </span>
+        </div>
+
         <div className="admin-v2-sidebar-header">
           <Link to="/" className="admin-v2-logo-link">
             {!sidebarCollapsed ? (
@@ -446,9 +503,12 @@ const AdminV2Layout = ({ children }) => {
                     {selectedPatient.first_name} {selectedPatient.last_name}
                   </span>
                   <span className="admin-v2-patient-selector-meta">
-                    {calculateAge(selectedPatient.date_of_birth) !== null 
+                    {calculateAge(selectedPatient.date_of_birth) !== null
                       ? `Age ${calculateAge(selectedPatient.date_of_birth)}`
                       : 'Age unknown'}
+                  </span>
+                  <span className={`admin-v2-patient-selector-status ${selectedPatient.is_active ? 'active' : ''}`}>
+                    {selectedPatient.is_active ? 'Care plan active' : 'Inactive'}
                   </span>
                 </div>
                 <ChevronRightIcon size={16} className={`admin-v2-patient-selector-arrow ${showPatientDropdown ? 'open' : ''}`} />
@@ -526,22 +586,29 @@ const AdminV2Layout = ({ children }) => {
         )}
         
         <nav className="admin-v2-sidebar-nav">
-          {visibleNavItems.map((item) => {
-            const IconComponent = item.Icon;
-            return (
-              <Link
-                key={item.path}
-                to={item.path}
-                className={`admin-v2-sidebar-link ${isActiveLink(item.path) ? 'active' : ''}`}
-                onClick={closeMobileMenu}
-              >
-                <span className="admin-v2-sidebar-icon">
-                  <IconComponent size={18} />
-                </span>
-                <span className="admin-v2-sidebar-label">{item.label}</span>
-              </Link>
-            );
-          })}
+          {visibleNavGroups.map((group) => (
+            <div key={group.label} className="admin-v2-nav-group">
+              <span className="admin-v2-nav-group-label">{group.label}</span>
+              <div className="admin-v2-nav-group-items">
+                {group.items.map((item) => {
+                  const IconComponent = item.Icon;
+                  return (
+                    <Link
+                      key={item.path}
+                      to={item.path}
+                      className={`admin-v2-sidebar-link ${isActiveLink(item.path) ? 'active' : ''}`}
+                      onClick={closeMobileMenu}
+                    >
+                      <span className="admin-v2-sidebar-icon">
+                        <IconComponent size={18} />
+                      </span>
+                      <span className="admin-v2-sidebar-label">{item.label}</span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
         </nav>
         
         <div className="admin-v2-sidebar-footer">
@@ -571,17 +638,30 @@ const AdminV2Layout = ({ children }) => {
             Grouped in one sticky container so they never overlap each other (two sibling
             sticky bars would collide at top:0 and one would hide the other). */}
         <div className="admin-v2-pinned-top">
-          {/* Mobile header - menu button and page title (visible only on small screens) */}
+          {/* Mobile header - labeled NAV button, section + patient context,
+              live connection chip (visible only on small screens) */}
           <header className="admin-v2-mobile-header">
             <button
               type="button"
               className="admin-v2-mobile-menu-btn"
               onClick={toggleSidebar}
-              aria-label="Open menu"
+              aria-label="Open navigation"
             >
-              <MenuIcon size={24} />
+              <MenuIcon size={20} />
+              <span className="admin-v2-mobile-menu-caption">Nav</span>
             </button>
-            <span className="admin-v2-mobile-header-title">{activeNavLabel}</span>
+            <div className="admin-v2-mobile-header-titles">
+              <span className="admin-v2-mobile-header-title">{activeNavLabel}</span>
+              {(selectedPatient || activeSubNavLabel) && (
+                <span className="admin-v2-mobile-header-sub">
+                  {[selectedPatient && `${selectedPatient.first_name} ${selectedPatient.last_name}`,
+                    activeSubNavLabel]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </span>
+              )}
+            </div>
+            <ConnectionChip connection={connection} />
           </header>
 
           {/* Restricted mode banner */}

--- a/frontend/src/pages/admin-v2/AdminV2VitalsCapture.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2VitalsCapture.jsx
@@ -21,7 +21,7 @@
 import AdminV2Layout from './AdminV2Layout';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
 import CaptureVitalsPanel from '../capture/CaptureVitalsPanel';
-import useConnectionStatus from '../capture/useConnectionStatus';
+import useConnectionStatus from '../../hooks/useConnectionStatus';
 import './AdminV2.css';
 
 const AdminV2VitalsCapture = () => {

--- a/frontend/src/pages/admin-v2/admin-nav.css
+++ b/frontend/src/pages/admin-v2/admin-nav.css
@@ -1,0 +1,170 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Grouped-navigation STRUCTURE (both themes): labeled sections in the
+ * sidebar, a full-viewport drawer with its own header on mobile, richer
+ * mobile page header (labeled NAV button, section + patient context, live
+ * chip). Colors for the dark theme live in vc-shell.css. */
+
+/* ---------- Nav groups ---------- */
+.admin-v2-nav-group {
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem 0.5rem 0.5rem;
+}
+.admin-v2-nav-group + .admin-v2-nav-group {
+  border-top: 1px solid var(--border);
+  margin-top: 0.25rem;
+  padding-top: 0.6rem;
+}
+.admin-v2-nav-group-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+  padding: 0 0.5rem 0.35rem;
+}
+.admin-v2-sidebar.collapsed .admin-v2-nav-group-label { display: none; }
+.admin-v2-nav-group-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* ---------- Patient card status line ---------- */
+.admin-v2-patient-selector-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 11px;
+  color: var(--muted-foreground);
+}
+.admin-v2-patient-selector-status::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+.admin-v2-patient-selector-status.active { color: var(--success); }
+
+/* ---------- Mobile page header pieces ---------- */
+.admin-v2-mobile-menu-caption {
+  display: block;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.admin-v2-mobile-header .admin-v2-mobile-menu-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+}
+.admin-v2-mobile-header-titles {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.admin-v2-mobile-header-sub {
+  font-size: 11px;
+  color: var(--muted-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.admin-v2-mobile-header .vc-chip { margin-left: auto; flex-shrink: 0; }
+
+/* ---------- Drawer (mobile) ---------- */
+.admin-v2-drawer-header { display: none; }
+
+/* Desktop: the group labels add vertical spend — compact the rows so all
+ * five groups fit a typical viewport without scrolling. */
+@media (min-width: 769px) {
+  .admin-v2-sidebar-link {
+    padding-top: 0.45rem;
+    padding-bottom: 0.45rem;
+  }
+  .admin-v2-nav-group { padding: 0.2rem 0.5rem 0.4rem; }
+  .admin-v2-nav-group + .admin-v2-nav-group {
+    margin-top: 0.15rem;
+    padding-top: 0.45rem;
+  }
+}
+
+@media (max-width: 768px) {
+  /* Full-viewport drawer */
+  .admin-v2-sidebar {
+    width: 100vw;
+    max-width: 100vw;
+  }
+  /* The drawer has its own header; the desktop logo row hides */
+  .admin-v2-sidebar-header { display: none; }
+  .admin-v2-drawer-header {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    padding: 0.65rem 1rem;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .admin-v2-drawer-close {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.4rem 0.6rem;
+    min-width: 52px;
+    min-height: 48px;
+    color: var(--foreground);
+    cursor: pointer;
+  }
+  .admin-v2-drawer-close-caption {
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .admin-v2-drawer-title {
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--foreground);
+  }
+  .admin-v2-drawer-title-sep { color: var(--muted-foreground); margin: 0 0.3rem; }
+
+  /* Two-column item grid inside groups */
+  .admin-v2-nav-group { padding: 0.4rem 1rem 0.6rem; }
+  .admin-v2-nav-group-items {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.15rem 0.75rem;
+  }
+  .admin-v2-nav-group-label { padding-left: 0; }
+}

--- a/frontend/src/pages/admin-v2/vc-shell.css
+++ b/frontend/src/pages/admin-v2/vc-shell.css
@@ -134,6 +134,39 @@
   background: rgba(0, 0, 0, 0.6);
 }
 
+/* ---------- Grouped nav + drawer (dark colors for admin-nav.css) ---------- */
+:root:not(.light) .admin-v2-nav-group + .admin-v2-nav-group {
+  border-top-color: var(--vc-line-hairline);
+}
+:root:not(.light) .admin-v2-nav-group-label {
+  font-family: var(--vc-font-mono);
+  color: var(--vc-text-tertiary);
+}
+:root:not(.light) .admin-v2-drawer-header {
+  background: var(--vc-bg-surface);
+  border-bottom-color: var(--vc-line-hairline);
+}
+:root:not(.light) .admin-v2-drawer-close {
+  border-color: var(--vc-line-hairline);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-drawer-close-caption { font-family: var(--vc-font-mono); }
+:root:not(.light) .admin-v2-drawer-title {
+  font-family: var(--vc-font-mono);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-drawer-title-sep { color: var(--vc-text-tertiary); }
+:root:not(.light) .admin-v2-patient-selector-status { color: var(--vc-text-tertiary); }
+:root:not(.light) .admin-v2-patient-selector-status.active { color: var(--vc-state-complete); }
+:root:not(.light) .admin-v2-mobile-menu-caption { font-family: var(--vc-font-mono); }
+:root:not(.light) .admin-v2-mobile-header-sub {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
 /* ---------- Sub-nav strip (Record | History …) ---------- */
 :root:not(.light) .admin-v2-topnav {
   background: var(--vc-bg-base);

--- a/frontend/src/pages/admin-v2/vc-shell.css
+++ b/frontend/src/pages/admin-v2/vc-shell.css
@@ -104,11 +104,64 @@
   border: 1px solid var(--vc-line-strong);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
 }
+:root:not(.light) .admin-v2-patient-dropdown-header {
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+:root:not(.light) .admin-v2-patient-dropdown-clear {
+  background: transparent;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 999px;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .admin-v2-patient-dropdown-clear:hover {
+  border-color: color-mix(in srgb, var(--vc-state-due) 50%, transparent);
+  color: var(--vc-state-due);
+}
+:root:not(.light) .admin-v2-patient-dropdown-avatar {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-strong);
+  color: var(--vc-data-live);
+  font-family: var(--vc-font-mono);
+}
+:root:not(.light) .admin-v2-patient-dropdown-info .name {
+  font-family: var(--vc-font-mono);
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .admin-v2-patient-dropdown-info .age {
+  font-size: 11px;
+  color: var(--vc-text-secondary);
+}
 :root:not(.light) .admin-v2-patient-dropdown-item:hover {
   background: var(--vc-bg-surface);
 }
 :root:not(.light) .admin-v2-patient-dropdown-item.selected {
+  background: var(--vc-bg-surface);
+  box-shadow: inset 2px 0 0 var(--vc-data-live);
+}
+:root:not(.light) .admin-v2-patient-dropdown-item.selected .name {
   color: var(--vc-data-live);
+}
+:root:not(.light) .admin-v2-patient-dropdown-item.selected .admin-v2-patient-dropdown-avatar {
+  border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
+}
+:root:not(.light) .admin-v2-patient-dropdown-loading,
+:root:not(.light) .admin-v2-patient-dropdown-empty {
+  color: var(--vc-text-secondary);
 }
 
 /* ---------- Mobile header (hamburger) ---------- */

--- a/frontend/src/pages/capture/CaptureVitalsPanel.jsx
+++ b/frontend/src/pages/capture/CaptureVitalsPanel.jsx
@@ -28,6 +28,7 @@ import { buildConfigs } from './vitalConfigs';
 import CaptureSheet from './components/CaptureSheet';
 import VitalTile from './components/VitalTile';
 import { clearDraft, loadDraft, newEncounterUid, saveDraft } from './useCaptureDraft';
+import ConnectionChip from '../../components/ConnectionChip';
 
 const newEncounter = () => ({
   encounterUid: newEncounterUid(),
@@ -38,21 +39,6 @@ const newEncounter = () => ({
 function encounterLabel(startedAt) {
   const d = new Date(startedAt);
   return `${d.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' })} · ${d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`;
-}
-
-export function ConnectionChip({ connection }) {
-  const { connected, lastSuccess } = connection;
-  const stamp = lastSuccess
-    ? lastSuccess.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
-    : null;
-  return (
-    <span className={`vc-chip ${connected ? '' : 'offline'}`}>
-      <span className="vc-chip-dot" aria-hidden="true" />
-      {connected
-        ? `Connected${stamp ? ` · Synced ${stamp}` : ''}`
-        : `Offline${stamp ? ` · Last synced ${stamp}` : ''}`}
-    </span>
-  );
 }
 
 export default function CaptureVitalsPanel({ patient, connection, embedded = false }) {

--- a/frontend/src/pages/capture/VitalsCapturePage.jsx
+++ b/frontend/src/pages/capture/VitalsCapturePage.jsx
@@ -21,9 +21,10 @@
 import { useEffect, useState } from 'react';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
 import config, { apiFetch } from '../../config';
-import CaptureVitalsPanel, { ConnectionChip } from './CaptureVitalsPanel';
+import CaptureVitalsPanel from './CaptureVitalsPanel';
+import ConnectionChip from '../../components/ConnectionChip';
 import CaptureTabBar from './components/CaptureTabBar';
-import useConnectionStatus from './useConnectionStatus';
+import useConnectionStatus from '../../hooks/useConnectionStatus';
 
 export default function VitalsCapturePage() {
   const { patients: contextPatients, selectedPatient, selectPatient } = useAdminPatient();

--- a/frontend/src/pages/capture/capture.css
+++ b/frontend/src/pages/capture/capture.css
@@ -142,26 +142,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.vc-chip {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-family: var(--vc-font-mono);
-  font-size: 10.5px;
-  letter-spacing: 0.08em;
-  color: var(--vc-text-secondary);
-  white-space: nowrap;
-}
-.vc-chip-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--vc-state-complete);
-  flex-shrink: 0;
-}
-.vc-chip.offline { color: var(--vc-state-due); }
-.vc-chip.offline .vc-chip-dot { background: var(--vc-state-due); }
-
 .vc-title {
   font-family: var(--vc-font-mono);
   font-size: 17px;


### PR DESCRIPTION
Implements the supplied navigation mockup on both form factors.

**Mobile**
- The drawer now takes the **full viewport**, with its own header: labeled CLOSE button and `SHH / NAVIGATION`
- Patient card gains a care-plan status line (green dot when active) above the grouped nav
- Nav items lay out in a **two-column grid** within labeled groups (Overview / Clinical / Care / Records / Account)
- The page header gets a labeled **NAV** button, the section title with a `patient · sub-section` context line, and the live **CONNECTED · SYNCED** chip

**Desktop**
- Same groups as single-column sections with mono-caps labels; row density compacted so all five groups fit a typical viewport; collapse mode hides group labels

**Plumbing**
- `ConnectionChip` + `useConnectionStatus` extracted from the capture surface into `src/components` / `src/hooks` (single source; capture pages updated)
- Structure is theme-neutral (`admin-nav.css`) — light theme gets the same layout with its own palette; `vc-shell.css` adds the dark vc colors
- Permission filtering unchanged (groups with no visible items vanish; Equipment label shortened from "Equipment & Supplies" to fit the grid)

Verified live (dark, 390/1380): drawer, closed header with chip, desktop sidebar. Tests 353 green, lint and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS8WMSAiMKmozbMuwbiocw