### PR TITLE
Active + History symptom tabs rebuilt from the mockups

### DIFF
--- a/frontend/src/components/Icons.jsx
+++ b/frontend/src/components/Icons.jsx
@@ -973,3 +973,16 @@ export const PlusSquareIcon = ({ size = 20 }) => (
     <line x1="8.5" y1="12" x2="15.5" y2="12" />
   </svg>
 );
+export const FilterIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M4 5h16l-6.5 8v5.5L10.5 20v-7L4 5z" />
+  </svg>
+);
+export const BodyIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="4.5" r="2.2" />
+    <path d="M12 7.5v6.5M12 14l-2.5 6M12 14l2.5 6M6.5 9.5 12 8.2l5.5 1.3" />
+  </svg>
+);

--- a/frontend/src/pages/admin-v2/AdminV2Symptoms.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Symptoms.jsx
@@ -48,28 +48,17 @@ import {
 import { Field, FormRow } from '@/components/ui/field';
 import { Alert } from '@/components/ui/alert';
 import SymptomLogForm from './components/SymptomLogForm';
+import SymptomActiveList from './components/SymptomActiveList';
+import SymptomHistoryList from './components/SymptomHistoryList';
 import './AdminV2.css';
 
 // Severity color mapping
-const getSeverityColor = (severity) => {
-  if (!severity) return 'var(--muted-foreground)';
-  if (severity <= 3) return '#3fb950';  // Green - mild
-  if (severity <= 6) return '#d29922';  // Yellow - moderate
-  if (severity <= 8) return '#db6d28';  // Orange - significant
-  return '#f85149';  // Red - severe
-};
-
 // Format symptom type for display
 const formatSymptomType = (type) => {
   if (!type) return '';
   return type.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
 };
 
-// Format body location for display
-const formatLocation = (location) => {
-  if (!location) return '';
-  return location.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
-};
 
 const AdminV2Symptoms = () => {
   const location = useLocation();
@@ -78,12 +67,6 @@ const AdminV2Symptoms = () => {
   const selectedPatient = contextPatient;
 
   // Helper to get local datetime string for datetime-local input
-  const getLocalDateTimeString = () => {
-    const now = new Date();
-    const offset = now.getTimezoneOffset();
-    const local = new Date(now.getTime() - offset * 60 * 1000);
-    return local.toISOString().slice(0, 16);
-  };
 
   // Determine active view based on URL
   const isHistoryView = location.pathname.includes('/history');
@@ -98,31 +81,15 @@ const AdminV2Symptoms = () => {
   // History/filtering state
   const [historySymptoms, setHistorySymptoms] = useState([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
-  const [filterType, setFilterType] = useState('');
-  const [filterStatus, setFilterStatus] = useState('all'); // 'all', 'active', 'resolved'
-  const [filterDateFrom, setFilterDateFrom] = useState('');
-  const [filterDateTo, setFilterDateTo] = useState('');
-  const [searchTerm, setSearchTerm] = useState('');
 
   // Modal states
-  const [showSymptomModal, setShowSymptomModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [selectedSymptom, setSelectedSymptom] = useState(null);
   const [editingSymptom, setEditingSymptom] = useState(null);
 
   // Symptom form state
-  const [symptomFormData, setSymptomFormData] = useState({
-    symptom_type: '',
-    severity: 5,
-    location: '',
-    duration: '',
-    description: '',
-    notes: '',
-    timestamp: getLocalDateTimeString()
-  });
 
   // Form states
-  const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
 
@@ -192,50 +159,18 @@ const AdminV2Symptoms = () => {
     }
   };
 
+  // Search / range / type / status filtering now lives client-side inside
+  // SymptomHistoryList — fetch everything once per patient.
   const loadHistorySymptoms = async () => {
     if (!selectedPatient) return;
-
     setLoadingHistory(true);
     try {
-      let url = `${config.apiUrl}/api/symptoms/patient/${selectedPatient.id}?limit=100`;
-
-      if (filterStatus === 'active') {
-        url += '&resolved=false';
-      } else if (filterStatus === 'resolved') {
-        url += '&resolved=true';
-      }
-
-      if (filterType) {
-        url += `&symptom_type=${filterType}`;
-      }
-
-      const response = await fetch(url, { credentials: 'include' });
+      const response = await fetch(
+        `${config.apiUrl}/api/symptoms/patient/${selectedPatient.id}?limit=200`,
+        { credentials: 'include' }
+      );
       if (response.ok) {
-        let data = await response.json();
-
-        // Client-side date filtering
-        if (filterDateFrom) {
-          const fromDate = new Date(filterDateFrom);
-          data = data.filter(s => new Date(s.timestamp) >= fromDate);
-        }
-        if (filterDateTo) {
-          const toDate = new Date(filterDateTo);
-          toDate.setHours(23, 59, 59);
-          data = data.filter(s => new Date(s.timestamp) <= toDate);
-        }
-
-        // Client-side search
-        if (searchTerm) {
-          const term = searchTerm.toLowerCase();
-          data = data.filter(s =>
-            formatSymptomType(s.symptom_type).toLowerCase().includes(term) ||
-            (s.description && s.description.toLowerCase().includes(term)) ||
-            (s.notes && s.notes.toLowerCase().includes(term)) ||
-            (s.location && formatLocation(s.location).toLowerCase().includes(term))
-          );
-        }
-
-        setHistorySymptoms(data);
+        setHistorySymptoms(await response.json());
       }
     } catch (err) {
       console.error('Error loading symptom history:', err);
@@ -244,68 +179,6 @@ const AdminV2Symptoms = () => {
     }
   };
 
-  // Reload history when filters change
-  useEffect(() => {
-    if (isHistoryView && selectedPatient) {
-      loadHistorySymptoms();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helper is recreated each render; effect re-runs on filter change only, view/patient changes are handled by the effect above
-  }, [filterType, filterStatus, filterDateFrom, filterDateTo, searchTerm]);
-
-  const handleSymptomSubmit = async (e) => {
-    e.preventDefault();
-    if (!selectedPatient) {
-      setError('Please select a patient first');
-      return;
-    }
-
-    setSaving(true);
-    setError(null);
-
-    try {
-      const payload = {
-        symptom_type: symptomFormData.symptom_type,
-        patient_id: selectedPatient.id,
-        severity: parseInt(symptomFormData.severity),
-        location: symptomFormData.location || null,
-        duration: symptomFormData.duration || null,
-        description: symptomFormData.description || null,
-        notes: symptomFormData.notes || null,
-        timestamp: symptomFormData.timestamp
-      };
-
-      const url = editingSymptom
-        ? `${config.apiUrl}/api/symptoms/${editingSymptom.id}`
-        : `${config.apiUrl}/api/symptoms`;
-
-      const response = await fetch(url, {
-        method: editingSymptom ? 'PUT' : 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(payload)
-      });
-
-      if (response.ok) {
-        setSuccess(editingSymptom ? 'Symptom updated!' : 'Symptom logged!');
-        setShowSymptomModal(false);
-        setEditingSymptom(null);
-        resetSymptomForm();
-        if (isHistoryView) {
-          loadHistorySymptoms();
-        } else {
-          loadSymptoms();
-        }
-        setTimeout(() => setSuccess(null), 3000);
-      } else {
-        const data = await response.json();
-        throw new Error(data.detail || 'Failed to save symptom');
-      }
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setSaving(false);
-    }
-  };
 
   const handleResolveSymptom = async (symptomId) => {
     try {
@@ -353,73 +226,7 @@ const AdminV2Symptoms = () => {
     }
   };
 
-  const openEditSymptom = (symptom) => {
-    setEditingSymptom(symptom);
-    setSymptomFormData({
-      symptom_type: symptom.symptom_type,
-      severity: symptom.severity || 5,
-      location: symptom.location || '',
-      duration: symptom.duration || '',
-      description: symptom.description || '',
-      notes: symptom.notes || '',
-      timestamp: symptom.timestamp ? symptom.timestamp.slice(0, 16) : getLocalDateTimeString()
-    });
-    setShowSymptomModal(true);
-  };
-
-  const resetSymptomForm = () => {
-    setSymptomFormData({
-      symptom_type: '',
-      severity: 5,
-      location: '',
-      duration: '',
-      description: '',
-      notes: '',
-      timestamp: getLocalDateTimeString()
-    });
-  };
-
-  const clearFilters = () => {
-    setFilterType('');
-    setFilterStatus('all');
-    setFilterDateFrom('');
-    setFilterDateTo('');
-    setSearchTerm('');
-  };
-
-  const hasActiveFilters = !!(filterType || filterStatus !== 'all' || filterDateFrom || filterDateTo || searchTerm);
-
-  // The severity slider keeps its dedicated chrome classes
-  // (.symptom-severity-slider styles the range track/thumb itself, so it
-  // survives inside .tw where bare element rules are scoped out).
-  const renderSeveritySlider = () => (
-    <div className="symptom-severity-slider">
-      <input
-        type="range"
-        min="1"
-        max="10"
-        value={symptomFormData.severity}
-        onChange={(e) => setSymptomFormData(prev => ({ ...prev, severity: e.target.value }))}
-        style={{
-          '--severity-color': getSeverityColor(symptomFormData.severity),
-          '--severity-percent': `${(symptomFormData.severity - 1) / 9 * 100}%`
-        }}
-      />
-      <div className="severity-labels">
-        <span>Mild</span>
-        <span>Severe</span>
-      </div>
-    </div>
-  );
-
-  const severityLabel = (
-    <span className="flex w-full items-center justify-between">
-      <span>Severity</span>
-      <span className="font-semibold" style={{ color: getSeverityColor(symptomFormData.severity) }}>
-        {symptomFormData.severity}/10
-      </span>
-    </span>
-  );
+  const openEditSymptom = (symptom) => setEditingSymptom(symptom);
 
   // Render log symptom view
   const renderLogView = () => (
@@ -433,250 +240,22 @@ const AdminV2Symptoms = () => {
 
   // Render active symptoms view
   const renderActiveView = () => (
-    <div className="admin-v2-vitals-content">
-      <div className="admin-v2-symptoms-list">
-        {loadingSymptoms ? (
-          <div className="admin-v2-loading">Loading symptoms...</div>
-        ) : symptoms.length === 0 ? (
-          <div className="admin-v2-empty-state">
-            <p>No active symptoms</p>
-          </div>
-        ) : (
-          symptoms.map(symptom => (
-            <div key={symptom.id} className="admin-v2-symptom-card">
-              <div className="admin-v2-symptom-header">
-                <div className="admin-v2-symptom-type">
-                  <span
-                    className="admin-v2-symptom-severity-badge"
-                    style={{ backgroundColor: getSeverityColor(symptom.severity) }}
-                  >
-                    {symptom.severity || '?'}/10
-                  </span>
-                  <span className="admin-v2-symptom-name">
-                    {formatSymptomType(symptom.symptom_type)}
-                  </span>
-                  {symptom.location && (
-                    <span className="admin-v2-symptom-location">
-                      — {formatLocation(symptom.location)}
-                    </span>
-                  )}
-                </div>
-                <div className="admin-v2-symptom-actions tw">
-                  <Button
-                    size="icon"
-                    className="h-7 w-7"
-                    onClick={() => handleResolveSymptom(symptom.id)}
-                    title="Mark as resolved"
-                  >
-                    <CheckIcon size={14} />
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    size="icon"
-                    className="h-7 w-7"
-                    onClick={() => openEditSymptom(symptom)}
-                    title="Edit"
-                  >
-                    <EditIcon size={14} />
-                  </Button>
-                  <Button
-                    variant="destructive"
-                    size="icon"
-                    className="h-7 w-7"
-                    onClick={() => {
-                      setSelectedSymptom(symptom);
-                      setShowDeleteModal(true);
-                    }}
-                    title="Delete"
-                  >
-                    <TrashIcon size={14} />
-                  </Button>
-                </div>
-              </div>
-
-              <div className="admin-v2-symptom-meta">
-                <span className="admin-v2-symptom-time">
-                  {symptom.timestamp ? new Date(symptom.timestamp).toLocaleString() : 'Unknown time'}
-                </span>
-                {symptom.duration && (
-                  <span className="admin-v2-symptom-duration">Duration: {symptom.duration}</span>
-                )}
-              </div>
-
-              {symptom.description && (
-                <p className="admin-v2-symptom-description">{symptom.description}</p>
-              )}
-            </div>
-          ))
-        )}
-      </div>
-    </div>
+    <SymptomActiveList
+      symptoms={symptoms.filter((s) => !s.is_resolved)}
+      loading={loadingSymptoms}
+      onResolve={handleResolveSymptom}
+      onEdit={openEditSymptom}
+      onDelete={(s) => { setSelectedSymptom(s); setShowDeleteModal(true); }}
+    />
   );
 
   // Render history view with table
   const renderHistoryView = () => (
-    <div className="admin-v2-vitals-content">
-      {/* Filters */}
-      <div className="vitals-history-filters">
-        <div className="tw flex flex-col gap-4">
-          {/* Search Input */}
-          <div className="relative">
-            <SearchIcon size={16} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              type="text"
-              placeholder="Search symptoms..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-9 pr-9"
-            />
-            {searchTerm && (
-              <button
-                type="button"
-                onClick={() => setSearchTerm('')}
-                className="absolute right-2 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:text-foreground"
-              >
-                <XIcon size={14} />
-              </button>
-            )}
-          </div>
-
-          {/* Filters grid */}
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <Field label="Type">
-              <Select value={filterType || '__all__'} onValueChange={(v) => setFilterType(v === '__all__' ? '' : v)}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__all__">All Types</SelectItem>
-                  {symptomTypes.map(type => (
-                    <SelectItem key={type} value={type}>{formatSymptomType(type)}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
-
-            <Field label="Status">
-              <Select value={filterStatus} onValueChange={setFilterStatus}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All</SelectItem>
-                  <SelectItem value="active">Active</SelectItem>
-                  <SelectItem value="resolved">Resolved</SelectItem>
-                </SelectContent>
-              </Select>
-            </Field>
-
-            <Field label="From" htmlFor="symptoms-hist-from">
-              <Input
-                id="symptoms-hist-from"
-                type="date"
-                value={filterDateFrom}
-                onChange={(e) => setFilterDateFrom(e.target.value)}
-              />
-            </Field>
-
-            <Field label="To" htmlFor="symptoms-hist-to">
-              <Input
-                id="symptoms-hist-to"
-                type="date"
-                value={filterDateTo}
-                onChange={(e) => setFilterDateTo(e.target.value)}
-              />
-            </Field>
-          </div>
-
-          {/* Actions */}
-          {hasActiveFilters && (
-            <div className="flex flex-wrap items-center gap-2">
-              <Button variant="secondary" onClick={clearFilters}>
-                Clear Filters
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* History Table */}
-      <div className="admin-v2-table-container">
-        {loadingHistory ? (
-          <div className="admin-v2-loading">Loading history...</div>
-        ) : historySymptoms.length === 0 ? (
-          <div className="admin-v2-empty-state">
-            <p>No symptoms found</p>
-          </div>
-        ) : (
-          <table className="admin-v2-table">
-            <thead>
-              <tr>
-                <th>Date/Time</th>
-                <th>Type</th>
-                <th>Severity</th>
-                <th>Location</th>
-                <th>Duration</th>
-                <th>Status</th>
-                <th>Description</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {historySymptoms.map(symptom => (
-                <tr key={symptom.id} className={symptom.is_resolved ? 'resolved-row' : ''}>
-                  <td>{symptom.timestamp ? new Date(symptom.timestamp).toLocaleString() : '-'}</td>
-                  <td>{formatSymptomType(symptom.symptom_type)}</td>
-                  <td>
-                    <span
-                      className="admin-v2-symptom-severity-badge"
-                      style={{ backgroundColor: getSeverityColor(symptom.severity) }}
-                    >
-                      {symptom.severity || '?'}/10
-                    </span>
-                  </td>
-                  <td>{symptom.location ? formatLocation(symptom.location) : '-'}</td>
-                  <td>{symptom.duration || '-'}</td>
-                  <td>
-                    <span className={`admin-v2-status-badge ${symptom.is_resolved ? 'resolved' : 'active'}`}>
-                      {symptom.is_resolved ? 'Resolved' : 'Active'}
-                    </span>
-                  </td>
-                  <td className="admin-v2-table-description">
-                    {symptom.description || '-'}
-                  </td>
-                  <td>
-                    <div className="admin-v2-table-actions">
-                      {!symptom.is_resolved && (
-                        <button
-                          className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-success"
-                          onClick={() => handleResolveSymptom(symptom.id)}
-                          title="Resolve"
-                        >
-                          <CheckIcon size={14} />
-                        </button>
-                      )}
-                      <button
-                        className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-secondary"
-                        onClick={() => openEditSymptom(symptom)}
-                        title="Edit"
-                      >
-                        <EditIcon size={14} />
-                      </button>
-                      <button
-                        className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-danger"
-                        onClick={() => {
-                          setSelectedSymptom(symptom);
-                          setShowDeleteModal(true);
-                        }}
-                        title="Delete"
-                      >
-                        <TrashIcon size={14} />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
-    </div>
+    <SymptomHistoryList
+      symptoms={historySymptoms}
+      symptomTypes={symptomTypes}
+      loading={loadingHistory}
+    />
   );
 
   return (
@@ -713,105 +292,24 @@ const AdminV2Symptoms = () => {
           isHistoryView ? renderHistoryView() : isActiveView ? renderActiveView() : renderLogView()
         )}
 
-        {/* Edit Symptom Dialog */}
-        <Dialog open={showSymptomModal} onOpenChange={(o) => { if (!o) setShowSymptomModal(false); }}>
-          <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-[560px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>Edit Symptom</DialogTitle>
-            </DialogHeader>
-
-            <form onSubmit={handleSymptomSubmit} className="flex flex-col gap-4">
-              <Field label="Symptom Type" required>
-                <Select
-                  value={symptomFormData.symptom_type || undefined}
-                  onValueChange={(v) => setSymptomFormData(prev => ({ ...prev, symptom_type: v }))}
-                >
-                  <SelectTrigger><SelectValue placeholder="Select symptom..." /></SelectTrigger>
-                  <SelectContent>
-                    {symptomTypes.map(type => (
-                      <SelectItem key={type} value={type}>{formatSymptomType(type)}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </Field>
-
-              <FormRow>
-                <Field label={severityLabel}>
-                  {renderSeveritySlider()}
-                </Field>
-
-                <Field label="Body Location">
-                  <Select
-                    value={symptomFormData.location || '__none__'}
-                    onValueChange={(v) => setSymptomFormData(prev => ({ ...prev, location: v === '__none__' ? '' : v }))}
-                  >
-                    <SelectTrigger><SelectValue placeholder="Select location..." /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">Not specified</SelectItem>
-                      {bodyLocations.map(loc => (
-                        <SelectItem key={loc} value={loc}>{formatLocation(loc)}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </Field>
-              </FormRow>
-
-              <FormRow>
-                <Field label="Duration">
-                  <Input
-                    type="text"
-                    value={symptomFormData.duration}
-                    onChange={(e) => setSymptomFormData(prev => ({ ...prev, duration: e.target.value }))}
-                    placeholder="e.g., 30 minutes, 2 hours"
-                  />
-                </Field>
-
-                <Field label="Date/Time" required>
-                  <Input
-                    type="datetime-local"
-                    value={symptomFormData.timestamp}
-                    onChange={(e) => setSymptomFormData(prev => ({ ...prev, timestamp: e.target.value }))}
-                    required
-                  />
-                </Field>
-              </FormRow>
-
-              <Field label="Description">
-                <Textarea
-                  value={symptomFormData.description}
-                  onChange={(e) => setSymptomFormData(prev => ({ ...prev, description: e.target.value }))}
-                  rows={3}
-                  placeholder="Describe the symptom..."
-                />
-              </Field>
-
-              <Field label="Notes">
-                <Textarea
-                  value={symptomFormData.notes}
-                  onChange={(e) => setSymptomFormData(prev => ({ ...prev, notes: e.target.value }))}
-                  rows={2}
-                  placeholder="Any additional notes..."
-                />
-              </Field>
-
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={() => setShowSymptomModal(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  type="submit"
-                  disabled={saving || !symptomFormData.symptom_type}
-                >
-                  {saving ? 'Saving...' : 'Update Symptom'}
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
+        {/* Edit symptom: the log form reused in edit mode (vc overlay) */}
+        {editingSymptom && selectedPatient && (
+          <div className="sl-edit-overlay" role="dialog" aria-modal="true"
+               aria-label="Edit symptom"
+               onClick={(e) => { if (e.target === e.currentTarget) setEditingSymptom(null); }}>
+            <div className="sl-edit-panel">
+              <SymptomLogForm
+                key={editingSymptom.id}
+                patient={selectedPatient}
+                symptomTypes={symptomTypes}
+                bodyLocations={bodyLocations}
+                initial={editingSymptom}
+                onCancel={() => setEditingSymptom(null)}
+                onLogged={() => { loadSymptoms(); loadHistorySymptoms(); setSuccess('Symptom updated'); setTimeout(() => setSuccess(null), 3000); }}
+              />
+            </div>
+          </div>
+        )}
 
         {/* Delete Confirmation Dialog */}
         <Dialog open={showDeleteModal && !!selectedSymptom} onOpenChange={(o) => { if (!o) setShowDeleteModal(false); }}>

--- a/frontend/src/pages/admin-v2/AdminV2Symptoms.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Symptoms.jsx
@@ -18,7 +18,8 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import AdminV2Layout from './AdminV2Layout';
-import config from '../../config';
+import config, { apiFetch } from '../../config';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
 import {
   EditIcon,
@@ -113,7 +114,7 @@ const AdminV2Symptoms = () => {
 
   const loadSymptomTypes = async () => {
     try {
-      const response = await fetch(`${config.apiUrl}/api/symptoms/types`, {
+      const response = await apiFetch(`${config.apiUrl}/api/symptoms/types`, {
         credentials: 'include'
       });
       if (response.ok) {
@@ -127,7 +128,7 @@ const AdminV2Symptoms = () => {
 
   const loadBodyLocations = async () => {
     try {
-      const response = await fetch(`${config.apiUrl}/api/symptoms/locations`, {
+      const response = await apiFetch(`${config.apiUrl}/api/symptoms/locations`, {
         credentials: 'include'
       });
       if (response.ok) {
@@ -144,7 +145,7 @@ const AdminV2Symptoms = () => {
 
     setLoadingSymptoms(true);
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `${config.apiUrl}/api/symptoms/patient/${selectedPatient.id}?limit=20&resolved=false`,
         { credentials: 'include' }
       );
@@ -165,7 +166,7 @@ const AdminV2Symptoms = () => {
     if (!selectedPatient) return;
     setLoadingHistory(true);
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `${config.apiUrl}/api/symptoms/patient/${selectedPatient.id}?limit=200`,
         { credentials: 'include' }
       );
@@ -182,7 +183,7 @@ const AdminV2Symptoms = () => {
 
   const handleResolveSymptom = async (symptomId) => {
     try {
-      const response = await fetch(`${config.apiUrl}/api/symptoms/${symptomId}/resolve`, {
+      const response = await apiFetch(`${config.apiUrl}/api/symptoms/${symptomId}/resolve`, {
         method: 'POST',
         credentials: 'include'
       });
@@ -205,7 +206,7 @@ const AdminV2Symptoms = () => {
     if (!selectedSymptom) return;
 
     try {
-      const response = await fetch(`${config.apiUrl}/api/symptoms/${selectedSymptom.id}`, {
+      const response = await apiFetch(`${config.apiUrl}/api/symptoms/${selectedSymptom.id}`, {
         method: 'DELETE',
         credentials: 'include'
       });
@@ -292,24 +293,29 @@ const AdminV2Symptoms = () => {
           isHistoryView ? renderHistoryView() : isActiveView ? renderActiveView() : renderLogView()
         )}
 
-        {/* Edit symptom: the log form reused in edit mode (vc overlay) */}
-        {editingSymptom && selectedPatient && (
-          <div className="sl-edit-overlay" role="dialog" aria-modal="true"
-               aria-label="Edit symptom"
-               onClick={(e) => { if (e.target === e.currentTarget) setEditingSymptom(null); }}>
-            <div className="sl-edit-panel">
-              <SymptomLogForm
-                key={editingSymptom.id}
-                patient={selectedPatient}
-                symptomTypes={symptomTypes}
-                bodyLocations={bodyLocations}
-                initial={editingSymptom}
-                onCancel={() => setEditingSymptom(null)}
-                onLogged={() => { loadSymptoms(); loadHistorySymptoms(); setSuccess('Symptom updated'); setTimeout(() => setSuccess(null), 3000); }}
-              />
-            </div>
-          </div>
-        )}
+        {/* Edit symptom: the log form reused in edit mode. Radix primitives
+            provide the focus trap, Escape dismissal and scroll lock the
+            previous Dialog had; chrome stays vc (sl-edit-* classes). */}
+        <DialogPrimitive.Root open={Boolean(editingSymptom && selectedPatient)}
+                              onOpenChange={(o) => { if (!o) setEditingSymptom(null); }}>
+          <DialogPrimitive.Portal>
+            <DialogPrimitive.Overlay className="sl-edit-overlay" />
+            <DialogPrimitive.Content className="sl-edit-panel" aria-describedby={undefined}>
+              <DialogPrimitive.Title className="sl-sr-only">Edit symptom</DialogPrimitive.Title>
+              {editingSymptom && selectedPatient && (
+                <SymptomLogForm
+                  key={editingSymptom.id}
+                  patient={selectedPatient}
+                  symptomTypes={symptomTypes}
+                  bodyLocations={bodyLocations}
+                  initial={editingSymptom}
+                  onCancel={() => setEditingSymptom(null)}
+                  onLogged={() => { loadSymptoms(); loadHistorySymptoms(); setSuccess('Symptom updated'); setTimeout(() => setSuccess(null), 3000); }}
+                />
+              )}
+            </DialogPrimitive.Content>
+          </DialogPrimitive.Portal>
+        </DialogPrimitive.Root>
 
         {/* Delete Confirmation Dialog */}
         <Dialog open={showDeleteModal && !!selectedSymptom} onOpenChange={(o) => { if (!o) setShowDeleteModal(false); }}>

--- a/frontend/src/pages/admin-v2/components/SymptomActiveList.jsx
+++ b/frontend/src/pages/admin-v2/components/SymptomActiveList.jsx
@@ -102,7 +102,8 @@ function ActiveCard({ symptom, onResolve, onEdit, onDelete }) {
         </button>
         <div className="sa-menu-wrap" ref={menuRef}>
           <button type="button" className="sa-icon-btn" aria-label="More actions"
-                  aria-expanded={menuOpen} onClick={() => setMenuOpen((v) => !v)}>
+                  aria-haspopup="menu" aria-expanded={menuOpen}
+                  onClick={() => setMenuOpen((v) => !v)}>
             <MoreHorizontalIcon size={16} />
           </button>
           {menuOpen && (

--- a/frontend/src/pages/admin-v2/components/SymptomActiveList.jsx
+++ b/frontend/src/pages/admin-v2/components/SymptomActiveList.jsx
@@ -1,0 +1,147 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Active symptoms as bedside-monitor cards (from the supplied mockup):
+// summary strip, per-symptom card with severity hero + band, ongoing
+// elapsed time, started stamp, and resolve/edit/delete actions.
+import { useEffect, useRef, useState } from 'react';
+import {
+  BodyIcon, CheckCircleIcon, ChevronDownIcon, ChevronRightIcon, EditIcon,
+  MoreHorizontalIcon,
+} from '../../../components/Icons';
+import { titleCase, bandFor, elapsedLabel } from './symptomUtils';
+import '../symptom-log.css';
+
+const stamp = (iso) => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return `${d.toLocaleDateString([], { month: 'short', day: 'numeric' })} · ${d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`;
+};
+
+function ActiveCard({ symptom, onResolve, onEdit, onDelete }) {
+  const [expanded, setExpanded] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+  const band = bandFor(symptom.severity);
+
+  useEffect(() => {
+    if (!menuOpen) return undefined;
+    const close = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) setMenuOpen(false);
+    };
+    document.addEventListener('pointerdown', close);
+    return () => document.removeEventListener('pointerdown', close);
+  }, [menuOpen]);
+
+  return (
+    <article className="sa-card">
+      <button type="button" className="sa-card-head" onClick={() => setExpanded((v) => !v)}
+              aria-expanded={expanded}>
+        <span className="sa-figure"><BodyIcon size={26} /></span>
+        <span className="sa-head-text">
+          <span className="sa-name">{titleCase(symptom.symptom_type)}</span>
+          <span className="sa-loc">{symptom.location ? titleCase(symptom.location) : 'Location not specified'}</span>
+        </span>
+        {expanded ? <ChevronDownIcon size={18} /> : <ChevronRightIcon size={18} />}
+      </button>
+
+      <div className="sa-grid">
+        <div className="sa-cell">
+          <span className="sl-label">Severity (0–10)</span>
+          <span className="sa-severity">
+            <span className={`sa-severity-value band-${band.key}`}>{symptom.severity ?? '—'}</span>
+            <span className="sa-severity-denominator">/ 10</span>
+          </span>
+          <span className={`sl-severity-band band-${band.key}`}>
+            <span className="sl-band-dot" aria-hidden="true" /> {band.label}
+          </span>
+        </div>
+        <div className="sa-cell">
+          <span className="sl-label">Status</span>
+          <span className="sa-status">Ongoing</span>
+          <span className="sa-elapsed">{elapsedLabel(symptom.timestamp)}</span>
+        </div>
+        <div className="sa-cell">
+          <span className="sl-label">Started</span>
+          <span className="sa-stamp">{stamp(symptom.timestamp)}</span>
+        </div>
+        <div className="sa-cell">
+          <span className="sl-label">Duration noted</span>
+          <span className="sa-stamp">{symptom.duration || '—'}</span>
+        </div>
+      </div>
+
+      {expanded && (symptom.description || symptom.notes) && (
+        <div className="sa-details">
+          {symptom.description && <p><span className="sl-label">Observation</span>{symptom.description}</p>}
+          {symptom.notes && <p><span className="sl-label">Care action</span>{symptom.notes}</p>}
+        </div>
+      )}
+
+      <div className="sa-actions">
+        <button type="button" className="sa-resolve" onClick={() => onResolve(symptom.id)}>
+          <CheckCircleIcon size={16} /> Resolve
+        </button>
+        <button type="button" className="sa-icon-btn" aria-label="Edit symptom"
+                onClick={() => onEdit(symptom)}>
+          <EditIcon size={16} />
+        </button>
+        <div className="sa-menu-wrap" ref={menuRef}>
+          <button type="button" className="sa-icon-btn" aria-label="More actions"
+                  aria-expanded={menuOpen} onClick={() => setMenuOpen((v) => !v)}>
+            <MoreHorizontalIcon size={16} />
+          </button>
+          {menuOpen && (
+            <div className="sa-menu" role="menu">
+              <button type="button" role="menuitem" className="sa-menu-item danger"
+                      onClick={() => { setMenuOpen(false); onDelete(symptom); }}>
+                Delete entry
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default function SymptomActiveList({ symptoms = [], loading,
+                                            onResolve, onEdit, onDelete }) {
+  if (loading) return <p className="sh-muted">Loading…</p>;
+  if (symptoms.length === 0) {
+    return <p className="sh-muted">No active symptoms — nothing needs attention.</p>;
+  }
+  const longest = symptoms.reduce((best, s) => {
+    const ms = Date.now() - new Date(s.timestamp).getTime();
+    return ms > best ? ms : best;
+  }, 0);
+  const longestDays = Math.floor(longest / 86400000);
+
+  return (
+    <div className="symptom-active">
+      <div className="sa-summary">
+        <span><span className="sa-summary-num">{symptoms.length}</span> Active</span>
+        <span className="sa-summary-sep" aria-hidden="true" />
+        <span>Longest <span className="sa-summary-num">{longestDays} day{longestDays === 1 ? '' : 's'}</span></span>
+      </div>
+      {symptoms.map((s) => (
+        <ActiveCard key={s.id} symptom={s} onResolve={onResolve}
+                    onEdit={onEdit} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin-v2/components/SymptomHistoryList.jsx
+++ b/frontend/src/pages/admin-v2/components/SymptomHistoryList.jsx
@@ -1,0 +1,191 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Symptom history as a date-grouped timeline (from the supplied mockup):
+// search + filter panel, 7D/30D/90D/ALL range chips, records summary,
+// amber dots for still-active entries and green for resolved.
+import { useMemo, useState } from 'react';
+import {
+  ChevronDownIcon, ChevronRightIcon, FilterIcon, SearchIcon,
+} from '../../../components/Icons';
+import { titleCase, bandFor } from './symptomUtils';
+import '../symptom-log.css';
+
+const RANGES = [
+  { key: '7d', label: '7D', days: 7 },
+  { key: '30d', label: '30D', days: 30 },
+  { key: '90d', label: '90D', days: 90 },
+  { key: 'all', label: 'All', days: null },
+];
+
+const dayKey = (iso) => new Date(iso).toLocaleDateString([], {
+  month: 'short', day: 'numeric', year: 'numeric',
+});
+const timeLabel = (iso) => new Date(iso).toLocaleTimeString([], {
+  hour: 'numeric', minute: '2-digit',
+});
+
+function HistoryEntry({ symptom }) {
+  const [expanded, setExpanded] = useState(false);
+  const band = bandFor(symptom.severity);
+  const resolved = symptom.is_resolved;
+  return (
+    <button type="button" className="sh-entry" onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}>
+      <span className={`sh-dot ${resolved ? 'resolved' : 'active'}`} aria-hidden="true" />
+      <span className="sh-time">{timeLabel(symptom.timestamp)}</span>
+      <span className="sh-main">
+        <span className="sh-name">{titleCase(symptom.symptom_type)}</span>
+        <span className="sh-loc">
+          {symptom.location ? titleCase(symptom.location) : 'No location'}
+        </span>
+        {expanded && (symptom.description || symptom.notes) && (
+          <span className="sh-details">
+            {symptom.description && <span>{symptom.description}</span>}
+            {symptom.notes && <span>Care action: {symptom.notes}</span>}
+          </span>
+        )}
+      </span>
+      <span className="sh-right">
+        <span className="sh-severity">
+          <span className={`sh-severity-value band-${band.key}`}>{symptom.severity ?? '—'}</span>
+          <span className="sh-severity-denominator">/ 10</span>
+        </span>
+        <span className={`sh-status ${resolved ? 'resolved' : 'active'}`}>
+          <span className="sl-band-dot" aria-hidden="true" />
+          {resolved
+            ? `Resolved${symptom.resolved_at ? ` ${dayKey(symptom.resolved_at)}` : ''}`
+            : `Active / ${symptom.duration || 'Ongoing'}`}
+        </span>
+      </span>
+      {expanded ? <ChevronDownIcon size={16} /> : <ChevronRightIcon size={16} />}
+    </button>
+  );
+}
+
+export default function SymptomHistoryList({ symptoms = [], symptomTypes = [], loading }) {
+  const [search, setSearch] = useState('');
+  const [range, setRange] = useState('all');
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [typeFilter, setTypeFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+
+  const activeFilterCount = (typeFilter ? 1 : 0) + (statusFilter !== 'all' ? 1 : 0);
+
+  const visible = useMemo(() => {
+    const rangeDays = RANGES.find((r) => r.key === range)?.days;
+    const cutoff = rangeDays ? Date.now() - rangeDays * 86400000 : null;
+    const q = search.trim().toLowerCase();
+    return symptoms.filter((s) => {
+      if (cutoff && new Date(s.timestamp).getTime() < cutoff) return false;
+      if (typeFilter && s.symptom_type !== typeFilter) return false;
+      if (statusFilter === 'active' && s.is_resolved) return false;
+      if (statusFilter === 'resolved' && !s.is_resolved) return false;
+      if (q) {
+        const hay = `${titleCase(s.symptom_type)} ${titleCase(s.location || '')} ${s.description || ''} ${s.notes || ''}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    }).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+  }, [symptoms, range, search, typeFilter, statusFilter]);
+
+  const groups = useMemo(() => {
+    const byDay = new Map();
+    for (const s of visible) {
+      const key = dayKey(s.timestamp);
+      if (!byDay.has(key)) byDay.set(key, []);
+      byDay.get(key).push(s);
+    }
+    return [...byDay.entries()];
+  }, [visible]);
+
+  const rangeLabel = useMemo(() => {
+    if (visible.length === 0) return '';
+    const times = visible.map((s) => new Date(s.timestamp).getTime());
+    const lo = new Date(Math.min(...times));
+    const hi = new Date(Math.max(...times));
+    const fmt = (d) => d.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+    return lo.toDateString() === hi.toDateString() ? fmt(hi) : `${fmt(lo)} – ${fmt(hi)}`;
+  }, [visible]);
+
+  return (
+    <div className="symptom-history">
+      <div className="sh-toolbar">
+        <div className="sh-search">
+          <SearchIcon size={16} />
+          <input type="text" placeholder="Search symptoms" value={search}
+                 onChange={(e) => setSearch(e.target.value)} />
+        </div>
+        <button type="button" className={`sh-filter-btn ${activeFilterCount ? 'has-filters' : ''}`}
+                aria-expanded={filtersOpen} onClick={() => setFiltersOpen((v) => !v)}>
+          <FilterIcon size={15} /> Filter
+          <span className="sh-filter-count">{activeFilterCount}</span>
+        </button>
+      </div>
+
+      {filtersOpen && (
+        <div className="sh-filter-panel">
+          <label>
+            <span className="sl-label">Type</span>
+            <select value={typeFilter} onChange={(e) => setTypeFilter(e.target.value)}>
+              <option value="">All types</option>
+              {symptomTypes.map((t) => (
+                <option key={t} value={t}>{titleCase(t)}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span className="sl-label">Status</span>
+            <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)}>
+              <option value="all">All</option>
+              <option value="active">Active</option>
+              <option value="resolved">Resolved</option>
+            </select>
+          </label>
+        </div>
+      )}
+
+      <div className="sh-ranges" role="radiogroup" aria-label="Time range">
+        {RANGES.map((r) => (
+          <button key={r.key} type="button" role="radio" aria-checked={range === r.key}
+                  className={`sh-range ${range === r.key ? 'selected' : ''}`}
+                  onClick={() => setRange(r.key)}>
+            {r.label}
+          </button>
+        ))}
+      </div>
+
+      <p className="sh-summary">
+        {loading ? 'Loading…'
+          : `${visible.length} record${visible.length === 1 ? '' : 's'}${rangeLabel ? ` · ${rangeLabel}` : ''}`}
+      </p>
+
+      {!loading && visible.length === 0 && (
+        <p className="sh-muted">No symptoms match the current filters.</p>
+      )}
+
+      {groups.map(([day, entries]) => (
+        <section key={day} className="sh-day">
+          <h3 className="sh-day-label">{day}</h3>
+          <div className="sh-day-entries">
+            {entries.map((s) => <HistoryEntry key={s.id} symptom={s} />)}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin-v2/components/SymptomLogForm.jsx
+++ b/frontend/src/pages/admin-v2/components/SymptomLogForm.jsx
@@ -28,17 +28,7 @@ import {
 import BottomSheet from '../../capture/components/BottomSheet';
 import '../symptom-log.css';
 
-const titleCase = (s) =>
-  (s || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-
-// Severity bands: 0 idle, 1–3 mild (green), 4–7 moderate (amber),
-// 8–10 severe (red — clinical concern, the one place red belongs).
-const bandFor = (sev) => {
-  if (sev === 0) return { key: 'none', label: 'None' };
-  if (sev <= 3) return { key: 'mild', label: 'Mild' };
-  if (sev <= 7) return { key: 'moderate', label: 'Moderate' };
-  return { key: 'severe', label: 'Severe' };
-};
+import { titleCase, bandFor } from './symptomUtils';
 
 const DURATION_OPTIONS = ['Ongoing', '15 minutes', '30 minutes', '1 hour',
                           '2 hours', '4 hours', 'All day'];
@@ -50,22 +40,26 @@ const nowLocalInput = () => {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 };
 
+// `initial` switches the form into edit mode (PUT to the existing record);
+// mount with a key so a different symptom reseeds the state.
 export default function SymptomLogForm({ patient, symptomTypes = [],
-                                         bodyLocations = [], onLogged }) {
+                                         bodyLocations = [], onLogged,
+                                         initial = null, onCancel }) {
   // Recent entries feed the quick chips; fetched here because the page only
   // loads symptoms for its Active/History views.
   const [recentSymptoms, setRecentSymptoms] = useState([]);
-  const [observedAt, setObservedAt] = useState(nowLocalInput);
-  const [timeEdited, setTimeEdited] = useState(false);
+  const [observedAt, setObservedAt] = useState(() =>
+    initial?.timestamp ? initial.timestamp.slice(0, 16) : nowLocalInput());
+  const [timeEdited, setTimeEdited] = useState(Boolean(initial));
   const [editingTime, setEditingTime] = useState(false);
-  const [symptomType, setSymptomType] = useState('');
-  const [severity, setSeverity] = useState(5);
-  const [location, setLocation] = useState('');
-  const [duration, setDuration] = useState('');
-  const [note, setNote] = useState('');
-  const [careAction, setCareAction] = useState('');
-  const [showCareAction, setShowCareAction] = useState(false);
-  const [stillActive, setStillActive] = useState(true);
+  const [symptomType, setSymptomType] = useState(initial?.symptom_type || '');
+  const [severity, setSeverity] = useState(initial?.severity ?? 5);
+  const [location, setLocation] = useState(initial?.location || '');
+  const [duration, setDuration] = useState(initial?.duration || '');
+  const [note, setNote] = useState(initial?.description || '');
+  const [careAction, setCareAction] = useState(initial?.notes || '');
+  const [showCareAction, setShowCareAction] = useState(Boolean(initial?.notes));
+  const [stillActive, setStillActive] = useState(initial ? !initial.is_resolved : true);
   const [sheet, setSheet] = useState(null); // 'type' | 'location' | 'duration'
   const [typeSearch, setTypeSearch] = useState('');
   const [saving, setSaving] = useState(false);
@@ -133,8 +127,11 @@ export default function SymptomLogForm({ patient, symptomTypes = [],
     if (!symptomType || saving) return;
     setSaving(true);
     try {
-      const resp = await apiFetch(`${config.apiUrl}/api/symptoms`, {
-        method: 'POST',
+      const url = initial
+        ? `${config.apiUrl}/api/symptoms/${initial.id}`
+        : `${config.apiUrl}/api/symptoms`;
+      const resp = await apiFetch(url, {
+        method: initial ? 'PUT' : 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           patient_id: patient.id,
@@ -149,9 +146,14 @@ export default function SymptomLogForm({ patient, symptomTypes = [],
         }),
       });
       if (resp.ok) {
-        showToast(`Symptom logged · ${titleCase(symptomType)}`);
-        reset();
-        onLogged?.();
+        if (initial) {
+          onLogged?.();
+          onCancel?.();
+        } else {
+          showToast(`Symptom logged · ${titleCase(symptomType)}`);
+          reset();
+          onLogged?.();
+        }
       } else {
         const data = await resp.json().catch(() => ({}));
         showToast(typeof data.detail === 'string' ? data.detail : 'Could not log symptom', 'error');
@@ -315,14 +317,18 @@ export default function SymptomLogForm({ patient, symptomTypes = [],
 
       {/* Footer */}
       <div className="sl-footer">
-        <span className={`sl-footer-status ${missingRequired ? 'missing' : 'ready'}`}>
-          {missingRequired
-            ? `${missingRequired} required field${missingRequired === 1 ? '' : 's'}`
-            : 'Ready to log'}
-        </span>
+        {onCancel ? (
+          <button type="button" className="sl-cancel" onClick={onCancel}>Cancel</button>
+        ) : (
+          <span className={`sl-footer-status ${missingRequired ? 'missing' : 'ready'}`}>
+            {missingRequired
+              ? `${missingRequired} required field${missingRequired === 1 ? '' : 's'}`
+              : 'Ready to log'}
+          </span>
+        )}
         <button type="button" className="sl-submit"
                 disabled={missingRequired > 0 || saving} onClick={submit}>
-          {saving ? 'Logging…' : 'Log symptom'}
+          {saving ? 'Saving…' : initial ? 'Update symptom' : 'Log symptom'}
         </button>
       </div>
 

--- a/frontend/src/pages/admin-v2/components/SymptomViews.test.jsx
+++ b/frontend/src/pages/admin-v2/components/SymptomViews.test.jsx
@@ -1,0 +1,76 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Active cards + history timeline behaviors.
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import SymptomActiveList from './SymptomActiveList';
+import SymptomHistoryList from './SymptomHistoryList';
+
+const daysAgo = (d) => new Date(Date.now() - d * 86400000).toISOString();
+const ACTIVE = [
+  { id: 1, symptom_type: 'pain', severity: 10, location: 'abdomen',
+    duration: 'Ongoing', timestamp: daysAgo(4), is_resolved: false },
+  { id: 2, symptom_type: 'chills', severity: 9, timestamp: daysAgo(11), is_resolved: false },
+];
+const HISTORY = [
+  ...ACTIVE,
+  { id: 3, symptom_type: 'cough', severity: 3, timestamp: daysAgo(2),
+    is_resolved: true, resolved_at: daysAgo(1) },
+  { id: 4, symptom_type: 'spasticity', severity: 5, timestamp: daysAgo(40),
+    is_resolved: true, resolved_at: daysAgo(39) },
+];
+
+describe('SymptomActiveList', () => {
+  it('summarizes and wires the card actions', () => {
+    const onResolve = vi.fn();
+    const onEdit = vi.fn();
+    render(<SymptomActiveList symptoms={ACTIVE} onResolve={onResolve}
+                              onEdit={onEdit} onDelete={vi.fn()} />);
+    expect(screen.getByText('2')).toBeInTheDocument();          // 2 Active
+    expect(screen.getByText(/11 days/i)).toBeInTheDocument();   // longest
+    fireEvent.click(screen.getAllByRole('button', { name: /Resolve/i })[0]);
+    expect(onResolve).toHaveBeenCalledWith(1);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit symptom' })[0]);
+    expect(onEdit).toHaveBeenCalledWith(ACTIVE[0]);
+  });
+});
+
+describe('SymptomHistoryList', () => {
+  it('sorts newest first and honors the range chips', () => {
+    render(<SymptomHistoryList symptoms={HISTORY} symptomTypes={['pain', 'cough']} />);
+    const names = () => [...document.querySelectorAll('.sh-name')].map((n) => n.textContent);
+    expect(names()).toEqual(['Cough', 'Pain', 'Chills', 'Spasticity']); // desc by time
+    expect(screen.getByText(/4 records/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('radio', { name: '7D' }));
+    expect(names()).toEqual(['Cough', 'Pain']);
+  });
+
+  it('filters by search and status', () => {
+    render(<SymptomHistoryList symptoms={HISTORY} symptomTypes={['pain', 'cough']} />);
+    fireEvent.change(screen.getByPlaceholderText(/Search symptoms/i),
+                     { target: { value: 'chills' } });
+    expect(screen.getByText(/1 record\b/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText(/Search symptoms/i),
+                     { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /Filter/i }));
+    fireEvent.change(screen.getByDisplayValue('All'), { target: { value: 'resolved' } });
+    expect(screen.getByText(/2 records/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Resolved/).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/pages/admin-v2/components/symptomUtils.js
+++ b/frontend/src/pages/admin-v2/components/symptomUtils.js
@@ -1,0 +1,42 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Shared helpers for the symptoms views (log form, active cards, history).
+
+export const titleCase = (s) =>
+  (s || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+// Severity bands: 0 idle, 1–3 mild (green), 4–7 moderate (amber),
+// 8–10 severe (red — clinical concern, the one place red belongs).
+export const bandFor = (sev) => {
+  if (!sev || sev === 0) return { key: 'none', label: 'None' };
+  if (sev <= 3) return { key: 'mild', label: 'Mild' };
+  if (sev <= 7) return { key: 'moderate', label: 'Moderate' };
+  return { key: 'severe', label: 'Severe' };
+};
+
+// "4D 19H" style elapsed label from an ISO start time.
+export const elapsedLabel = (iso) => {
+  if (!iso) return '';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 0) return '0H';
+  const hours = Math.floor(ms / 3600000);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `${days}D ${hours % 24}H`;
+  if (hours > 0) return `${hours}H`;
+  return `${Math.max(1, Math.floor(ms / 60000))}M`;
+};

--- a/frontend/src/pages/admin-v2/symptom-log.css
+++ b/frontend/src/pages/admin-v2/symptom-log.css
@@ -937,19 +937,36 @@
 .sh-status.active { color: var(--vc-state-due); }
 .sh-status.resolved { color: var(--vc-state-complete); }
 
-/* Edit overlay: the log form reused as an editor */
+/* Edit overlay: the log form reused as an editor (Radix Dialog chrome) */
 .sl-edit-overlay {
   position: fixed;
   inset: 0;
   z-index: 1000;
   background: rgba(0, 0, 0, 0.65);
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 2rem 0.75rem;
-  overflow-y: auto;
 }
-.sl-edit-panel { width: 100%; max-width: 560px; }
+.sl-edit-panel {
+  position: fixed;
+  left: 50%;
+  top: 1.5rem;
+  transform: translateX(-50%);
+  z-index: 1001;
+  width: calc(100% - 1.5rem);
+  max-width: 560px;
+  max-height: calc(100dvh - 3rem);
+  overflow-y: auto;
+  border-radius: 12px;
+}
+.sl-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 .sl-cancel {
   background: transparent;
   border: 1px solid var(--vc-line-strong);

--- a/frontend/src/pages/admin-v2/symptom-log.css
+++ b/frontend/src/pages/admin-v2/symptom-log.css
@@ -207,10 +207,10 @@
 
 /* Severity — band colors are semantic: none idle, mild green, moderate
  * amber, severe red (clinical) */
-.symptom-log .band-none { --sl-band: var(--vc-state-idle); }
-.symptom-log .band-mild { --sl-band: var(--vc-state-complete); }
-.symptom-log .band-moderate { --sl-band: var(--vc-state-due); }
-.symptom-log .band-severe { --sl-band: var(--vc-state-alert); }
+.symptom-log .band-none, .symptom-active .band-none, .symptom-history .band-none { --sl-band: var(--vc-state-idle); }
+.symptom-log .band-mild, .symptom-active .band-mild, .symptom-history .band-mild { --sl-band: var(--vc-state-complete); }
+.symptom-log .band-moderate, .symptom-active .band-moderate, .symptom-history .band-moderate { --sl-band: var(--vc-state-due); }
+.symptom-log .band-severe, .symptom-active .band-severe, .symptom-history .band-severe { --sl-band: var(--vc-state-alert); }
 
 .sl-severity-hero {
   display: flex;
@@ -519,3 +519,449 @@
 @media (prefers-reduced-motion: reduce) {
   .sl-toast { animation: none; }
 }
+
+/* ================= Active symptoms cards ================= */
+.symptom-active {
+  max-width: 560px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-variant-numeric: tabular-nums;
+}
+.symptom-active *, .symptom-active *::before, .symptom-active *::after { box-sizing: border-box; }
+.symptom-active button { appearance: none; -webkit-appearance: none; font-family: inherit; }
+
+.sa-summary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  padding: 0.6rem 0.9rem;
+  font-family: var(--vc-font-mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.sa-summary-num { color: var(--vc-data-live); font-weight: 600; }
+.sa-summary-sep { width: 1px; height: 16px; background: var(--vc-line-strong); }
+
+.sa-card {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.sa-card-head {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--vc-line-hairline);
+  color: var(--vc-text-secondary);
+  padding: 0.75rem 0.9rem;
+  min-height: 60px;
+  cursor: pointer;
+  text-align: left;
+}
+.sa-figure {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-content: center;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  color: var(--vc-text-secondary);
+  flex-shrink: 0;
+}
+.sa-head-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.sa-name {
+  font-family: var(--vc-font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+.sa-loc {
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+.sa-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--vc-line-hairline);
+}
+.sa-cell {
+  background: var(--vc-bg-surface);
+  padding: 0.65rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.sa-cell .sl-label { margin-top: 0; }
+.sa-severity { display: flex; align-items: baseline; gap: 0.4rem; }
+.sa-severity-value {
+  font-family: var(--vc-font-mono);
+  font-size: 34px;
+  font-weight: 400;
+  line-height: 1;
+  color: var(--sl-band);
+}
+.sa-severity-denominator { font-family: var(--vc-font-mono); font-size: 15px; color: var(--vc-text-secondary); }
+.sa-status {
+  font-family: var(--vc-font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-data-live);
+}
+.sa-elapsed, .sa-stamp {
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+.sa-details {
+  border-top: 1px solid var(--vc-line-hairline);
+  padding: 0.6rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 14px;
+  color: var(--vc-text-primary);
+}
+.sa-details p { margin: 0; display: flex; flex-direction: column; gap: 2px; }
+
+.sa-actions {
+  display: flex;
+  gap: 0.5rem;
+  border-top: 1px solid var(--vc-line-hairline);
+  padding: 0.6rem 0.9rem;
+}
+.sa-resolve {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--vc-data-live) 50%, transparent);
+  border-radius: 8px;
+  color: var(--vc-data-live);
+  font-family: var(--vc-font-mono);
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  min-height: 46px;
+  cursor: pointer;
+}
+.sa-resolve:hover { background: color-mix(in srgb, var(--vc-data-live) 12%, transparent); }
+.sa-icon-btn {
+  width: 56px;
+  min-height: 46px;
+  display: grid;
+  place-content: center;
+  background: transparent;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+.sa-icon-btn:hover { border-color: var(--vc-line-strong); color: var(--vc-text-primary); }
+.sa-menu-wrap { position: relative; }
+.sa-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 6px);
+  background: var(--vc-bg-raised);
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  min-width: 160px;
+  padding: 0.25rem;
+  z-index: 20;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+.sa-menu-item {
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  text-align: left;
+  font-size: 14px;
+  padding: 0.6rem 0.7rem;
+  min-height: 44px;
+  color: var(--vc-text-primary);
+  cursor: pointer;
+}
+.sa-menu-item:hover { background: var(--vc-bg-surface); }
+.sa-menu-item.danger { color: var(--vc-state-alert); }
+
+/* ================= History timeline ================= */
+.symptom-history {
+  max-width: 560px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-variant-numeric: tabular-nums;
+}
+.symptom-history *, .symptom-history *::before, .symptom-history *::after { box-sizing: border-box; }
+.symptom-history button { appearance: none; -webkit-appearance: none; font-family: inherit; }
+
+.sh-toolbar { display: flex; gap: 0.5rem; }
+.sh-search {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: transparent;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  padding: 0 0.75rem;
+  color: var(--vc-text-secondary);
+}
+.sh-search input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  min-height: 48px;
+}
+.sh-search input::placeholder { color: var(--vc-text-tertiary); }
+.sh-search:focus-within {
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--vc-data-live) 30%, transparent);
+}
+.sh-filter-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: transparent;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0 0.8rem;
+  min-height: 48px;
+  cursor: pointer;
+}
+.sh-filter-btn:hover, .sh-filter-btn.has-filters { color: var(--vc-text-primary); }
+.sh-filter-count {
+  display: grid;
+  place-content: center;
+  min-width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--vc-data-live) 30%, transparent);
+  color: var(--vc-data-live);
+  font-size: 11px;
+}
+.sh-filter-panel {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  padding: 0.6rem 0.75rem;
+}
+.sh-filter-panel label { display: flex; flex-direction: column; gap: 0.3rem; }
+.sh-filter-panel select {
+  background: var(--vc-bg-raised);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  min-height: 44px;
+  padding: 0 0.5rem;
+}
+.sh-filter-panel select:focus {
+  outline: none;
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--vc-data-live) 30%, transparent);
+}
+
+.sh-ranges {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--vc-line-hairline);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.sh-range {
+  background: var(--vc-bg-base);
+  border: none;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  min-height: 44px;
+  cursor: pointer;
+}
+.sh-range.selected { background: var(--vc-bg-raised); color: var(--vc-data-live); }
+
+.sh-summary {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.sh-muted { color: var(--vc-text-secondary); }
+
+.sh-day { margin-top: 0.35rem; }
+.sh-day-label {
+  margin: 0 0 0.35rem;
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.sh-day-entries {
+  border-left: 1px solid var(--vc-line-strong);
+  margin-left: 4px;
+  display: flex;
+  flex-direction: column;
+}
+.sh-entry {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  background: transparent;
+  border: none;
+  border-top: 1px solid var(--vc-line-hairline);
+  color: var(--vc-text-primary);
+  padding: 0.7rem 0.25rem 0.7rem 0;
+  min-height: 64px;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+.sh-entry:first-child { border-top: none; }
+.sh-entry:hover { background: var(--vc-bg-surface); }
+.sh-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  margin-left: -5px;
+  flex-shrink: 0;
+}
+.sh-dot.active { background: var(--vc-state-due); }
+.sh-dot.resolved { background: var(--vc-state-complete); }
+.sh-time {
+  font-family: var(--vc-font-mono);
+  font-size: 12.5px;
+  letter-spacing: 0.04em;
+  color: var(--vc-text-secondary);
+  min-width: 66px;
+  flex-shrink: 0;
+}
+.sh-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.sh-name {
+  font-family: var(--vc-font-mono);
+  font-size: 14.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sh-loc {
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sh-details { font-size: 13px; color: var(--vc-text-secondary); display: flex; flex-direction: column; gap: 2px; }
+.sh-right { display: flex; flex-direction: column; align-items: flex-start; gap: 3px; flex-shrink: 0; }
+.sh-severity { display: flex; align-items: baseline; gap: 0.3rem; }
+.sh-severity-value {
+  font-family: var(--vc-font-mono);
+  font-size: 20px;
+  font-weight: 500;
+  color: var(--sl-band);
+}
+.sh-severity-denominator { font-family: var(--vc-font-mono); font-size: 12px; color: var(--vc-text-secondary); }
+.sh-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.sh-status.active { color: var(--vc-state-due); }
+.sh-status.resolved { color: var(--vc-state-complete); }
+
+/* Edit overlay: the log form reused as an editor */
+.sl-edit-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2rem 0.75rem;
+  overflow-y: auto;
+}
+.sl-edit-panel { width: 100%; max-width: 560px; }
+.sl-cancel {
+  background: transparent;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  min-height: 50px;
+  padding: 0 1.1rem;
+  cursor: pointer;
+}
+.sl-cancel:hover { background: var(--vc-bg-raised); }


### PR DESCRIPTION
Implements the supplied Active and History mockups with our tokens, and finishes the symptoms family by moving EDIT onto the new form.

**Active** — summary strip (`2 ACTIVE | LONGEST 11 DAYS`), per-symptom cards: figure tile, severity hero with clinical band, ONGOING elapsed (`4D 19H`), started stamp, noted duration, expandable details, and Resolve / edit / overflow-Delete wired to the existing endpoints. One honest adaptation: the mockup's LAST UPDATED cell became **Duration noted** — there's no `updated_at` column to back it truthfully.

**History** — search + filter panel (type/status with a count badge), 7D/30D/90D/ALL range chips, records summary with the visible date span, and a date-grouped timeline sorted newest-first: amber dots for still-active entries, green for resolved with the resolve date.

**Edit** — the old shadcn dialog (rainbow severity slider, red asterisks) is gone; editing reuses `SymptomLogForm` in edit mode (prefilled, PUT, Cancel/Update footer) inside a vc overlay. The page shed its dead filter state; history fetches once per patient and filters client-side.

3 new Vitest cases; 361 total green, lint/build green. Verified live at 390px (log, active, edit overlay, history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS8WMSAiMKmozbMuwbiocw