### PR TITLE
Entity admin pages rebuilt on shared EntityCard/EntityModal components

### DIFF
--- a/frontend/src/components/Icons.jsx
+++ b/frontend/src/components/Icons.jsx
@@ -986,3 +986,37 @@ export const BodyIcon = ({ size = 20 }) => (
     <path d="M12 7.5v6.5M12 14l-2.5 6M12 14l2.5 6M6.5 9.5 12 8.2l5.5 1.3" />
   </svg>
 );
+export const PhoneIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M22 16.9v3a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3.1 19.5 19.5 0 0 1-6-6A19.8 19.8 0 0 1 2.1 4.2 2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.1 1 .4 2 .7 2.9a2 2 0 0 1-.5 2.1L8.1 10a16 16 0 0 0 6 6l1.3-1.3a2 2 0 0 1 2.1-.4c.9.3 1.9.5 2.9.7a2 2 0 0 1 1.6 2z" />
+  </svg>
+);
+export const MailIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="2.5" y="4.5" width="19" height="15" rx="2" />
+    <path d="m3 6 9 7 9-7" />
+  </svg>
+);
+export const StethoscopeIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M5 3v6a5 5 0 0 0 10 0V3M5 3H3.5M15 3h1.5M10 14v3a5 5 0 0 0 10 0v-2" />
+    <circle cx="20" cy="12.5" r="2" />
+  </svg>
+);
+export const GlobeIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="9" />
+    <path d="M3 12h18M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18z" />
+  </svg>
+);
+export const MoreVerticalIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" stroke="none">
+    <circle cx="12" cy="5" r="1.6" />
+    <circle cx="12" cy="12" r="1.6" />
+    <circle cx="12" cy="19" r="1.6" />
+  </svg>
+);

--- a/frontend/src/components/vc/EntityCard.jsx
+++ b/frontend/src/components/vc/EntityCard.jsx
@@ -103,7 +103,7 @@ export default function EntityCard({
                 {d.icon && <span className="ec-detail-icon" aria-hidden="true">{d.icon}</span>}
                 <span className="ec-detail-text">
                   <span className="ec-detail-label">{d.label}</span>
-                  <span className="ec-detail-value">{d.value || '—'}</span>
+                  <span className="ec-detail-value">{d.value || d.value === 0 ? d.value : '—'}</span>
                 </span>
               </div>
             ))}
@@ -115,7 +115,7 @@ export default function EntityCard({
                 return a.href ? (
                   <a key={a.label} className="ec-quick-btn" href={a.href}
                      aria-label={a.label} title={a.label}
-                     {...(a.external ? { target: '_blank', rel: 'noreferrer' } : {})}>{inner}</a>
+                     {...(a.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}>{inner}</a>
                 ) : (
                   <button key={a.label} type="button" className="ec-quick-btn"
                           aria-label={a.label} title={a.label}

--- a/frontend/src/components/vc/EntityCard.jsx
+++ b/frontend/src/components/vc/EntityCard.jsx
@@ -1,0 +1,133 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// THE standard entity card for config pages (providers, businesses,
+// connections, diagnoses, …), from the providers mockup:
+//
+//   [avatar]  NAME                          ⋮
+//             (badge) (badge)          TAG
+//   ───────────────────────────────────────
+//   icon | Label            │  [quick] [quick]
+//        | VALUE            │
+//   icon | Label            │
+//        | VALUE            │
+//
+// All slots optional. Colors come from the vc tokens; keep new usages to
+// the props here rather than custom card markup.
+import { useEffect, useRef, useState } from 'react';
+import { MoreVerticalIcon } from '../Icons';
+import './entity-card.css';
+
+export default function EntityCard({
+  initials,          // avatar initials (string) — or pass `icon` instead
+  icon,              // avatar icon node (e.g. <PlugIcon/>)
+  title,
+  badges = [],       // strings -> outline pills under the title
+  tag,               // { label, tone?: 'accent'|'complete'|'due'|'idle' }
+  inactive = false,  // dims the card
+  details = [],      // [{ icon, label, value }]
+  quickActions = [], // [{ icon, label, href?, onClick?, external? }] -> accent tiles
+  menu = [],         // [{ label, onClick, danger? }] -> kebab menu
+  children,          // optional extra content below the detail grid
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    if (!menuOpen) return undefined;
+    const close = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) setMenuOpen(false);
+    };
+    document.addEventListener('pointerdown', close);
+    return () => document.removeEventListener('pointerdown', close);
+  }, [menuOpen]);
+
+  return (
+    <article className={`ec-card ${inactive ? 'inactive' : ''}`}>
+      <header className="ec-head">
+        <span className="ec-avatar" aria-hidden="true">
+          {icon || initials}
+        </span>
+        <div className="ec-head-text">
+          <h3 className="ec-title">{title}</h3>
+          {(badges.length > 0 || tag) && (
+            <div className="ec-badges">
+              {badges.map((b) => <span key={b} className="ec-badge">{b}</span>)}
+              {tag && (
+                <span className={`ec-tag tone-${tag.tone || 'accent'}`}>{tag.label}</span>
+              )}
+            </div>
+          )}
+        </div>
+        {menu.length > 0 && (
+          <div className="ec-menu-wrap" ref={menuRef}>
+            <button type="button" className="ec-kebab" aria-label={`Actions for ${title}`}
+                    aria-haspopup="menu" aria-expanded={menuOpen}
+                    onClick={() => setMenuOpen((v) => !v)}>
+              <MoreVerticalIcon size={18} />
+            </button>
+            {menuOpen && (
+              <div className="ec-menu" role="menu">
+                {menu.map((item) => (
+                  <button key={item.label} type="button" role="menuitem"
+                          className={`ec-menu-item ${item.danger ? 'danger' : ''}`}
+                          onClick={() => { setMenuOpen(false); item.onClick(); }}>
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </header>
+
+      {(details.length > 0 || quickActions.length > 0) && (
+        <div className="ec-body">
+          <div className="ec-details">
+            {details.map((d) => (
+              <div key={d.label} className="ec-detail">
+                {d.icon && <span className="ec-detail-icon" aria-hidden="true">{d.icon}</span>}
+                <span className="ec-detail-text">
+                  <span className="ec-detail-label">{d.label}</span>
+                  <span className="ec-detail-value">{d.value || '—'}</span>
+                </span>
+              </div>
+            ))}
+          </div>
+          {quickActions.length > 0 && (
+            <div className="ec-quick">
+              {quickActions.map((a) => {
+                const inner = a.icon;
+                return a.href ? (
+                  <a key={a.label} className="ec-quick-btn" href={a.href}
+                     aria-label={a.label} title={a.label}
+                     {...(a.external ? { target: '_blank', rel: 'noreferrer' } : {})}>{inner}</a>
+                ) : (
+                  <button key={a.label} type="button" className="ec-quick-btn"
+                          aria-label={a.label} title={a.label}
+                          onClick={a.onClick}>{inner}</button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {children}
+    </article>
+  );
+}

--- a/frontend/src/components/vc/EntityModal.jsx
+++ b/frontend/src/components/vc/EntityModal.jsx
@@ -1,0 +1,95 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// THE standard add/edit dialog for entity pages, pairing with EntityCard.
+// Bare Radix Dialog (focus trap + Escape) with vc chrome; form fields are
+// native inputs/selects/textareas carrying the em-input class, wrapped in
+// EmField/EmRow. Required fields get the amber REQUIRED tag (never a red
+// asterisk — red stays clinical).
+//
+//   <EntityModal open={open} onOpenChange={...} title="Edit provider">
+//     <form className="em-form" onSubmit={...}>
+//       {error && <div className="em-error">{error}</div>}
+//       <EmRow>
+//         <EmField label="First name" required htmlFor="p-first">
+//           <input id="p-first" className="em-input" ... />
+//         </EmField>
+//         ...
+//       </EmRow>
+//       <EmField label="Type"><EmSelect ...>{options}</EmSelect></EmField>
+//       <label className="em-check-row">
+//         <input type="checkbox" className="em-check" ... />
+//         <span className="em-check-label">…</span>
+//       </label>
+//       <div className="em-footer">
+//         <button type="button" className="em-cancel" ...>Cancel</button>
+//         <button type="submit" className="em-submit" ...>Save</button>
+//       </div>
+//     </form>
+//   </EntityModal>
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon, ChevronDownIcon } from '../Icons';
+import './entity-card.css';
+
+export default function EntityModal({ open, onOpenChange, title, wide = false, children }) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="em-overlay" />
+        <DialogPrimitive.Content
+          className={`em-panel ${wide ? 'wide' : ''}`}
+          aria-describedby={undefined}
+        >
+          <div className="em-head">
+            <DialogPrimitive.Title className="em-title">{title}</DialogPrimitive.Title>
+            <DialogPrimitive.Close className="em-close" aria-label="Close">
+              <XIcon size={18} />
+            </DialogPrimitive.Close>
+          </div>
+          {children}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+export function EmField({ label, required = false, optional = false, htmlFor, children }) {
+  return (
+    <div className="em-field">
+      <label className="em-label" htmlFor={htmlFor}>
+        {label}
+        {required && <span className="em-req">Required</span>}
+        {optional && <span className="em-optional">Optional</span>}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+export function EmRow({ children }) {
+  return <div className="em-row">{children}</div>;
+}
+
+// Native select with the vc chevron; forwards all props to <select>.
+export function EmSelect({ children, ...props }) {
+  return (
+    <span className="em-select-wrap">
+      <select className="em-input" {...props}>{children}</select>
+      <ChevronDownIcon size={16} />
+    </span>
+  );
+}

--- a/frontend/src/components/vc/EntityToolbar.jsx
+++ b/frontend/src/components/vc/EntityToolbar.jsx
@@ -1,0 +1,76 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Standard toolbar for entity-card pages: count tabs, search, optional
+// filter select, Add. The mockup's single row cramps the search on phones,
+// so this wraps to two rows there: counts + Add first, search + filter on
+// their own full-width line.
+import { PlusIcon, SearchIcon } from '../Icons';
+import './entity-card.css';
+
+export default function EntityToolbar({
+  counts = [],       // [{ key, label, count }]
+  activeCount,       // key of the selected count tab
+  onCountChange,
+  search = '',
+  onSearchChange,
+  searchPlaceholder = 'Search…',
+  filter,            // { value, onChange, options: [{value,label}], label } — or an array of these
+  onAdd,
+  addLabel = 'Add',
+}) {
+  return (
+    <div className="ec-toolbar">
+      <div className="ec-toolbar-row">
+        {counts.length > 0 && (
+          <div className="ec-counts" role="tablist">
+            {counts.map((c) => (
+              <button key={c.key} type="button" role="tab"
+                      aria-selected={activeCount === c.key}
+                      className={`ec-count ${activeCount === c.key ? 'selected' : ''}`}
+                      onClick={() => onCountChange(c.key)}>
+                {c.label} <span className="ec-count-num">{c.count}</span>
+              </button>
+            ))}
+          </div>
+        )}
+        {onAdd && (
+          <button type="button" className="ec-add" onClick={onAdd}>
+            <PlusIcon size={16} /> {addLabel}
+          </button>
+        )}
+      </div>
+      <div className="ec-toolbar-row">
+        <div className="ec-search">
+          <SearchIcon size={16} />
+          <input type="text" placeholder={searchPlaceholder} value={search}
+                 onChange={(e) => onSearchChange(e.target.value)} />
+        </div>
+        {(Array.isArray(filter) ? filter : filter ? [filter] : []).map((f) => (
+          <label key={f.label} className="ec-filter">
+            <span className="ec-filter-label">{f.label}</span>
+            <select value={f.value} onChange={(e) => f.onChange(e.target.value)}>
+              {f.options.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/vc/EntityToolbar.jsx
+++ b/frontend/src/components/vc/EntityToolbar.jsx
@@ -57,7 +57,7 @@ export default function EntityToolbar({
       <div className="ec-toolbar-row">
         <div className="ec-search">
           <SearchIcon size={16} />
-          <input type="text" placeholder={searchPlaceholder} value={search}
+          <input type="text" placeholder={searchPlaceholder} aria-label={searchPlaceholder || 'Search'} value={search}
                  onChange={(e) => onSearchChange(e.target.value)} />
         </div>
         {(Array.isArray(filter) ? filter : filter ? [filter] : []).map((f) => (

--- a/frontend/src/components/vc/entity-card.css
+++ b/frontend/src/components/vc/entity-card.css
@@ -1,0 +1,629 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* THE standard entity-card + toolbar vocabulary for config pages
+ * (providers / businesses / connections / diagnoses …). vc-native (dark by
+ * design), tokens only. */
+@import '../../styles/vc-tokens.css';
+
+.ec-card, .ec-toolbar,
+.ec-card *, .ec-toolbar *,
+.ec-card *::before, .ec-toolbar *::before,
+.ec-card *::after, .ec-toolbar *::after { box-sizing: border-box; }
+.ec-card button, .ec-toolbar button {
+  appearance: none;
+  -webkit-appearance: none;
+  font-family: inherit;
+}
+
+/* ---------- Card ---------- */
+.ec-card {
+  min-width: 0;
+  max-width: 100%;
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 12px;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-variant-numeric: tabular-nums;
+  overflow: visible; /* kebab menu overhangs */
+}
+.ec-card.inactive { opacity: 0.6; }
+
+.ec-head {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 0.9rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.ec-avatar {
+  width: 46px;
+  height: 46px;
+  flex-shrink: 0;
+  display: grid;
+  place-content: center;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 50%;
+  color: var(--vc-data-live);
+  font-family: var(--vc-font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.ec-head-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 0.3rem; }
+.ec-title {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 14.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ec-badges { display: flex; gap: 0.4rem; flex-wrap: wrap; align-items: center; }
+/* The status tag sits on the badge row, pushed to the far right,
+ * across from the type badge. */
+.ec-badges .ec-tag { margin-left: auto; padding-right: 0.15rem; }
+.ec-badge {
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.ec-tag {
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+.ec-tag.tone-accent { color: var(--vc-data-live); }
+.ec-tag.tone-complete { color: var(--vc-state-complete); }
+.ec-tag.tone-due { color: var(--vc-state-due); }
+.ec-tag.tone-idle { color: var(--vc-text-tertiary); }
+
+.ec-kebab {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+.ec-kebab:hover { color: var(--vc-text-primary); background: var(--vc-bg-raised); }
+.ec-menu-wrap { position: relative; flex-shrink: 0; }
+.ec-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  background: var(--vc-bg-raised);
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  min-width: 170px;
+  padding: 0.25rem;
+  z-index: 30;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+.ec-menu-item {
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  text-align: left;
+  font-size: 14px;
+  padding: 0.6rem 0.7rem;
+  min-height: 44px;
+  color: var(--vc-text-primary);
+  cursor: pointer;
+}
+.ec-menu-item:hover { background: var(--vc-bg-surface); }
+.ec-menu-item.danger { color: var(--vc-state-alert); }
+
+.ec-body {
+  display: flex;
+  align-items: stretch;
+  gap: 0.75rem;
+  padding: 0.7rem 0.9rem;
+}
+.ec-details {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.ec-detail { display: flex; align-items: center; gap: 0.7rem; min-width: 0; }
+.ec-detail-icon {
+  color: var(--vc-text-secondary);
+  flex-shrink: 0;
+  display: flex;
+}
+.ec-detail-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.ec-detail-label { font-size: 12px; color: var(--vc-text-secondary); }
+.ec-detail-value {
+  font-family: var(--vc-font-mono);
+  font-size: 13.5px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ec-quick {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.5rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid var(--vc-line-hairline);
+}
+.ec-quick-btn {
+  width: 52px;
+  height: 44px;
+  display: grid;
+  place-content: center;
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--vc-data-live) 45%, transparent);
+  border-radius: 8px;
+  color: var(--vc-data-live);
+  cursor: pointer;
+  text-decoration: none;
+}
+.ec-quick-btn:hover { background: color-mix(in srgb, var(--vc-data-live) 12%, transparent); }
+
+/* ---------- Toolbar ---------- */
+.ec-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.9rem;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+}
+/* Rows wrap so search keeps breathing room when a page has two filter
+ * selects (e.g. diagnoses: status + category) on a phone. */
+.ec-toolbar-row { display: flex; gap: 0.5rem; align-items: stretch; flex-wrap: wrap; }
+.ec-counts {
+  flex: 1;
+  display: flex;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.ec-count {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  min-height: 46px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+.ec-count + .ec-count { border-left: 1px solid var(--vc-line-hairline); }
+.ec-count.selected { color: var(--vc-data-live); background: var(--vc-bg-surface); }
+.ec-count-num { color: var(--vc-text-primary); }
+.ec-count.selected .ec-count-num { color: var(--vc-data-live); }
+
+.ec-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--vc-data-live) 45%, transparent);
+  border-radius: 10px;
+  color: var(--vc-data-live);
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0 0.9rem;
+  min-height: 46px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.ec-add:hover { background: color-mix(in srgb, var(--vc-data-live) 12%, transparent); }
+
+.ec-search {
+  flex: 1 1 12rem;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  padding: 0 0.75rem;
+  color: var(--vc-text-secondary);
+}
+.ec-search input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-size: 14px;
+  min-height: 46px;
+}
+.ec-search input::placeholder { color: var(--vc-text-tertiary); }
+.ec-search:focus-within {
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--vc-data-live) 30%, transparent);
+}
+.ec-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  padding: 0 0.35rem 0 0.75rem;
+  flex-shrink: 0;
+}
+.ec-filter-label {
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.ec-filter select {
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-size: 13.5px;
+  min-height: 44px;
+  max-width: 9rem;
+}
+.ec-filter select:focus-visible { outline: 2px solid var(--vc-data-live); border-radius: 6px; }
+
+/* Grid helper for the card lists. minmax(0,…) everywhere: the cards keep
+ * overflow visible (kebab menu) so an auto track minimum would let long
+ * nowrap values push the grid past the viewport. */
+.ec-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
+}
+@media (min-width: 900px) {
+  .ec-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (min-width: 1400px) {
+  .ec-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+/* Desktop: the toolbar collapses back to one row */
+@media (min-width: 720px) {
+  .ec-toolbar { flex-direction: row; }
+  .ec-toolbar-row { flex: 1; }
+  .ec-toolbar-row:first-child { flex: 0 1 auto; }
+  .ec-counts { flex: 0 1 auto; }
+  .ec-count { padding: 0 0.9rem; flex: 0 1 auto; }
+  /* Add moves visually to the far right */
+  .ec-toolbar-row:first-child { order: 2; }
+  .ec-toolbar-row:last-child { order: 1; }
+  .ec-counts { order: 0; }
+}
+
+.ec-empty {
+  border: 1px dashed var(--vc-line-strong);
+  border-radius: 12px;
+  padding: 2.25rem 1rem;
+  text-align: center;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-sans);
+}
+
+/* ---------- Entity modal (add/edit dialogs) ---------- */
+.em-panel, .em-panel *, .em-panel *::before, .em-panel *::after { box-sizing: border-box; }
+.em-panel button {
+  appearance: none;
+  -webkit-appearance: none;
+  font-family: inherit;
+}
+
+.em-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.65);
+}
+.em-panel {
+  position: fixed;
+  left: 50%;
+  top: 1.5rem;
+  transform: translateX(-50%);
+  z-index: 1001;
+  width: calc(100% - 1.5rem);
+  max-width: 560px;
+  max-height: calc(100dvh - 3rem);
+  overflow-y: auto;
+  background: var(--vc-bg-sheet);
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 12px;
+  padding: 1rem;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+}
+.em-panel.wide { max-width: 680px; }
+
+.em-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-bottom: 0.7rem;
+  margin-bottom: 0.9rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.em-title {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 14.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+.em-close {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  display: grid;
+  place-content: center;
+  background: transparent;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+.em-close:hover {
+  color: var(--vc-text-primary);
+  background: var(--vc-bg-raised);
+  border-color: var(--vc-line-strong);
+}
+
+.em-form { display: flex; flex-direction: column; gap: 0.9rem; }
+.em-field { display: flex; flex-direction: column; gap: 0.35rem; min-width: 0; }
+.em-label {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+/* Required = needs action -> amber (red stays clinical) */
+.em-req {
+  color: var(--vc-state-due);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+}
+.em-optional { color: var(--vc-text-tertiary); font-size: 10px; letter-spacing: 0.06em; }
+.em-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+@media (max-width: 480px) {
+  .em-row { grid-template-columns: 1fr; }
+}
+
+.em-input {
+  width: 100%;
+  background: var(--vc-bg-raised);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-size: 15px;
+  min-height: 46px;
+  padding: 0.5rem 0.75rem;
+}
+.em-input::placeholder { color: var(--vc-text-tertiary); }
+.em-input:focus {
+  outline: none;
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--vc-data-live) 30%, transparent);
+}
+textarea.em-input { min-height: 0; resize: vertical; padding: 0.6rem 0.75rem; }
+.em-select-wrap { position: relative; display: block; }
+.em-select-wrap svg {
+  position: absolute;
+  right: 0.7rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--vc-text-secondary);
+}
+select.em-input {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 2.2rem;
+  cursor: pointer;
+}
+
+.em-check {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  display: grid;
+  place-content: center;
+}
+.em-check:focus-visible {
+  outline: none;
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--vc-data-live) 30%, transparent);
+}
+.em-check:checked {
+  background: var(--vc-state-complete);
+  border-color: var(--vc-state-complete);
+}
+.em-check:checked::after {
+  content: '';
+  width: 10px;
+  height: 6px;
+  border-left: 2px solid var(--vc-bg-base);
+  border-bottom: 2px solid var(--vc-bg-base);
+  transform: rotate(-45deg) translateY(-1px);
+}
+.em-check-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: fit-content;
+  cursor: pointer;
+}
+.em-check-label { font-size: 14px; color: var(--vc-text-primary); }
+/* Compact checklist for multi-select options (short labels, 2-up even on phones) */
+.em-check-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem 0.75rem;
+}
+@media (min-width: 560px) {
+  .em-check-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+/* Page-level variant of em-error, sitting above the toolbar */
+.ec-page-alert { margin-bottom: 0.9rem; font-family: var(--vc-font-sans); }
+.ec-page-alerts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.9rem;
+  font-family: var(--vc-font-sans);
+}
+.em-alert-row { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
+.em-dismiss {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+  display: grid;
+  place-content: center;
+  padding: 0.25rem;
+  flex-shrink: 0;
+}
+.em-dismiss:hover { color: var(--vc-text-primary); }
+
+/* Confirmation = done -> green */
+.em-success {
+  border: 1px solid var(--vc-state-complete);
+  background: color-mix(in srgb, var(--vc-state-complete) 10%, transparent);
+  border-radius: 8px;
+  padding: 0.6rem 0.8rem;
+  color: var(--vc-text-primary);
+  font-size: 13.5px;
+}
+
+/* Save failures = needs action -> amber (red stays clinical/destructive) */
+.em-error {
+  border: 1px solid var(--vc-state-due);
+  background: color-mix(in srgb, var(--vc-state-due) 10%, transparent);
+  border-radius: 8px;
+  padding: 0.6rem 0.8rem;
+  color: var(--vc-text-primary);
+  font-size: 13.5px;
+}
+
+.em-footer {
+  position: sticky;
+  bottom: -1rem; /* cancel the panel's bottom padding so nothing scrolls past */
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  background: var(--vc-bg-sheet);
+  border-top: 1px solid var(--vc-line-hairline);
+  margin: 0.25rem -1rem -1rem;
+  padding: 0.7rem 1rem calc(0.7rem + env(safe-area-inset-bottom));
+}
+.em-cancel {
+  background: transparent;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  min-height: 48px;
+  padding: 0 1rem;
+  cursor: pointer;
+}
+.em-cancel:hover { border-color: var(--vc-line-strong); color: var(--vc-text-primary); }
+.em-submit {
+  background: color-mix(in srgb, var(--vc-data-live) 45%, var(--vc-bg-surface));
+  border: 1px solid color-mix(in srgb, var(--vc-data-live) 45%, transparent);
+  border-radius: 8px;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  min-height: 48px;
+  padding: 0 1.2rem;
+  cursor: pointer;
+}
+.em-submit:hover { border-color: color-mix(in srgb, var(--vc-data-live) 60%, transparent); }
+.em-submit:disabled {
+  background: transparent;
+  border-color: var(--vc-line-hairline);
+  color: var(--vc-text-tertiary);
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/admin-v2/AdminV2Businesses.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Businesses.jsx
@@ -20,41 +20,16 @@ import AdminV2Layout from './AdminV2Layout';
 import config from '../../config';
 import { useAuth } from '../../contexts/AuthContext';
 import {
-  PlusIcon,
-  EditIcon,
-  TrashIcon,
   BuildingIcon,
-  CheckIcon,
-  SearchIcon
+  BusinessesIcon,
+  PhoneIcon,
+  MailIcon,
+  GlobeIcon,
 } from '../../components/Icons';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
-import { Alert } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
-import { Field, FormRow } from '@/components/ui/field';
-import { cn } from '@/lib/utils';
+import EntityCard from '../../components/vc/EntityCard';
+import EntityToolbar from '../../components/vc/EntityToolbar';
+import EntityModal, { EmField, EmRow } from '../../components/vc/EntityModal';
 import './AdminV2.css';
-
-// Label/value row used inside the business cards.
-function Row({ label, value }) {
-  return (
-    <div className="flex justify-between gap-3">
-      <span className="shrink-0 text-muted-foreground">{label}:</span>
-      <span className="text-right text-foreground">{value}</span>
-    </div>
-  );
-}
 
 const AdminV2Businesses = () => {
   const { user } = useAuth();
@@ -116,19 +91,25 @@ const AdminV2Businesses = () => {
     return user.permissions?.includes(permission) || false;
   };
 
-  // Fetch businesses on mount
+  // Fetch business types on mount
+  useEffect(() => {
+    fetchBusinessTypes();
+  }, []);
+
+  // Fetch businesses when the type filter changes
   useEffect(() => {
     fetchBusinesses();
-    fetchBusinessTypes();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helper is recreated each render; effect is keyed on tab/filter change only
-  }, [activeTab, filterType]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helper is recreated each render; effect is keyed on filter change only
+  }, [filterType]);
 
   const fetchBusinesses = async () => {
     try {
       setLoading(true);
       setError(null);
 
-      let url = `${config.apiUrl}/api/businesses?active_only=${activeTab === 'active'}`;
+      // Fetch active + inactive together so the count tabs are accurate;
+      // the tab split happens client-side.
+      let url = `${config.apiUrl}/api/businesses?active_only=false`;
       if (filterType) {
         url += `&business_type=${encodeURIComponent(filterType)}`;
       }
@@ -275,259 +256,215 @@ const AdminV2Businesses = () => {
     setShowCreateModal(true);
   };
 
-  const filteredBusinesses = businesses.filter(business => {
+  const matchesSearch = (business) => {
     const typesStr = (business.business_types || []).join(' ').toLowerCase();
-    const searchLower = searchTerm.toLowerCase();
-    return business.name.toLowerCase().includes(searchLower) ||
-      typesStr.includes(searchLower) ||
-      business.city?.toLowerCase().includes(searchLower) ||
-      business.state?.toLowerCase().includes(searchLower);
-  });
+    const q = searchTerm.toLowerCase();
+    return (
+      business.name.toLowerCase().includes(q) ||
+      typesStr.includes(q) ||
+      business.city?.toLowerCase().includes(q) ||
+      business.state?.toLowerCase().includes(q)
+    );
+  };
 
-  // Stats
-  const activeCount = businesses.filter(b => b.active).length;
-  const inactiveCount = businesses.filter(b => !b.active).length;
+  const activeCount = businesses.filter((b) => b.active).length;
+  const inactiveCount = businesses.length - activeCount;
+  const filteredBusinesses = businesses.filter(
+    (b) => (activeTab === 'active' ? b.active : !b.active) && matchesSearch(b)
+  );
+
+  const typeLabel = (t) => t.replace('_', ' ').toUpperCase();
+
+  const businessAddress = (business) => {
+    const cityStateZip = [
+      business.city,
+      [business.state, business.zip_code].filter(Boolean).join(' '),
+    ].filter(Boolean).join(', ');
+    return [business.address_line1, business.address_line2, cityStateZip]
+      .filter(Boolean)
+      .join(', ');
+  };
+
+  const websiteHref = (website) =>
+    /^https?:\/\//i.test(website) ? website : `https://${website}`;
+
+  const businessMenu = (business) => {
+    const items = [];
+    if (hasPermission('businesses.update')) {
+      items.push({ label: 'Edit', onClick: () => handleEdit(business) });
+      if (!business.active) {
+        items.push({ label: 'Activate', onClick: () => handleActivate(business.id) });
+      }
+    }
+    if (business.active && hasPermission('businesses.delete')) {
+      items.push({ label: 'Deactivate', onClick: () => handleDelete(business.id), danger: true });
+    }
+    return items;
+  };
 
   return (
     <AdminV2Layout>
       <div className="admin-v2-page">
-        {error && (
-          <div className="tw mb-4">
-            <Alert variant="destructive">{error}</Alert>
+        {error && <div className="em-error ec-page-alert">{error}</div>}
+
+        <EntityToolbar
+          counts={[
+            { key: 'active', label: 'Active', count: activeCount },
+            { key: 'inactive', label: 'Inactive', count: inactiveCount },
+          ]}
+          activeCount={activeTab}
+          onCountChange={setActiveTab}
+          search={searchTerm}
+          onSearchChange={setSearchTerm}
+          searchPlaceholder="Search businesses"
+          filter={{
+            value: filterType,
+            onChange: setFilterType,
+            label: 'Type',
+            options: [
+              { value: '', label: 'All types' },
+              ...businessTypes.map((t) => ({ value: t, label: typeLabel(t) })),
+            ],
+          }}
+          onAdd={hasPermission('businesses.create') ? openCreateModal : undefined}
+          addLabel="Add business"
+        />
+
+        {loading ? (
+          <div className="ec-empty">Loading businesses…</div>
+        ) : filteredBusinesses.length === 0 ? (
+          <div className="ec-empty">
+            {searchTerm
+              ? 'No businesses match your search.'
+              : `No ${activeTab} businesses.`}
+          </div>
+        ) : (
+          <div className="ec-grid">
+            {filteredBusinesses.map((business) => (
+              <EntityCard
+                key={business.id}
+                icon={<BusinessesIcon size={22} />}
+                title={business.name}
+                badges={(business.business_types || [business.business_type]).filter(Boolean).map(typeLabel)}
+                inactive={!business.active}
+                details={[
+                  { icon: <BuildingIcon size={18} />, label: 'Address', value: businessAddress(business) },
+                  ...(business.fax
+                    ? [{ icon: <PhoneIcon size={18} />, label: 'Fax', value: business.fax }]
+                    : []),
+                ]}
+                quickActions={[
+                  ...(business.phone
+                    ? [{ icon: <PhoneIcon size={18} />, label: `Call ${business.phone}`, href: `tel:${business.phone}` }]
+                    : []),
+                  ...(business.email
+                    ? [{ icon: <MailIcon size={18} />, label: `Email ${business.email}`, href: `mailto:${business.email}` }]
+                    : []),
+                  ...(business.website
+                    ? [{ icon: <GlobeIcon size={18} />, label: 'Website', href: websiteHref(business.website), external: true }]
+                    : []),
+                ]}
+                menu={businessMenu(business)}
+              />
+            ))}
           </div>
         )}
 
-        {/* Tabs and Filters */}
-        <div className="admin-v2-controls-bar">
-          <div className="admin-v2-tabs">
-            <button
-              className={`admin-v2-tab ${activeTab === 'active' ? 'active' : ''}`}
-              onClick={() => setActiveTab('active')}
-            >
-              Active ({activeCount})
-            </button>
-            <button
-              className={`admin-v2-tab ${activeTab === 'inactive' ? 'active' : ''}`}
-              onClick={() => setActiveTab('inactive')}
-            >
-              Inactive ({inactiveCount})
-            </button>
-          </div>
-
-          <div className="admin-v2-filters">
-            <div className="admin-v2-search-wrapper">
-              <SearchIcon size={16} />
-              <input
-                type="text"
-                placeholder="Search businesses..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="admin-v2-search-input"
-              />
-            </div>
-            <select
-              value={filterType}
-              onChange={(e) => setFilterType(e.target.value)}
-              className="admin-v2-filter-select"
-            >
-              <option value="">All Types</option>
-              {businessTypes.map(type => (
-                <option key={type} value={type}>{type.replace('_', ' ').toUpperCase()}</option>
-              ))}
-            </select>
-          </div>
-
-          {hasPermission('businesses.create') && (
-            <button
-              className="admin-v2-btn admin-v2-btn-primary"
-              onClick={openCreateModal}
-            >
-              <PlusIcon size={16} /> Add Business
-            </button>
-          )}
-        </div>
-
-        {/* Business Cards Grid */}
-        <div className="tw mt-4">
-          {loading ? (
-            <p className="text-sm text-muted-foreground">Loading businesses...</p>
-          ) : filteredBusinesses.length === 0 ? (
-            <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-border py-12 text-center text-muted-foreground">
-              <BuildingIcon size={48} />
-              <h3 className="text-base font-semibold text-foreground">
-                {searchTerm ? 'No businesses found matching your search.' : 'No businesses found.'}
-              </h3>
-              {hasPermission('businesses.create') && (
-                <Button onClick={openCreateModal}>
-                  <PlusIcon size={16} /> Add First Business
-                </Button>
-              )}
-            </div>
-          ) : (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {filteredBusinesses.map(business => (
-                <Card key={business.id} className={cn(!business.active && "opacity-60")}>
-                  <CardHeader className="gap-2 py-3">
-                    <CardTitle className="text-sm">{business.name}</CardTitle>
-                    <div className="flex flex-wrap gap-1.5">
-                      {(business.business_types || [business.business_type]).filter(Boolean).map(type => (
-                        <Badge key={type} variant="secondary">{type.replace('_', ' ').toUpperCase()}</Badge>
-                      ))}
-                    </div>
-                  </CardHeader>
-
-                  <CardContent className="flex flex-col gap-1.5 py-3 text-sm">
-                    {(business.address_line1 || business.city) && (
-                      <Row
-                        label="Address"
-                        value={
-                          <>
-                            {business.address_line1 && <>{business.address_line1}<br /></>}
-                            {business.address_line2 && <>{business.address_line2}<br /></>}
-                            {business.city && `${business.city}, `}
-                            {business.state} {business.zip_code}
-                          </>
-                        }
-                      />
-                    )}
-                    {business.phone && <Row label="Phone" value={business.phone} />}
-                    {business.fax && <Row label="Fax" value={business.fax} />}
-                    {business.email && <Row label="Email" value={business.email} />}
-                    {business.website && (
-                      <Row
-                        label="Website"
-                        value={
-                          <a className="text-ring underline-offset-4 hover:underline" href={business.website} target="_blank" rel="noopener noreferrer">
-                            {business.website.replace('https://', '').replace('http://', '')}
-                          </a>
-                        }
-                      />
-                    )}
-                    {business.provider_count > 0 && <Row label="Providers" value={business.provider_count} />}
-                  </CardContent>
-
-                  <CardFooter className="justify-start gap-2 py-3">
-                    {hasPermission('businesses.update') && (
-                      <Button size="sm" variant="ghost" onClick={() => handleEdit(business)}>
-                        <EditIcon size={14} /> Edit
-                      </Button>
-                    )}
-                    {business.active ? (
-                      hasPermission('businesses.delete') && (
-                        <Button size="sm" variant="ghost" className="text-[#ff7b72] hover:text-[#ff7b72]" onClick={() => handleDelete(business.id)}>
-                          <TrashIcon size={14} /> Deactivate
-                        </Button>
-                      )
-                    ) : (
-                      hasPermission('businesses.update') && (
-                        <Button size="sm" variant="ghost" className="text-[#3fb950] hover:text-[#3fb950]" onClick={() => handleActivate(business.id)}>
-                          <CheckIcon size={14} /> Activate
-                        </Button>
-                      )
-                    )}
-                  </CardFooter>
-                </Card>
-              ))}
-            </div>
-          )}
-        </div>
-
         {/* Create / Edit Dialog */}
-        <Dialog open={showCreateModal} onOpenChange={(o) => { if (!o) { setShowCreateModal(false); resetForm(); } }}>
-          <DialogContent className="sm:max-w-[680px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>{selectedBusiness ? 'Edit Business' : 'Add New Business'}</DialogTitle>
-            </DialogHeader>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-              {formError && <Alert variant="destructive">{formError}</Alert>}
+        <EntityModal
+          open={showCreateModal}
+          onOpenChange={(o) => { if (!o) { setShowCreateModal(false); resetForm(); } }}
+          title={selectedBusiness ? 'Edit business' : 'Add business'}
+          wide
+        >
+          <form onSubmit={handleSubmit} className="em-form">
+            {formError && <div className="em-error">{formError}</div>}
 
-              <div className="flex flex-col gap-1.5">
-                <Label>
-                  Business Types <span className="text-xs font-normal text-muted-foreground">(select all that apply)</span>
-                  <span className="text-destructive"> *</span>
-                </Label>
-                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                  {businessTypeOptions.map(type => (
-                    <label key={type} className="flex cursor-pointer items-center gap-2 text-sm text-foreground">
-                      <Checkbox
-                        checked={(formData.business_types || []).includes(type)}
-                        onCheckedChange={() => toggleBusinessType(type)}
-                      />
-                      {type.replace('_', ' ').toUpperCase()}
-                    </label>
-                  ))}
-                </div>
-                {formData.business_types?.length === 0 && (
-                  <p className="text-xs text-destructive">Please select at least one type</p>
-                )}
-              </div>
+            <EmField label="Business types (select all that apply)" required>
+              <EmRow>
+                {businessTypeOptions.map(type => (
+                  <label key={type} className="em-check-row">
+                    <input
+                      type="checkbox"
+                      className="em-check"
+                      checked={(formData.business_types || []).includes(type)}
+                      onChange={() => toggleBusinessType(type)}
+                    />
+                    <span className="em-check-label">{typeLabel(type)}</span>
+                  </label>
+                ))}
+              </EmRow>
+              {formData.business_types?.length === 0 && (
+                <div className="em-error">Please select at least one type</div>
+              )}
+            </EmField>
 
-              <FormRow>
-                <Field label="Business Name" required htmlFor="biz-name">
-                  <Input id="biz-name" value={formData.name} onChange={(e) => setFormData({ ...formData, name: e.target.value })} required />
-                </Field>
-                <Field label="Phone" htmlFor="biz-phone">
-                  <Input id="biz-phone" type="tel" value={formData.phone} onChange={(e) => setFormData({ ...formData, phone: e.target.value })} />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Business name" required htmlFor="biz-name">
+                <input id="biz-name" className="em-input" value={formData.name} onChange={(e) => setFormData({ ...formData, name: e.target.value })} required />
+              </EmField>
+              <EmField label="Phone" htmlFor="biz-phone">
+                <input id="biz-phone" className="em-input" type="tel" value={formData.phone} onChange={(e) => setFormData({ ...formData, phone: e.target.value })} />
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Fax" htmlFor="biz-fax">
-                  <Input id="biz-fax" type="tel" value={formData.fax} onChange={(e) => setFormData({ ...formData, fax: e.target.value })} />
-                </Field>
-                <Field label="Email" htmlFor="biz-email">
-                  <Input id="biz-email" type="email" value={formData.email} onChange={(e) => setFormData({ ...formData, email: e.target.value })} />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Fax" htmlFor="biz-fax">
+                <input id="biz-fax" className="em-input" type="tel" value={formData.fax} onChange={(e) => setFormData({ ...formData, fax: e.target.value })} />
+              </EmField>
+              <EmField label="Email" htmlFor="biz-email">
+                <input id="biz-email" className="em-input" type="email" value={formData.email} onChange={(e) => setFormData({ ...formData, email: e.target.value })} />
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Website" htmlFor="biz-website">
-                  <Input id="biz-website" type="url" value={formData.website} onChange={(e) => setFormData({ ...formData, website: e.target.value })} placeholder="https://" />
-                </Field>
-                <Field label="Address Line 1" htmlFor="biz-addr1">
-                  <Input id="biz-addr1" value={formData.address_line1} onChange={(e) => setFormData({ ...formData, address_line1: e.target.value })} />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Website" htmlFor="biz-website">
+                <input id="biz-website" className="em-input" type="url" value={formData.website} onChange={(e) => setFormData({ ...formData, website: e.target.value })} placeholder="https://" />
+              </EmField>
+              <EmField label="Address line 1" htmlFor="biz-addr1">
+                <input id="biz-addr1" className="em-input" value={formData.address_line1} onChange={(e) => setFormData({ ...formData, address_line1: e.target.value })} />
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Address Line 2" htmlFor="biz-addr2">
-                  <Input id="biz-addr2" value={formData.address_line2} onChange={(e) => setFormData({ ...formData, address_line2: e.target.value })} />
-                </Field>
-                <Field label="City" htmlFor="biz-city">
-                  <Input id="biz-city" value={formData.city} onChange={(e) => setFormData({ ...formData, city: e.target.value })} />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Address line 2" htmlFor="biz-addr2">
+                <input id="biz-addr2" className="em-input" value={formData.address_line2} onChange={(e) => setFormData({ ...formData, address_line2: e.target.value })} />
+              </EmField>
+              <EmField label="City" htmlFor="biz-city">
+                <input id="biz-city" className="em-input" value={formData.city} onChange={(e) => setFormData({ ...formData, city: e.target.value })} />
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="State" htmlFor="biz-state">
-                  <Input id="biz-state" value={formData.state} onChange={(e) => setFormData({ ...formData, state: e.target.value })} maxLength="2" />
-                </Field>
-                <Field label="ZIP Code" htmlFor="biz-zip">
-                  <Input id="biz-zip" value={formData.zip_code} onChange={(e) => setFormData({ ...formData, zip_code: e.target.value })} />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="State" htmlFor="biz-state">
+                <input id="biz-state" className="em-input" value={formData.state} onChange={(e) => setFormData({ ...formData, state: e.target.value })} maxLength="2" />
+              </EmField>
+              <EmField label="ZIP code" htmlFor="biz-zip">
+                <input id="biz-zip" className="em-input" value={formData.zip_code} onChange={(e) => setFormData({ ...formData, zip_code: e.target.value })} />
+              </EmField>
+            </EmRow>
 
-              <Field label="Notes" htmlFor="biz-notes">
-                <Textarea
-                  id="biz-notes"
-                  rows={4}
-                  value={formData.notes}
-                  onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-                  placeholder="Additional notes about this business..."
-                />
-              </Field>
+            <EmField label="Notes" htmlFor="biz-notes">
+              <textarea
+                id="biz-notes"
+                className="em-input"
+                rows={4}
+                value={formData.notes}
+                onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                placeholder="Additional notes about this business..."
+              />
+            </EmField>
 
-              <DialogFooter>
-                <Button type="button" variant="secondary" onClick={() => { setShowCreateModal(false); resetForm(); }}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={saving}>
-                  {saving ? 'Saving...' : (selectedBusiness ? 'Update Business' : 'Add Business')}
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
+            <div className="em-footer">
+              <button type="button" className="em-cancel" onClick={() => { setShowCreateModal(false); resetForm(); }}>
+                Cancel
+              </button>
+              <button type="submit" className="em-submit" disabled={saving}>
+                {saving ? 'Saving…' : (selectedBusiness ? 'Update business' : 'Add business')}
+              </button>
+            </div>
+          </form>
+        </EntityModal>
       </div>
     </AdminV2Layout>
   );

--- a/frontend/src/pages/admin-v2/AdminV2Connections.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Connections.jsx
@@ -26,42 +26,18 @@ import {
   RefreshIcon,
   XIcon,
   LinkIcon,
-  TrashIcon
+  WifiIcon,
+  ClockIcon,
+  GlobeIcon,
+  VitalsIcon,
+  AlertIcon,
+  FileTextIcon
 } from '../../components/Icons';
+import EntityCard from '../../components/vc/EntityCard';
+import EntityModal, { EmField, EmRow, EmSelect } from '../../components/vc/EntityModal';
 import { VentImportPanel } from './components';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Alert } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
-import { Field } from '@/components/ui/field';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
-import { cn } from '@/lib/utils';
 import './AdminV2.css';
-
-// Label/value row used inside the integration & reader cards.
-function CardRow({ label, value }) {
-  return (
-    <div className="flex items-center justify-between gap-3">
-      <span className="text-muted-foreground">{label}:</span>
-      <span className="text-right text-foreground">{value}</span>
-    </div>
-  );
-}
 
 export default function AdminV2Connections() {
   const { selectedPatient, loadingPatients } = useAdminPatient();
@@ -536,15 +512,27 @@ export default function AdminV2Connections() {
   };
 
   // Plain-English status wording — technical detail lives behind the error
-  // line, not the badge.
-  const getStatusBadge = (integration) => {
-    if (!integration.is_enabled) return <Badge variant="muted">Paused</Badge>;
-    if (integration.last_sync_status === 'failed') return <Badge variant="danger">Needs attention</Badge>;
-    if (integration.last_sync_at) return <Badge variant="success">Working</Badge>;
-    if (integration.auth_type === 'none') return <Badge variant="success">Working</Badge>;
-    if (integration.auth_type === 'oauth2') return <Badge variant="warning">Waiting for sign-in</Badge>;
-    return <Badge variant="warning">Finishing setup</Badge>;
+  // line, not the tag.
+  const getStatusTag = (integration) => {
+    if (!integration.is_enabled) return { label: 'Paused', tone: 'idle' };
+    if (integration.last_sync_status === 'failed') return { label: 'Needs attention', tone: 'due' };
+    if (integration.last_sync_at) return { label: 'Working', tone: 'complete' };
+    if (integration.auth_type === 'none') return { label: 'Working', tone: 'complete' };
+    if (integration.auth_type === 'oauth2') return { label: 'Waiting for sign-in', tone: 'accent' };
+    return { label: 'Finishing setup', tone: 'accent' };
   };
+
+  const integrationMenu = (integration) => [
+    {
+      label: integration.is_enabled ? 'Pause' : 'Resume',
+      onClick: () => handleToggle(integration, !integration.is_enabled),
+    },
+    {
+      label: 'Delete',
+      danger: true,
+      onClick: () => { if (deletingId !== integration.id) handleDelete(integration); },
+    },
+  ];
 
   // Check URL params for OAuth callback
   useEffect(() => {
@@ -626,22 +614,22 @@ export default function AdminV2Connections() {
       <div className="admin-v2-page">
         {/* Alerts */}
         {(error || success) && (
-          <div className="tw mb-4 flex flex-col gap-3">
+          <div className="ec-page-alerts">
             {error && (
-              <Alert variant="destructive" className="flex items-center justify-between gap-3">
+              <div className="em-error em-alert-row">
                 <span>{error}</span>
-                <button type="button" className="shrink-0 opacity-70 hover:opacity-100" onClick={() => setError('')}>
+                <button type="button" className="em-dismiss" aria-label="Dismiss" onClick={() => setError('')}>
                   <XIcon size={16} />
                 </button>
-              </Alert>
+              </div>
             )}
             {success && (
-              <Alert variant="success" className="flex items-center justify-between gap-3">
+              <div className="em-success em-alert-row">
                 <span>{success}</span>
-                <button type="button" className="shrink-0 opacity-70 hover:opacity-100" onClick={() => setSuccess('')}>
+                <button type="button" className="em-dismiss" aria-label="Dismiss" onClick={() => setSuccess('')}>
                   <XIcon size={16} />
                 </button>
-              </Alert>
+              </div>
             )}
           </div>
         )}
@@ -673,59 +661,55 @@ export default function AdminV2Connections() {
                   </Button>
                 </div>
               ) : patientIntegrations.length === 0 ? null : (
-                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <div className="ec-grid">
                   {patientIntegrations.map(integration => (
-                    <Card key={integration.id} className={cn(!integration.is_enabled && "opacity-60")}>
-                      <CardHeader className="py-3">
-                        <div className="flex items-center justify-between gap-2">
-                          <CardTitle className="text-sm">{integration.integration_name}</CardTitle>
-                          {getStatusBadge(integration)}
-                        </div>
-                      </CardHeader>
-                      <CardContent className="flex flex-col gap-1.5 py-3 text-sm">
-                        <p className="text-muted-foreground">
-                          {integration.last_sync_at
+                    <EntityCard
+                      key={integration.id}
+                      icon={<LinkIcon size={22} />}
+                      title={integration.integration_name}
+                      tag={getStatusTag(integration)}
+                      inactive={!integration.is_enabled}
+                      details={[
+                        {
+                          icon: <ClockIcon size={18} />,
+                          label: 'Last sync',
+                          value: integration.last_sync_at
                             ? `Synced ${timeAgo(integration.last_sync_at)}`
-                            : 'Not synced yet'}
-                        </p>
-                        {integration.last_sync_status === 'failed' && integration.last_sync_error && (
-                          <div className="text-xs text-[#ff7b72]">
-                            Something went wrong: {integration.last_sync_error}
-                          </div>
-                        )}
-                      </CardContent>
-                      <CardFooter className="flex-wrap justify-start gap-2 py-3">
-                        {integration.is_enabled && integration.auth_type === 'oauth2' && !integration.last_sync_at && (
-                          <Button size="sm" variant="ghost" onClick={() => startOAuthFlow(integration.id)} title="Connect OAuth">
-                            <LinkIcon size={14} /> Connect
-                          </Button>
-                        )}
-                        {integration.is_enabled && integration.integration_slug !== 'ventilator' && (
-                          <Button size="sm" variant="ghost" onClick={() => handleSync(integration)} disabled={syncingId === integration.id} title="Sync Now">
-                            <RefreshIcon size={14} className={syncingId === integration.id ? 'spinning' : undefined} />
-                            {syncingId === integration.id ? 'Syncing...' : 'Sync'}
-                          </Button>
-                        )}
-                        {integration.is_enabled && integration.integration_slug === 'ventilator' && (
-                          <Button size="sm" variant="ghost" onClick={() => setImportsPanel({ open: true, integration })} title="Upload + view log exports">
-                            Logs
-                          </Button>
-                        )}
-                        <Button size="sm" variant="outline" onClick={() => handleToggle(integration, !integration.is_enabled)}>
-                          {integration.is_enabled ? 'Pause' : 'Resume'}
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="ml-auto text-[#ff7b72] hover:text-[#ff7b72]"
-                          onClick={() => handleDelete(integration)}
-                          disabled={deletingId === integration.id}
-                          title="Delete integration"
-                        >
-                          <TrashIcon size={14} />
-                        </Button>
-                      </CardFooter>
-                    </Card>
+                            : 'Not synced yet',
+                        },
+                        ...(integration.last_sync_status === 'failed' && integration.last_sync_error
+                          ? [{
+                              icon: <AlertIcon size={18} />,
+                              label: 'Something went wrong',
+                              value: integration.last_sync_error,
+                            }]
+                          : []),
+                      ]}
+                      quickActions={[
+                        ...(integration.is_enabled && integration.auth_type === 'oauth2' && !integration.last_sync_at
+                          ? [{
+                              icon: <LinkIcon size={18} />,
+                              label: 'Connect',
+                              onClick: () => startOAuthFlow(integration.id),
+                            }]
+                          : []),
+                        ...(integration.is_enabled && integration.integration_slug !== 'ventilator'
+                          ? [{
+                              icon: <RefreshIcon size={18} />,
+                              label: syncingId === integration.id ? 'Syncing...' : 'Sync now',
+                              onClick: () => { if (syncingId !== integration.id) handleSync(integration); },
+                            }]
+                          : []),
+                        ...(integration.is_enabled && integration.integration_slug === 'ventilator'
+                          ? [{
+                              icon: <FileTextIcon size={18} />,
+                              label: 'Upload + view log exports',
+                              onClick: () => setImportsPanel({ open: true, integration }),
+                            }]
+                          : []),
+                      ]}
+                      menu={integrationMenu(integration)}
+                    />
                   ))}
                 </div>
               )}
@@ -733,36 +717,32 @@ export default function AdminV2Connections() {
 
             {/* Connected Readers */}
             {patientReaders.filter(r => r.is_paired).length > 0 && (
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="ec-grid">
                 {patientReaders.filter(r => r.is_paired).map(reader => (
-                  <Card key={`reader-${reader.id}`}>
-                    <CardHeader className="py-3">
-                      <div className="flex items-center justify-between gap-2">
-                        <CardTitle className="text-sm">{reader.name}</CardTitle>
-                        {reader.connected ? (
-                          <Badge variant="success">
-                            <span className="inline-block h-2 w-2 rounded-full" style={{ background: '#3fb950' }} />
-                            Online
-                          </Badge>
-                        ) : (
-                          <Badge variant="muted">Offline</Badge>
-                        )}
-                      </div>
-                    </CardHeader>
-                    <CardContent className="flex flex-col gap-1.5 py-3 text-sm">
-                      <p className="text-muted-foreground">
-                        {reader.last_seen ? `Last seen ${timeAgo(reader.last_seen)}` : 'Never seen'}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        Pulse oximeter reader · {reader.ip_address}
-                      </p>
-                    </CardContent>
-                    <CardFooter className="justify-start py-3">
-                      <Button size="sm" variant="ghost" className="text-[#ff7b72] hover:text-[#ff7b72]" onClick={() => handleUnpairReader(reader.id)}>
-                        Disconnect
-                      </Button>
-                    </CardFooter>
-                  </Card>
+                  <EntityCard
+                    key={`reader-${reader.id}`}
+                    icon={<WifiIcon size={22} />}
+                    title={reader.name}
+                    badges={['Pulse oximeter reader']}
+                    tag={reader.connected
+                      ? { label: 'Online', tone: 'complete' }
+                      : { label: 'Offline', tone: 'idle' }}
+                    details={[
+                      {
+                        icon: <ClockIcon size={18} />,
+                        label: 'Last seen',
+                        value: reader.last_seen ? timeAgo(reader.last_seen) : 'Never seen',
+                      },
+                      {
+                        icon: <GlobeIcon size={18} />,
+                        label: 'Address',
+                        value: reader.ip_address,
+                      },
+                    ]}
+                    menu={[
+                      { label: 'Disconnect', danger: true, onClick: () => handleUnpairReader(reader.id) },
+                    ]}
+                  />
                 ))}
               </div>
             )}
@@ -772,53 +752,54 @@ export default function AdminV2Connections() {
               <h3 className="text-base font-semibold text-foreground">
                 Available to add ({allAvailableIntegrations.length})
               </h3>
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="ec-grid">
                 {allAvailableIntegrations.map(integration => {
                   const isSHHDevice = integration.slug === 'shh_pulse_ox';
                   const isConfigured = isSHHDevice
                     ? hasConfiguredReaders
                     : patientIntegrations.some(pi => pi.integration_slug === integration.slug);
                   return (
-                    <Card key={integration.slug} className={cn(isConfigured && "opacity-60")}>
-                      <CardHeader className="gap-2 py-3">
-                        <div className="flex items-center justify-between gap-2">
-                          <CardTitle className="text-sm">{integration.name}</CardTitle>
-                          {isConfigured && (
-                            <Badge variant="success">
-                              {isSHHDevice ? `${patientReaders.filter(r => r.is_paired).length} Connected` : 'Configured'}
-                            </Badge>
-                          )}
-                        </div>
-                        <Badge variant="info" className="w-fit">{getAuthTypeLabel(integration.auth_type)}</Badge>
-                      </CardHeader>
-                      <CardContent className="flex flex-col gap-1.5 py-3 text-sm">
-                        <p className="text-muted-foreground">{integration.description}</p>
-                        <CardRow
-                          label="Supports"
-                          value={
-                            <>
-                              {integration.supported_vitals?.slice(0, 4).join(', ')}
-                              {integration.supported_vitals?.length > 4 && '...'}
-                            </>
+                    <EntityCard
+                      key={integration.slug}
+                      icon={isSHHDevice ? <WifiIcon size={22} /> : <LinkIcon size={22} />}
+                      title={integration.name}
+                      badges={[getAuthTypeLabel(integration.auth_type)]}
+                      tag={isConfigured
+                        ? {
+                            label: isSHHDevice ? `${pairedReaderCount} Connected` : 'Configured',
+                            tone: 'complete',
                           }
-                        />
-                      </CardContent>
-                      <CardFooter className="justify-start py-3">
-                        <Button
-                          size="sm"
-                          onClick={() => {
+                        : undefined}
+                      inactive={isConfigured}
+                      details={[
+                        {
+                          icon: <VitalsIcon size={18} />,
+                          label: 'Supports',
+                          value: integration.supported_vitals
+                            ? integration.supported_vitals.slice(0, 4).join(', ')
+                              + (integration.supported_vitals.length > 4 ? '...' : '')
+                            : undefined,
+                        },
+                      ]}
+                      quickActions={[
+                        {
+                          icon: <PlusIcon size={18} />,
+                          label: isSHHDevice ? 'Add Device' : `Add ${integration.name}`,
+                          onClick: () => {
                             if (isSHHDevice) {
                               setShowReaderModal(true);
                             } else {
                               pickIntegration(integration);
                               setShowAddModal(true);
                             }
-                          }}
-                        >
-                          <PlusIcon size={14} /> {isSHHDevice ? 'Add Device' : 'Add'}
-                        </Button>
-                      </CardFooter>
-                    </Card>
+                          },
+                        },
+                      ]}
+                    >
+                      <div className="ec-body">
+                        <span className="ec-detail-label">{integration.description}</span>
+                      </div>
+                    </EntityCard>
                   );
                 })}
               </div>
@@ -827,205 +808,197 @@ export default function AdminV2Connections() {
         )}
 
         {/* Add Reader Dialog */}
-        <Dialog open={showReaderModal} onOpenChange={(o) => { if (!o) resetReaderModal(); }}>
-          <DialogContent className="sm:max-w-[520px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>{pairingReader ? 'Approve on Reader' : 'Add SHH Reader'}</DialogTitle>
-            </DialogHeader>
-
+        <EntityModal
+          open={showReaderModal}
+          onOpenChange={(o) => { if (!o) resetReaderModal(); }}
+          title={pairingReader ? 'Approve on reader' : 'Add SHH reader'}
+        >
+          <div className="em-form">
             {!pairingReader ? (
-              <div className="flex flex-col gap-4">
-                <p className="text-sm text-muted-foreground">
+              <>
+                <p className="ec-detail-label">
                   Enter the IP address and port of your SHH Reader device. Make sure the reader is powered on and connected to your network.
                 </p>
-                <div className="flex gap-3">
-                  <Field label="Reader IP Address" required className="flex-1">
-                    <Input value={readerIp} onChange={(e) => setReaderIp(e.target.value)} placeholder="e.g., 192.168.1.100" autoFocus />
-                  </Field>
-                  <Field label="Port" className="w-24">
-                    <Input type="number" value={readerPort} onChange={(e) => setReaderPort(e.target.value)} placeholder="8080" />
-                  </Field>
-                </div>
-              </div>
+                <EmRow>
+                  <EmField label="Reader IP address" required htmlFor="reader-ip">
+                    <input id="reader-ip" className="em-input" value={readerIp} onChange={(e) => setReaderIp(e.target.value)} placeholder="e.g., 192.168.1.100" autoFocus />
+                  </EmField>
+                  <EmField label="Port" htmlFor="reader-port">
+                    <input id="reader-port" className="em-input" type="number" value={readerPort} onChange={(e) => setReaderPort(e.target.value)} placeholder="8080" />
+                  </EmField>
+                </EmRow>
+              </>
             ) : pairingReader.status === 'waiting' ? (
-              <div className="flex flex-col gap-4">
-                <Alert variant="default">
+              <>
+                <div>
                   <strong>Waiting for approval</strong>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Approve this hub on <strong className="text-foreground">{pairingReader.name}</strong> — open the reader's screen at <code className="text-foreground">{readerIp}</code> and click <strong className="text-foreground">Allow</strong>.
+                  <p className="ec-detail-label">
+                    Approve this hub on <strong>{pairingReader.name}</strong> — open the reader's screen at <code>{readerIp}</code> and click <strong>Allow</strong>.
                   </p>
-                </Alert>
-                <div className="flex items-center justify-center gap-3 rounded-lg bg-ring/10 py-6">
-                  <span className="inline-flex animate-spin text-[#58a6ff]"><RefreshIcon size={20} /></span>
-                  <span className="text-sm text-muted-foreground">Waiting for the reader…</span>
                 </div>
-              </div>
+                <p className="ec-detail-label">Waiting for the reader…</p>
+              </>
             ) : (
-              <Alert variant="destructive">
+              <div className="em-error">
                 <strong>{pairingReader.status === 'denied' ? 'Pairing denied' : 'Pairing request expired'}</strong>
-                <p className="mt-1 text-sm text-muted-foreground">
+                <p className="ec-detail-label">
                   {pairingReader.status === 'denied'
                     ? 'The request was denied on the reader.'
                     : 'The reader did not respond in time.'} You can try again.
                 </p>
-              </Alert>
+              </div>
             )}
 
-            <DialogFooter>
+            <div className="em-footer">
               {pairingReader && pairingReader.status !== 'waiting' && (
-                <Button variant="ghost" onClick={() => { stopPairPolling(); setPairingReader(null); }}>Try Again</Button>
+                <button type="button" className="em-cancel" onClick={() => { stopPairPolling(); setPairingReader(null); }}>Try Again</button>
               )}
-              <Button variant="secondary" onClick={resetReaderModal}>Cancel</Button>
+              <button type="button" className="em-cancel" onClick={resetReaderModal}>Cancel</button>
               {!pairingReader && (
-                <Button onClick={handleInitiatePairing} disabled={pairingLoading || !readerIp.trim()}>
-                  {pairingLoading ? 'Connecting...' : 'Connect Reader'}
-                </Button>
+                <button type="button" className="em-submit" onClick={handleInitiatePairing} disabled={pairingLoading || !readerIp.trim()}>
+                  {pairingLoading ? 'Connecting…' : 'Connect Reader'}
+                </button>
               )}
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+            </div>
+          </div>
+        </EntityModal>
 
         {/* Add Integration Dialog */}
-        <Dialog open={showAddModal} onOpenChange={(o) => { if (!o) closeAddModal(); }}>
-          <DialogContent className="sm:max-w-[560px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>{addStep === 'select-camera' ? 'Select Camera' : 'Add a connection'}</DialogTitle>
-            </DialogHeader>
-
+        <EntityModal
+          open={showAddModal}
+          onOpenChange={(o) => { if (!o) closeAddModal(); }}
+          title={addStep === 'select-camera' ? 'Select camera' : 'Add a connection'}
+        >
+          <div className="em-form">
             {addStep === 'select-camera' ? (
-              <div className="flex flex-col gap-4">
-                <p className="text-sm text-muted-foreground">
+              <>
+                <p className="ec-detail-label">
                   Choose which camera covers this patient. You can change this later from the integration settings.
                 </p>
                 {discoveredCameras.length === 0 ? (
-                  <Alert variant="default">No cameras were discovered on this Frigate instance.</Alert>
+                  <p className="ec-detail-label">No cameras were discovered on this Frigate instance.</p>
                 ) : (
-                  <Field label="Camera">
-                    <Select value={pickedCamera || undefined} onValueChange={(v) => setPickedCamera(v)}>
-                      <SelectTrigger><SelectValue placeholder="Select a camera" /></SelectTrigger>
-                      <SelectContent>
-                        {discoveredCameras.map(cam => (
-                          <SelectItem key={cam.device_id} value={cam.device_id}>
-                            {cam.device_name || cam.device_id}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </Field>
+                  <EmField label="Camera" htmlFor="int-camera">
+                    <EmSelect id="int-camera" value={pickedCamera} onChange={(e) => setPickedCamera(e.target.value)}>
+                      {discoveredCameras.map(cam => (
+                        <option key={cam.device_id} value={cam.device_id}>
+                          {cam.device_name || cam.device_id}
+                        </option>
+                      ))}
+                    </EmSelect>
+                  </EmField>
                 )}
-              </div>
+              </>
             ) : !selectedIntegration ? (
-              <div className="flex flex-col gap-2">
+              <>
                 <button
                   type="button"
-                  className="flex items-center justify-between gap-3 rounded-md border border-border bg-secondary px-3 py-3 text-left transition-colors hover:bg-accent"
+                  className="em-cancel"
                   onClick={() => { setShowAddModal(false); setShowReaderModal(true); }}
                 >
-                  <div>
-                    <strong className="text-sm text-foreground">{shhPulseOxIntegration.name}</strong>
-                    <p className="text-xs text-muted-foreground">{shhPulseOxIntegration.description}</p>
-                  </div>
-                  <Badge variant="secondary">{getAuthTypeLabel(shhPulseOxIntegration.auth_type)}</Badge>
+                  <div><strong>{shhPulseOxIntegration.name}</strong> <span className="ec-badge">{getAuthTypeLabel(shhPulseOxIntegration.auth_type)}</span></div>
+                  <div className="ec-detail-label">{shhPulseOxIntegration.description}</div>
                 </button>
                 {unconfiguredIntegrations.map(integration => (
                   <button
                     key={integration.slug}
                     type="button"
-                    className="flex items-center justify-between gap-3 rounded-md border border-border bg-secondary px-3 py-3 text-left transition-colors hover:bg-accent"
+                    className="em-cancel"
                     onClick={() => pickIntegration(integration)}
                   >
-                    <div>
-                      <strong className="text-sm text-foreground">{integration.name}</strong>
-                      <p className="text-xs text-muted-foreground">{integration.description}</p>
-                    </div>
-                    <Badge variant="secondary">{getAuthTypeLabel(integration.auth_type)}</Badge>
+                    <div><strong>{integration.name}</strong> <span className="ec-badge">{getAuthTypeLabel(integration.auth_type)}</span></div>
+                    <div className="ec-detail-label">{integration.description}</div>
                   </button>
                 ))}
                 {unconfiguredIntegrations.length === 0 && (
-                  <p className="py-8 text-center text-sm text-muted-foreground">
+                  <p className="ec-detail-label">
                     Everything available is already connected.
                   </p>
                 )}
-              </div>
+              </>
             ) : (
-              <div className="flex flex-col gap-3">
+              <>
                 <div>
-                  <h3 className="text-base font-semibold text-foreground">{selectedIntegration.name}</h3>
-                  <p className="text-sm text-muted-foreground">{selectedIntegration.description}</p>
+                  <strong>{selectedIntegration.name}</strong>
+                  <p className="ec-detail-label">{selectedIntegration.description}</p>
                 </div>
 
                 {selectedIntegration.auth_type === 'oauth2' && (
-                  <Alert variant="default">
+                  <p className="ec-detail-label">
                     You will be redirected to {selectedIntegration.name} to authorize access.
-                  </Alert>
+                  </p>
                 )}
 
                 {configSchemaProps && Object.keys(configSchemaProps).length > 0 && (
-                  <div className="flex flex-col gap-4">
-                    <h4 className="text-sm font-semibold text-foreground">Settings</h4>
+                  <>
+                    <strong>Settings</strong>
                     {Object.entries(configSchemaProps)
                       // Hide fields whose value is chosen in a later step
                       // (Frigate camera is picked from the discovered list)
                       .filter(([key]) => !(selectedIntegration.slug === 'frigate' && key === 'camera'))
                       .map(([key, schema]) => (
-                        <Field key={key} label={schema.title || key}>
+                        <EmField key={key} label={schema.title || key} htmlFor={`int-set-${key}`}>
                           {schema.type === 'boolean' ? (
-                            <label className="flex cursor-pointer items-center gap-2">
-                              <Checkbox
+                            <label className="em-check-row">
+                              <input
+                                id={`int-set-${key}`}
+                                type="checkbox"
+                                className="em-check"
                                 checked={newSettings[key] ?? schema.default ?? false}
-                                onCheckedChange={(v) => setNewSettings({ ...newSettings, [key]: v === true })}
+                                onChange={(e) => setNewSettings({ ...newSettings, [key]: e.target.checked })}
                               />
-                              <span className="text-sm text-muted-foreground">{schema.description}</span>
+                              <span className="em-check-label">{schema.description}</span>
                             </label>
                           ) : Array.isArray(schema.enum) ? (
-                            <Select
-                              value={(newSettings[key] ?? schema.default) != null ? String(newSettings[key] ?? schema.default) : undefined}
-                              onValueChange={(v) => setNewSettings({ ...newSettings, [key]: v })}
+                            <EmSelect
+                              id={`int-set-${key}`}
+                              value={(newSettings[key] ?? schema.default) != null ? String(newSettings[key] ?? schema.default) : ''}
+                              onChange={(e) => setNewSettings({ ...newSettings, [key]: e.target.value })}
                             >
-                              <SelectTrigger><SelectValue /></SelectTrigger>
-                              <SelectContent>
-                                {schema.enum.map((opt, idx) => (
-                                  <SelectItem key={opt} value={String(opt)}>
-                                    {(schema.enumLabels && schema.enumLabels[idx]) || opt}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
+                              {(newSettings[key] ?? schema.default) == null && <option value="" />}
+                              {schema.enum.map((opt, idx) => (
+                                <option key={opt} value={String(opt)}>
+                                  {(schema.enumLabels && schema.enumLabels[idx]) || opt}
+                                </option>
+                              ))}
+                            </EmSelect>
                           ) : (
-                            <Input
+                            <input
+                              id={`int-set-${key}`}
+                              className="em-input"
                               value={newSettings[key] ?? schema.default ?? ''}
                               onChange={(e) => setNewSettings({ ...newSettings, [key]: e.target.value })}
                               placeholder={schema.description}
                             />
                           )}
-                        </Field>
+                        </EmField>
                       ))}
-                  </div>
+                  </>
                 )}
-              </div>
+              </>
             )}
 
-            <DialogFooter>
+            <div className="em-footer">
               {selectedIntegration && addStep === 'form' && (
-                <Button variant="ghost" onClick={() => { setSelectedIntegration(null); setNewSettings({}); }}>Back</Button>
+                <button type="button" className="em-cancel" onClick={() => { setSelectedIntegration(null); setNewSettings({}); }}>Back</button>
               )}
-              <Button variant="secondary" onClick={closeAddModal}>Cancel</Button>
+              <button type="button" className="em-cancel" onClick={closeAddModal}>Cancel</button>
               {addStep === 'select-camera' ? (
-                <Button onClick={handlePickCamera} disabled={addingIntegration || !pickedCamera}>
-                  {addingIntegration ? 'Saving...' : 'Use this camera'}
-                </Button>
+                <button type="button" className="em-submit" onClick={handlePickCamera} disabled={addingIntegration || !pickedCamera}>
+                  {addingIntegration ? 'Saving…' : 'Use this camera'}
+                </button>
               ) : selectedIntegration && (
-                <Button onClick={handleAddIntegration} disabled={addingIntegration}>
-                  {addingIntegration ? 'Adding...' : (
+                <button type="button" className="em-submit" onClick={handleAddIntegration} disabled={addingIntegration}>
+                  {addingIntegration ? 'Adding…' : (
                     selectedIntegration.auth_type === 'oauth2'
                       ? `Connect to ${selectedIntegration.name}`
                       : 'Add'
                   )}
-                </Button>
+                </button>
               )}
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+            </div>
+          </div>
+        </EntityModal>
 
         <VentImportPanel
           open={importsPanel.open}

--- a/frontend/src/pages/admin-v2/AdminV2Diagnoses.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Diagnoses.jsx
@@ -23,57 +23,24 @@ import config from '../../config';
 import { useAuth } from '../../contexts/AuthContext';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
 import {
-  PlusIcon,
-  EditIcon,
   TrashIcon,
-  CheckIcon,
   ClipboardListIcon,
-  NotesIcon
+  NotesIcon,
+  FileTextIcon,
+  CalendarIcon,
+  AlertIcon,
+  StethoscopeIcon,
 } from '../../components/Icons';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Alert } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
-import { Field, FormRow } from '@/components/ui/field';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
-import { cn } from '@/lib/utils';
+import EntityCard from '../../components/vc/EntityCard';
+import EntityToolbar from '../../components/vc/EntityToolbar';
+import EntityModal, { EmField, EmRow, EmSelect } from '../../components/vc/EntityModal';
 import './AdminV2.css';
 
-// Radix Select forbids an empty-string value, so use a sentinel for "none".
-const NONE = '__none__';
-
-const statusVariant = (status) => (
-  { active: 'success', resolved: 'muted', chronic: 'warning', in_remission: 'info', ruled_out: 'danger' }[status] || 'muted'
+// Tag tones per the vc color roles: amber = ongoing concern, green = resolved,
+// accent = in remission, muted for historical/ruled-out.
+const statusTone = (status) => (
+  { active: 'due', chronic: 'due', in_remission: 'accent', resolved: 'complete', ruled_out: 'idle' }[status] || 'idle'
 );
-const severityVariant = (severity) => (
-  { mild: 'success', moderate: 'warning', severe: 'danger', critical: 'danger' }[severity] || 'muted'
-);
-
-// Label/value row used inside the diagnosis cards.
-function Row({ label, value }) {
-  return (
-    <div className="flex justify-between gap-3">
-      <span className="shrink-0 text-muted-foreground">{label}:</span>
-      <span className="text-right text-foreground">{value}</span>
-    </div>
-  );
-}
 
 const AdminV2Diagnoses = () => {
   const { user } = useAuth();
@@ -187,7 +154,7 @@ const AdminV2Diagnoses = () => {
       fetchProviders();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helpers are recreated each render; effect is keyed on patient/filter changes only
-  }, [selectedPatient, activeTab, filterStatus, filterCategory]);
+  }, [selectedPatient, filterStatus, filterCategory]);
 
   const fetchLookupData = async () => {
     try {
@@ -216,7 +183,9 @@ const AdminV2Diagnoses = () => {
       setLoading(true);
       setError(null);
 
-      let url = `${config.apiUrl}/api/diagnoses/patient/${selectedPatient.id}?active_only=${activeTab === 'active'}`;
+      // Fetch active + inactive together so the count tabs are accurate;
+      // the tab split happens client-side.
+      let url = `${config.apiUrl}/api/diagnoses/patient/${selectedPatient.id}?active_only=false`;
       if (filterStatus) url += `&status=${encodeURIComponent(filterStatus)}`;
       if (filterCategory) url += `&category=${encodeURIComponent(filterCategory)}`;
 
@@ -464,10 +433,15 @@ const AdminV2Diagnoses = () => {
     setShowCreateModal(true);
   };
 
-  const filteredDiagnoses = diagnoses.filter(d =>
+  const matchesSearch = (d) =>
     d.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
     d.icd10_code?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    d.category?.toLowerCase().includes(searchTerm.toLowerCase())
+    d.category?.toLowerCase().includes(searchTerm.toLowerCase());
+
+  const activeCount = diagnoses.filter((d) => d.active).length;
+  const inactiveCount = diagnoses.length - activeCount;
+  const filteredDiagnoses = diagnoses.filter(
+    (d) => (activeTab === 'active' ? d.active : !d.active) && matchesSearch(d)
   );
 
   const formatLabel = (str) => {
@@ -475,11 +449,70 @@ const AdminV2Diagnoses = () => {
     return str.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
   };
 
-  // Provider <Select> options, shared by the form + notes dialogs.
+  const badgeLabel = (str) => str.replace(/_/g, ' ').toUpperCase();
+
+  // People-style avatar: first letters of the first two words of the name.
+  const diagnosisInitials = (name) =>
+    (name || '').split(/\s+/).filter(Boolean).slice(0, 2).map((w) => w[0]).join('').toUpperCase();
+
+  // The Primary tag occupies the card's single tag slot, so status joins the
+  // badges on primary diagnoses to stay visible. A 'primary' diagnosis_type
+  // badge is dropped there — the tag already says it.
+  const diagnosisBadges = (d) => [
+    ...(d.is_primary_diagnosis && d.status ? [badgeLabel(d.status)] : []),
+    ...(d.diagnosis_type && !(d.is_primary_diagnosis && d.diagnosis_type === 'primary')
+      ? [badgeLabel(d.diagnosis_type)]
+      : []),
+    ...(d.category ? [badgeLabel(d.category)] : []),
+  ];
+
+  const diagnosisDetails = (d) => [
+    { icon: <FileTextIcon size={18} />, label: 'ICD-10 code', value: d.icd10_code },
+    {
+      icon: <CalendarIcon size={18} />,
+      label: 'Diagnosed',
+      value: d.diagnosis_date ? new Date(d.diagnosis_date).toLocaleDateString() : null,
+    },
+    ...(d.severity
+      ? [{ icon: <AlertIcon size={18} />, label: 'Severity', value: formatLabel(d.severity) }]
+      : []),
+    ...(d.diagnosing_provider_name
+      ? [{ icon: <StethoscopeIcon size={18} />, label: 'Diagnosed by', value: d.diagnosing_provider_name }]
+      : []),
+    ...(d.managing_provider_name
+      ? [{ icon: <StethoscopeIcon size={18} />, label: 'Managed by', value: d.managing_provider_name }]
+      : []),
+    ...(d.notes_count > 0
+      ? [{
+          icon: <NotesIcon size={18} />,
+          label: 'Notes',
+          value: `${d.notes_count} follow-up note${d.notes_count !== 1 ? 's' : ''}`,
+        }]
+      : []),
+  ];
+
+  const diagnosisMenu = (d) => {
+    const items = [];
+    if (hasPermission('diagnoses.update')) {
+      items.push({ label: 'Edit', onClick: () => handleEdit(d) });
+      if (!d.is_primary_diagnosis && d.active) {
+        items.push({ label: 'Set primary', onClick: () => handleSetPrimary(d.id) });
+      }
+      if (!d.active) {
+        items.push({ label: 'Activate', onClick: () => handleActivate(d.id) });
+      }
+    }
+    if (d.active && hasPermission('diagnoses.delete')) {
+      items.push({ label: 'Deactivate', onClick: () => handleDelete(d.id), danger: true });
+    }
+    return items;
+  };
+
+  // Provider select options, shared by the form + notes dialogs.
   const providerOptions = providers.map(p => (
-    <SelectItem key={p.id} value={String(p.id)}>
+    <option key={p.id} value={String(p.id)}>
       {p.title} {p.first_name} {p.last_name} ({p.specialty || p.provider_type})
-    </SelectItem>
+    </option>
   ));
 
   if (loadingPatients) {
@@ -495,149 +528,75 @@ const AdminV2Diagnoses = () => {
       <div className="admin-v2-page">
         {selectedPatient ? (
           <>
-            {error && (
-              <div className="tw mb-4">
-                <Alert variant="destructive">{error}</Alert>
+            {error && <div className="em-error ec-page-alert">{error}</div>}
+
+            <EntityToolbar
+              counts={[
+                { key: 'active', label: 'Active', count: activeCount },
+                { key: 'inactive', label: 'Inactive', count: inactiveCount },
+              ]}
+              activeCount={activeTab}
+              onCountChange={setActiveTab}
+              search={searchTerm}
+              onSearchChange={setSearchTerm}
+              searchPlaceholder="Search diagnoses"
+              filter={[
+                {
+                  value: filterStatus,
+                  onChange: setFilterStatus,
+                  label: 'Status',
+                  options: [
+                    { value: '', label: 'All statuses' },
+                    ...diagnosisStatuses.map((s) => ({ value: s, label: formatLabel(s) })),
+                  ],
+                },
+                {
+                  value: filterCategory,
+                  onChange: setFilterCategory,
+                  label: 'Category',
+                  options: [
+                    { value: '', label: 'All categories' },
+                    ...diagnosisCategories.map((c) => ({ value: c, label: formatLabel(c) })),
+                  ],
+                },
+              ]}
+              onAdd={hasPermission('diagnoses.create') ? openCreateModal : undefined}
+              addLabel="Add diagnosis"
+            />
+
+            {loading ? (
+              <div className="ec-empty">Loading diagnoses…</div>
+            ) : filteredDiagnoses.length === 0 ? (
+              <div className="ec-empty">
+                {searchTerm
+                  ? 'No diagnoses match your search.'
+                  : `No ${activeTab} diagnoses for this patient.`}
+              </div>
+            ) : (
+              <div className="ec-grid">
+                {filteredDiagnoses.map((diagnosis) => (
+                  <EntityCard
+                    key={diagnosis.id}
+                    initials={diagnosisInitials(diagnosis.name)}
+                    title={diagnosis.name}
+                    badges={diagnosisBadges(diagnosis)}
+                    tag={diagnosis.is_primary_diagnosis
+                      ? { label: 'Primary' }
+                      : { label: formatLabel(diagnosis.status), tone: statusTone(diagnosis.status) }}
+                    inactive={!diagnosis.active}
+                    details={diagnosisDetails(diagnosis)}
+                    quickActions={[
+                      {
+                        icon: <NotesIcon size={18} />,
+                        label: diagnosis.notes_count > 0 ? `Notes (${diagnosis.notes_count})` : 'Notes',
+                        onClick: () => openNotesModal(diagnosis),
+                      },
+                    ]}
+                    menu={diagnosisMenu(diagnosis)}
+                  />
+                ))}
               </div>
             )}
-
-            {/* Tabs and Filters */}
-            <div className="admin-v2-controls-bar">
-              <div className="admin-v2-tabs">
-                <button
-                  className={`admin-v2-tab ${activeTab === 'active' ? 'active' : ''}`}
-                  onClick={() => setActiveTab('active')}
-                >
-                  Active ({diagnoses.filter(d => d.active).length})
-                </button>
-                <button
-                  className={`admin-v2-tab ${activeTab === 'inactive' ? 'active' : ''}`}
-                  onClick={() => setActiveTab('inactive')}
-                >
-                  Inactive ({diagnoses.filter(d => !d.active).length})
-                </button>
-              </div>
-
-              <div className="admin-v2-filters">
-                <input
-                  type="text"
-                  placeholder="Search diagnoses..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="admin-v2-search-input"
-                />
-                <select
-                  value={filterStatus}
-                  onChange={(e) => setFilterStatus(e.target.value)}
-                  className="admin-v2-filter-select"
-                >
-                  <option value="">All Statuses</option>
-                  {diagnosisStatuses.map(status => (
-                    <option key={status} value={status}>{formatLabel(status)}</option>
-                  ))}
-                </select>
-                <select
-                  value={filterCategory}
-                  onChange={(e) => setFilterCategory(e.target.value)}
-                  className="admin-v2-filter-select"
-                >
-                  <option value="">All Categories</option>
-                  {diagnosisCategories.map(cat => (
-                    <option key={cat} value={cat}>{formatLabel(cat)}</option>
-                  ))}
-                </select>
-              </div>
-
-              {hasPermission('diagnoses.create') && (
-                <button
-                  className="admin-v2-btn admin-v2-btn-primary"
-                  onClick={openCreateModal}
-                >
-                  <PlusIcon size={16} /> Add Diagnosis
-                </button>
-              )}
-            </div>
-
-            {/* Diagnoses Cards Grid */}
-            <div className="tw mt-4">
-              {loading ? (
-                <p className="text-sm text-muted-foreground">Loading diagnoses...</p>
-              ) : filteredDiagnoses.length === 0 ? (
-                <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-border py-12 text-center text-muted-foreground">
-                  <ClipboardListIcon size={48} />
-                  <h3 className="text-base font-semibold text-foreground">
-                    {searchTerm ? 'No diagnoses found matching your search.' : 'No diagnoses found for this patient.'}
-                  </h3>
-                  {hasPermission('diagnoses.create') && (
-                    <Button onClick={openCreateModal}>
-                      <PlusIcon size={16} /> Add First Diagnosis
-                    </Button>
-                  )}
-                </div>
-              ) : (
-                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                  {filteredDiagnoses.map(diagnosis => (
-                    <Card key={diagnosis.id} className={cn(!diagnosis.active && "opacity-60")}>
-                      <CardHeader className="gap-2 py-3">
-                        <div className="flex items-center justify-between gap-2">
-                          <CardTitle className="text-sm">{diagnosis.name}</CardTitle>
-                          {diagnosis.is_primary_diagnosis && <Badge variant="info">PRIMARY</Badge>}
-                        </div>
-                        <div className="flex flex-wrap gap-1.5">
-                          <Badge variant={statusVariant(diagnosis.status)}>{formatLabel(diagnosis.status)}</Badge>
-                          {diagnosis.severity && (
-                            <Badge variant={severityVariant(diagnosis.severity)}>{formatLabel(diagnosis.severity)}</Badge>
-                          )}
-                        </div>
-                      </CardHeader>
-
-                      <CardContent className="flex flex-col gap-1.5 py-3 text-sm">
-                        {diagnosis.icd10_code && <Row label="ICD-10" value={diagnosis.icd10_code} />}
-                        {diagnosis.diagnosis_type && <Row label="Type" value={formatLabel(diagnosis.diagnosis_type)} />}
-                        {diagnosis.category && <Row label="Category" value={formatLabel(diagnosis.category)} />}
-                        {diagnosis.diagnosis_date && (
-                          <Row label="Diagnosed" value={new Date(diagnosis.diagnosis_date).toLocaleDateString()} />
-                        )}
-                        {diagnosis.diagnosing_provider_name && <Row label="Diagnosed by" value={diagnosis.diagnosing_provider_name} />}
-                        {diagnosis.managing_provider_name && <Row label="Managed by" value={diagnosis.managing_provider_name} />}
-                        {diagnosis.notes_count > 0 && (
-                          <Row label="Notes" value={`${diagnosis.notes_count} follow-up note${diagnosis.notes_count !== 1 ? 's' : ''}`} />
-                        )}
-                      </CardContent>
-
-                      <CardFooter className="flex-wrap justify-start gap-2 py-3">
-                        <Button size="sm" variant="ghost" onClick={() => openNotesModal(diagnosis)}>
-                          <NotesIcon size={14} /> Notes
-                        </Button>
-                        {hasPermission('diagnoses.update') && (
-                          <Button size="sm" variant="ghost" onClick={() => handleEdit(diagnosis)}>
-                            <EditIcon size={14} /> Edit
-                          </Button>
-                        )}
-                        {!diagnosis.is_primary_diagnosis && diagnosis.active && hasPermission('diagnoses.update') && (
-                          <Button size="sm" variant="ghost" onClick={() => handleSetPrimary(diagnosis.id)}>
-                            <CheckIcon size={14} /> Set Primary
-                          </Button>
-                        )}
-                        {diagnosis.active ? (
-                          hasPermission('diagnoses.delete') && (
-                            <Button size="sm" variant="ghost" className="text-[#ff7b72] hover:text-[#ff7b72]" onClick={() => handleDelete(diagnosis.id)}>
-                              <TrashIcon size={14} /> Deactivate
-                            </Button>
-                          )
-                        ) : (
-                          hasPermission('diagnoses.update') && (
-                            <Button size="sm" variant="ghost" className="text-[#3fb950] hover:text-[#3fb950]" onClick={() => handleActivate(diagnosis.id)}>
-                              <CheckIcon size={14} /> Activate
-                            </Button>
-                          )
-                        )}
-                      </CardFooter>
-                    </Card>
-                  ))}
-                </div>
-              )}
-            </div>
           </>
         ) : (
           <div className="admin-v2-placeholder-page">
@@ -659,201 +618,192 @@ const AdminV2Diagnoses = () => {
         )}
 
         {/* Create / Edit Dialog */}
-        <Dialog open={showCreateModal} onOpenChange={(o) => { if (!o) { setShowCreateModal(false); resetForm(); } }}>
-          <DialogContent className="sm:max-w-[720px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>{selectedDiagnosis ? 'Edit Diagnosis' : 'Add New Diagnosis'}</DialogTitle>
-            </DialogHeader>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-              {formError && <Alert variant="destructive">{formError}</Alert>}
+        <EntityModal
+          open={showCreateModal}
+          onOpenChange={(o) => { if (!o) { setShowCreateModal(false); resetForm(); } }}
+          title={selectedDiagnosis ? 'Edit diagnosis' : 'Add diagnosis'}
+          wide
+        >
+          <form onSubmit={handleSubmit} className="em-form">
+            {formError && <div className="em-error">{formError}</div>}
 
-              <Field label="Diagnosis Name" required htmlFor="dx-name">
-                <Input id="dx-name" value={formData.name} onChange={(e) => setFormData({ ...formData, name: e.target.value })} placeholder="e.g., Type 2 Diabetes Mellitus" required />
-              </Field>
+            <EmField label="Diagnosis name" required htmlFor="dx-name">
+              <input id="dx-name" className="em-input" value={formData.name} onChange={(e) => setFormData({ ...formData, name: e.target.value })} placeholder="e.g., Type 2 Diabetes Mellitus" required />
+            </EmField>
 
-              <FormRow>
-                <Field label="ICD-10 Code" htmlFor="dx-icd">
-                  <Input id="dx-icd" value={formData.icd10_code} onChange={(e) => setFormData({ ...formData, icd10_code: e.target.value })} placeholder="e.g., E11.9" />
-                </Field>
-                <Field label="ICD-10 Description" htmlFor="dx-icd-desc">
-                  <Input id="dx-icd-desc" value={formData.icd10_description} onChange={(e) => setFormData({ ...formData, icd10_description: e.target.value })} placeholder="Official ICD-10 description" />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="ICD-10 code" htmlFor="dx-icd">
+                <input id="dx-icd" className="em-input" value={formData.icd10_code} onChange={(e) => setFormData({ ...formData, icd10_code: e.target.value })} placeholder="e.g., E11.9" />
+              </EmField>
+              <EmField label="ICD-10 description" htmlFor="dx-icd-desc">
+                <input id="dx-icd-desc" className="em-input" value={formData.icd10_description} onChange={(e) => setFormData({ ...formData, icd10_description: e.target.value })} placeholder="Official ICD-10 description" />
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Diagnosis Type" required>
-                  <Select value={formData.diagnosis_type} onValueChange={(v) => setFormData({ ...formData, diagnosis_type: v })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      {diagnosisTypes.map(type => <SelectItem key={type} value={type}>{formatLabel(type)}</SelectItem>)}
-                    </SelectContent>
-                  </Select>
-                </Field>
-                <Field label="Status" required>
-                  <Select value={formData.status} onValueChange={(v) => setFormData({ ...formData, status: v })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      {diagnosisStatuses.map(status => <SelectItem key={status} value={status}>{formatLabel(status)}</SelectItem>)}
-                    </SelectContent>
-                  </Select>
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Diagnosis type" required htmlFor="dx-type">
+                <EmSelect id="dx-type" value={formData.diagnosis_type} onChange={(e) => setFormData({ ...formData, diagnosis_type: e.target.value })}>
+                  {diagnosisTypes.map(type => (
+                    <option key={type} value={type}>{formatLabel(type)}</option>
+                  ))}
+                </EmSelect>
+              </EmField>
+              <EmField label="Status" required htmlFor="dx-status">
+                <EmSelect id="dx-status" value={formData.status} onChange={(e) => setFormData({ ...formData, status: e.target.value })}>
+                  {diagnosisStatuses.map(status => (
+                    <option key={status} value={status}>{formatLabel(status)}</option>
+                  ))}
+                </EmSelect>
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Category">
-                  <Select value={formData.category || NONE} onValueChange={(v) => setFormData({ ...formData, category: v === NONE ? '' : v })}>
-                    <SelectTrigger><SelectValue placeholder="Select Category" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={NONE}>Select Category</SelectItem>
-                      {diagnosisCategories.map(cat => <SelectItem key={cat} value={cat}>{formatLabel(cat)}</SelectItem>)}
-                    </SelectContent>
-                  </Select>
-                </Field>
-                <Field label="Severity">
-                  <Select value={formData.severity || NONE} onValueChange={(v) => setFormData({ ...formData, severity: v === NONE ? '' : v })}>
-                    <SelectTrigger><SelectValue placeholder="Select Severity" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={NONE}>Select Severity</SelectItem>
-                      {severityLevels.map(level => <SelectItem key={level} value={level}>{formatLabel(level)}</SelectItem>)}
-                    </SelectContent>
-                  </Select>
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Category" htmlFor="dx-category">
+                <EmSelect id="dx-category" value={formData.category} onChange={(e) => setFormData({ ...formData, category: e.target.value })}>
+                  <option value="">Select category</option>
+                  {diagnosisCategories.map(cat => (
+                    <option key={cat} value={cat}>{formatLabel(cat)}</option>
+                  ))}
+                </EmSelect>
+              </EmField>
+              <EmField label="Severity" htmlFor="dx-severity">
+                <EmSelect id="dx-severity" value={formData.severity} onChange={(e) => setFormData({ ...formData, severity: e.target.value })}>
+                  <option value="">Select severity</option>
+                  {severityLevels.map(level => (
+                    <option key={level} value={level}>{formatLabel(level)}</option>
+                  ))}
+                </EmSelect>
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Onset Date" htmlFor="dx-onset">
-                  <Input id="dx-onset" type="date" value={formData.onset_date} onChange={(e) => setFormData({ ...formData, onset_date: e.target.value })} />
-                </Field>
-                <Field label="Diagnosis Date" htmlFor="dx-date">
-                  <Input id="dx-date" type="date" value={formData.diagnosis_date} onChange={(e) => setFormData({ ...formData, diagnosis_date: e.target.value })} />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Onset date" htmlFor="dx-onset">
+                <input id="dx-onset" className="em-input" type="date" value={formData.onset_date} onChange={(e) => setFormData({ ...formData, onset_date: e.target.value })} />
+              </EmField>
+              <EmField label="Diagnosis date" htmlFor="dx-date">
+                <input id="dx-date" className="em-input" type="date" value={formData.diagnosis_date} onChange={(e) => setFormData({ ...formData, diagnosis_date: e.target.value })} />
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Resolved Date" htmlFor="dx-resolved">
-                  <Input id="dx-resolved" type="date" value={formData.resolved_date} onChange={(e) => setFormData({ ...formData, resolved_date: e.target.value })} />
-                </Field>
-                <Field label="Diagnosing Provider">
-                  <Select
-                    value={formData.diagnosing_provider_id ? String(formData.diagnosing_provider_id) : NONE}
-                    onValueChange={(v) => setFormData({ ...formData, diagnosing_provider_id: v === NONE ? '' : v })}
-                  >
-                    <SelectTrigger><SelectValue placeholder="Select Provider" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={NONE}>Select Provider</SelectItem>
-                      {providerOptions}
-                    </SelectContent>
-                  </Select>
-                </Field>
-              </FormRow>
-
-              <Field label="Managing Provider">
-                <Select
-                  value={formData.managing_provider_id ? String(formData.managing_provider_id) : NONE}
-                  onValueChange={(v) => setFormData({ ...formData, managing_provider_id: v === NONE ? '' : v })}
+            <EmRow>
+              <EmField label="Resolved date" htmlFor="dx-resolved">
+                <input id="dx-resolved" className="em-input" type="date" value={formData.resolved_date} onChange={(e) => setFormData({ ...formData, resolved_date: e.target.value })} />
+              </EmField>
+              <EmField label="Diagnosing provider" htmlFor="dx-diag-provider">
+                <EmSelect
+                  id="dx-diag-provider"
+                  value={formData.diagnosing_provider_id ? String(formData.diagnosing_provider_id) : ''}
+                  onChange={(e) => setFormData({ ...formData, diagnosing_provider_id: e.target.value })}
                 >
-                  <SelectTrigger><SelectValue placeholder="Select Provider" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={NONE}>Select Provider</SelectItem>
-                    {providerOptions}
-                  </SelectContent>
-                </Select>
-              </Field>
+                  <option value="">Select provider</option>
+                  {providerOptions}
+                </EmSelect>
+              </EmField>
+            </EmRow>
 
-              <Field label="Clinical Notes" htmlFor="dx-notes">
-                <Textarea id="dx-notes" rows={3} value={formData.notes} onChange={(e) => setFormData({ ...formData, notes: e.target.value })} placeholder="Additional clinical notes..." />
-              </Field>
+            <EmField label="Managing provider" htmlFor="dx-mgr-provider">
+              <EmSelect
+                id="dx-mgr-provider"
+                value={formData.managing_provider_id ? String(formData.managing_provider_id) : ''}
+                onChange={(e) => setFormData({ ...formData, managing_provider_id: e.target.value })}
+              >
+                <option value="">Select provider</option>
+                {providerOptions}
+              </EmSelect>
+            </EmField>
 
-              <Field label="Treatment Plan" htmlFor="dx-plan">
-                <Textarea id="dx-plan" rows={3} value={formData.treatment_plan} onChange={(e) => setFormData({ ...formData, treatment_plan: e.target.value })} placeholder="Brief treatment approach..." />
-              </Field>
+            <EmField label="Clinical notes" htmlFor="dx-notes">
+              <textarea id="dx-notes" className="em-input" rows={3} value={formData.notes} onChange={(e) => setFormData({ ...formData, notes: e.target.value })} placeholder="Additional clinical notes..." />
+            </EmField>
 
-              <label className="flex w-fit cursor-pointer items-center gap-2">
-                <Checkbox checked={formData.is_primary_diagnosis} onCheckedChange={(v) => setFormData({ ...formData, is_primary_diagnosis: v === true })} />
-                <span className="text-sm text-foreground">Primary/Principal Diagnosis</span>
-              </label>
+            <EmField label="Treatment plan" htmlFor="dx-plan">
+              <textarea id="dx-plan" className="em-input" rows={3} value={formData.treatment_plan} onChange={(e) => setFormData({ ...formData, treatment_plan: e.target.value })} placeholder="Brief treatment approach..." />
+            </EmField>
 
-              <DialogFooter>
-                <Button type="button" variant="secondary" onClick={() => { setShowCreateModal(false); resetForm(); }}>Cancel</Button>
-                <Button type="submit" disabled={saving}>{saving ? 'Saving...' : (selectedDiagnosis ? 'Update Diagnosis' : 'Add Diagnosis')}</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
+            <label className="em-check-row">
+              <input type="checkbox" className="em-check" checked={formData.is_primary_diagnosis} onChange={(e) => setFormData({ ...formData, is_primary_diagnosis: e.target.checked })} />
+              <span className="em-check-label">Primary/principal diagnosis</span>
+            </label>
+
+            <div className="em-footer">
+              <button type="button" className="em-cancel" onClick={() => { setShowCreateModal(false); resetForm(); }}>
+                Cancel
+              </button>
+              <button type="submit" className="em-submit" disabled={saving}>
+                {saving ? 'Saving…' : (selectedDiagnosis ? 'Update diagnosis' : 'Add diagnosis')}
+              </button>
+            </div>
+          </form>
+        </EntityModal>
 
         {/* Notes Dialog */}
-        <Dialog
+        <EntityModal
           open={showNotesModal && !!selectedDiagnosis}
           onOpenChange={(o) => { if (!o) { setShowNotesModal(false); setSelectedDiagnosis(null); setDiagnosisNotes([]); } }}
+          title={`Follow-up notes: ${selectedDiagnosis?.name || ''}`}
+          wide
         >
-          <DialogContent className="sm:max-w-[640px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>Follow-up Notes: {selectedDiagnosis?.name}</DialogTitle>
-            </DialogHeader>
-
+          <div className="em-form">
             {/* Add Note Form */}
-            <div className="flex flex-col gap-3 rounded-md border border-border p-3">
-              <FormRow>
-                <Field label="Note Type">
-                  <Select value={newNoteType} onValueChange={setNewNoteType}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      {noteTypes.map(type => <SelectItem key={type} value={type}>{formatLabel(type)}</SelectItem>)}
-                    </SelectContent>
-                  </Select>
-                </Field>
-                <Field label="Provider (Optional)">
-                  <Select
-                    value={newNoteProviderId ? String(newNoteProviderId) : NONE}
-                    onValueChange={(v) => setNewNoteProviderId(v === NONE ? '' : v)}
-                  >
-                    <SelectTrigger><SelectValue placeholder="Select Provider" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={NONE}>Select Provider</SelectItem>
-                      {providers.map(p => (
-                        <SelectItem key={p.id} value={String(p.id)}>{p.title} {p.first_name} {p.last_name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </Field>
-              </FormRow>
-              <Field label="Note Content">
-                <Textarea rows={3} value={newNoteContent} onChange={(e) => setNewNoteContent(e.target.value)} placeholder="Enter note content..." />
-              </Field>
-              <div className="flex justify-end">
-                <Button onClick={handleAddNote} disabled={addingNote || !newNoteContent.trim()}>
-                  {addingNote ? 'Adding...' : 'Add Note'}
-                </Button>
-              </div>
+            <EmRow>
+              <EmField label="Note type" htmlFor="dx-note-type">
+                <EmSelect id="dx-note-type" value={newNoteType} onChange={(e) => setNewNoteType(e.target.value)}>
+                  {noteTypes.map(type => (
+                    <option key={type} value={type}>{formatLabel(type)}</option>
+                  ))}
+                </EmSelect>
+              </EmField>
+              <EmField label="Provider" optional htmlFor="dx-note-provider">
+                <EmSelect
+                  id="dx-note-provider"
+                  value={newNoteProviderId ? String(newNoteProviderId) : ''}
+                  onChange={(e) => setNewNoteProviderId(e.target.value)}
+                >
+                  <option value="">Select provider</option>
+                  {providers.map(p => (
+                    <option key={p.id} value={String(p.id)}>{p.title} {p.first_name} {p.last_name}</option>
+                  ))}
+                </EmSelect>
+              </EmField>
+            </EmRow>
+            <EmField label="Note content" htmlFor="dx-note-content">
+              <textarea id="dx-note-content" className="em-input" rows={3} value={newNoteContent} onChange={(e) => setNewNoteContent(e.target.value)} placeholder="Enter note content..." />
+            </EmField>
+            <div className="em-footer">
+              <button type="button" className="em-submit" onClick={handleAddNote} disabled={addingNote || !newNoteContent.trim()}>
+                {addingNote ? 'Adding…' : 'Add note'}
+              </button>
             </div>
 
             {/* Notes List */}
-            <div className="flex max-h-80 flex-col gap-3 overflow-y-auto">
-              {diagnosisNotes.length === 0 ? (
-                <p className="py-4 text-center text-sm text-muted-foreground">No notes yet for this diagnosis.</p>
-              ) : (
-                diagnosisNotes.map(note => (
-                  <div key={note.id} className="rounded-md border border-border p-3">
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Badge variant="secondary">{formatLabel(note.note_type)}</Badge>
-                        {note.provider_name && <span className="text-xs text-muted-foreground">{note.provider_name}</span>}
-                        <span className="text-xs text-muted-foreground">{new Date(note.created_at).toLocaleString()}</span>
-                      </div>
-                      <Button size="sm" variant="ghost" className="text-[#ff7b72] hover:text-[#ff7b72]" onClick={() => handleDeleteNote(note.id)}>
-                        <TrashIcon size={14} />
-                      </Button>
-                    </div>
-                    <div className="mt-2 whitespace-pre-wrap text-sm text-foreground">{note.content}</div>
-                    {note.created_by_name && (
-                      <div className="mt-2 text-xs text-muted-foreground">Added by: {note.created_by_name}</div>
-                    )}
+            {diagnosisNotes.length === 0 ? (
+              <div className="ec-empty">No notes yet for this diagnosis.</div>
+            ) : (
+              diagnosisNotes.map(note => (
+                <div key={note.id} className="em-field">
+                  <div className="ec-detail">
+                    <span className="ec-badge">{formatLabel(note.note_type)}</span>
+                    {note.provider_name && <span className="ec-detail-label">{note.provider_name}</span>}
+                    <span className="ec-detail-label">{new Date(note.created_at).toLocaleString()}</span>
+                    <button
+                      type="button"
+                      className="em-cancel"
+                      style={{ marginLeft: 'auto' }}
+                      aria-label="Delete note"
+                      onClick={() => handleDeleteNote(note.id)}
+                    >
+                      <TrashIcon size={14} />
+                    </button>
                   </div>
-                ))
-              )}
-            </div>
-          </DialogContent>
-        </Dialog>
+                  <div style={{ whiteSpace: 'pre-wrap' }}>{note.content}</div>
+                  {note.created_by_name && (
+                    <div className="ec-detail-label">Added by: {note.created_by_name}</div>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        </EntityModal>
       </div>
     </AdminV2Layout>
   );

--- a/frontend/src/pages/admin-v2/AdminV2Providers.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Providers.jsx
@@ -21,49 +21,16 @@ import config from '../../config';
 import { useAuth } from '../../contexts/AuthContext';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
 import {
-  PlusIcon,
-  EditIcon,
-  TrashIcon,
   UsersIcon,
-  CheckIcon
+  PhoneIcon,
+  MailIcon,
+  StethoscopeIcon,
+  BusinessesIcon,
 } from '../../components/Icons';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Alert } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
-import { Field, FormRow } from '@/components/ui/field';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
-import { cn } from '@/lib/utils';
+import EntityCard from '../../components/vc/EntityCard';
+import EntityToolbar from '../../components/vc/EntityToolbar';
+import EntityModal, { EmField, EmRow, EmSelect } from '../../components/vc/EntityModal';
 import './AdminV2.css';
-
-// Radix Select forbids an empty-string value, so use a sentinel for "none".
-const NONE = '__none__';
-
-// Label/value row used inside the provider cards.
-function Row({ label, value }) {
-  return (
-    <div className="flex justify-between gap-3">
-      <span className="shrink-0 text-muted-foreground">{label}:</span>
-      <span className="text-right text-foreground">{value}</span>
-    </div>
-  );
-}
 
 const AdminV2Providers = () => {
   const { user } = useAuth();
@@ -135,7 +102,7 @@ const AdminV2Providers = () => {
       fetchProviders();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helper is recreated each render; effect is keyed on patient change only
-  }, [selectedPatient, activeTab, filterType]);
+  }, [selectedPatient, filterType]);
 
   const fetchProviders = async () => {
     if (!selectedPatient) return;
@@ -144,7 +111,9 @@ const AdminV2Providers = () => {
       setLoading(true);
       setError(null);
 
-      let url = `${config.apiUrl}/api/providers/patient/${selectedPatient.id}?active_only=${activeTab === 'active'}`;
+      // Fetch active + inactive together so the count tabs are accurate;
+      // the tab split happens client-side.
+      let url = `${config.apiUrl}/api/providers/patient/${selectedPatient.id}?active_only=false`;
       if (filterType) {
         url += `&provider_type=${encodeURIComponent(filterType)}`;
       }
@@ -323,13 +292,41 @@ const AdminV2Providers = () => {
     setShowCreateModal(true);
   };
 
-  const filteredProviders = providers.filter(provider =>
-    provider.first_name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    provider.last_name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    provider.specialty?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    provider.provider_type.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (provider.business && provider.business.name.toLowerCase().includes(searchTerm.toLowerCase()))
+  const matchesSearch = (provider) => {
+    const q = searchTerm.toLowerCase();
+    return (
+      provider.first_name.toLowerCase().includes(q) ||
+      provider.last_name.toLowerCase().includes(q) ||
+      provider.specialty?.toLowerCase().includes(q) ||
+      provider.provider_type.toLowerCase().includes(q) ||
+      (provider.business && provider.business.name.toLowerCase().includes(q))
+    );
+  };
+
+  const activeCount = providers.filter((p) => p.active).length;
+  const inactiveCount = providers.length - activeCount;
+  const filteredProviders = providers.filter(
+    (p) => (activeTab === 'active' ? p.active : !p.active) && matchesSearch(p)
   );
+
+  const typeLabel = (t) => t.replace('_', ' ').toUpperCase();
+
+  const providerMenu = (provider) => {
+    const items = [];
+    if (hasPermission('providers.update')) {
+      items.push({ label: 'Edit', onClick: () => handleEdit(provider) });
+      if (!provider.is_primary && provider.active) {
+        items.push({ label: 'Set primary', onClick: () => handleSetPrimary(provider.id) });
+      }
+      if (!provider.active) {
+        items.push({ label: 'Activate', onClick: () => handleActivate(provider.id) });
+      }
+    }
+    if (provider.active && hasPermission('providers.delete')) {
+      items.push({ label: 'Deactivate', onClick: () => handleDelete(provider.id), danger: true });
+    }
+    return items;
+  };
 
   // Loading state
   if (loadingPatients) {
@@ -345,130 +342,66 @@ const AdminV2Providers = () => {
       <div className="admin-v2-page">
         {selectedPatient ? (
           <>
-            {error && (
-              <div className="tw mb-4">
-                <Alert variant="destructive">{error}</Alert>
+            {error && <div className="em-error ec-page-alert">{error}</div>}
+
+            <EntityToolbar
+              counts={[
+                { key: 'active', label: 'Active', count: activeCount },
+                { key: 'inactive', label: 'Inactive', count: inactiveCount },
+              ]}
+              activeCount={activeTab}
+              onCountChange={setActiveTab}
+              search={searchTerm}
+              onSearchChange={setSearchTerm}
+              searchPlaceholder="Search providers"
+              filter={{
+                value: filterType,
+                onChange: setFilterType,
+                label: 'Type',
+                options: [
+                  { value: '', label: 'All types' },
+                  ...providerTypes.map((t) => ({ value: t, label: typeLabel(t) })),
+                ],
+              }}
+              onAdd={hasPermission('providers.create') ? openCreateModal : undefined}
+              addLabel="Add provider"
+            />
+
+            {loading ? (
+              <div className="ec-empty">Loading providers…</div>
+            ) : filteredProviders.length === 0 ? (
+              <div className="ec-empty">
+                {searchTerm
+                  ? 'No providers match your search.'
+                  : `No ${activeTab} providers for this patient.`}
+              </div>
+            ) : (
+              <div className="ec-grid">
+                {filteredProviders.map((provider) => (
+                  <EntityCard
+                    key={provider.id}
+                    initials={`${provider.first_name?.[0] || ''}${provider.last_name?.[0] || ''}`}
+                    title={[provider.title, provider.first_name, provider.last_name].filter(Boolean).join(' ')}
+                    badges={[typeLabel(provider.provider_type)]}
+                    tag={provider.is_primary ? { label: 'Primary' } : undefined}
+                    inactive={!provider.active}
+                    details={[
+                      { icon: <StethoscopeIcon size={18} />, label: 'Specialty', value: provider.specialty },
+                      { icon: <BusinessesIcon size={18} />, label: 'Business', value: provider.business?.name },
+                    ]}
+                    quickActions={[
+                      ...(provider.phone
+                        ? [{ icon: <PhoneIcon size={18} />, label: `Call ${provider.phone}`, href: `tel:${provider.phone}` }]
+                        : []),
+                      ...(provider.email
+                        ? [{ icon: <MailIcon size={18} />, label: `Email ${provider.email}`, href: `mailto:${provider.email}` }]
+                        : []),
+                    ]}
+                    menu={providerMenu(provider)}
+                  />
+                ))}
               </div>
             )}
-
-            {/* Tabs and Filters */}
-            <div className="admin-v2-controls-bar">
-              <div className="admin-v2-tabs">
-                <button
-                  className={`admin-v2-tab ${activeTab === 'active' ? 'active' : ''}`}
-                  onClick={() => setActiveTab('active')}
-                >
-                  Active ({providers.filter(p => p.active).length})
-                </button>
-                <button
-                  className={`admin-v2-tab ${activeTab === 'inactive' ? 'active' : ''}`}
-                  onClick={() => setActiveTab('inactive')}
-                >
-                  Inactive ({providers.filter(p => !p.active).length})
-                </button>
-              </div>
-
-              <div className="admin-v2-filters">
-                <input
-                  type="text"
-                  placeholder="Search providers..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="admin-v2-search-input"
-                />
-                <select
-                  value={filterType}
-                  onChange={(e) => setFilterType(e.target.value)}
-                  className="admin-v2-filter-select"
-                >
-                  <option value="">All Types</option>
-                  {providerTypes.map(type => (
-                    <option key={type} value={type}>{type.replace('_', ' ').toUpperCase()}</option>
-                  ))}
-                </select>
-              </div>
-
-              {hasPermission('providers.create') && (
-                <button
-                  className="admin-v2-btn admin-v2-btn-primary"
-                  onClick={openCreateModal}
-                >
-                  <PlusIcon size={16} /> Add Provider
-                </button>
-              )}
-            </div>
-
-            {/* Provider Cards Grid */}
-            <div className="tw mt-4">
-              {loading ? (
-                <p className="text-sm text-muted-foreground">Loading providers...</p>
-              ) : filteredProviders.length === 0 ? (
-                <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-border py-12 text-center text-muted-foreground">
-                  <UsersIcon size={48} />
-                  <h3 className="text-base font-semibold text-foreground">
-                    {searchTerm ? 'No providers found matching your search.' : 'No providers found for this patient.'}
-                  </h3>
-                  {hasPermission('providers.create') && (
-                    <Button onClick={openCreateModal}>
-                      <PlusIcon size={16} /> Add First Provider
-                    </Button>
-                  )}
-                </div>
-              ) : (
-                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                  {filteredProviders.map(provider => (
-                    <Card key={provider.id} className={cn(!provider.active && "opacity-60")}>
-                      <CardHeader className="gap-2 py-3">
-                        <div className="flex items-center justify-between gap-2">
-                          <CardTitle className="text-sm">
-                            {provider.title} {provider.first_name} {provider.last_name}
-                          </CardTitle>
-                          {provider.is_primary && <Badge variant="info">PRIMARY</Badge>}
-                        </div>
-                        <Badge variant="secondary" className="w-fit">
-                          {provider.provider_type.replace('_', ' ').toUpperCase()}
-                        </Badge>
-                      </CardHeader>
-
-                      <CardContent className="flex flex-col gap-1.5 py-3 text-sm">
-                        {provider.specialty && <Row label="Specialty" value={provider.specialty} />}
-                        {provider.business && <Row label="Business" value={provider.business.name} />}
-                        {provider.department && <Row label="Department" value={provider.department} />}
-                        {provider.phone && <Row label="Phone" value={provider.phone} />}
-                        {provider.email && <Row label="Email" value={provider.email} />}
-                        {provider.license_number && <Row label="License" value={provider.license_number} />}
-                      </CardContent>
-
-                      <CardFooter className="flex-wrap justify-start gap-2 py-3">
-                        {hasPermission('providers.update') && (
-                          <Button size="sm" variant="ghost" onClick={() => handleEdit(provider)}>
-                            <EditIcon size={14} /> Edit
-                          </Button>
-                        )}
-                        {!provider.is_primary && provider.active && hasPermission('providers.update') && (
-                          <Button size="sm" variant="ghost" onClick={() => handleSetPrimary(provider.id)}>
-                            <CheckIcon size={14} /> Set Primary
-                          </Button>
-                        )}
-                        {provider.active ? (
-                          hasPermission('providers.delete') && (
-                            <Button size="sm" variant="ghost" className="text-[#ff7b72] hover:text-[#ff7b72]" onClick={() => handleDelete(provider.id)}>
-                              <TrashIcon size={14} /> Deactivate
-                            </Button>
-                          )
-                        ) : (
-                          hasPermission('providers.update') && (
-                            <Button size="sm" variant="ghost" className="text-[#3fb950] hover:text-[#3fb950]" onClick={() => handleActivate(provider.id)}>
-                              <CheckIcon size={14} /> Activate
-                            </Button>
-                          )
-                        )}
-                      </CardFooter>
-                    </Card>
-                  ))}
-                </div>
-              )}
-            </div>
           </>
         ) : (
           <div className="admin-v2-placeholder-page">
@@ -479,108 +412,103 @@ const AdminV2Providers = () => {
         )}
 
         {/* Create / Edit Dialog */}
-        <Dialog open={showCreateModal} onOpenChange={(o) => { if (!o) { setShowCreateModal(false); resetForm(); } }}>
-          <DialogContent className="sm:max-w-[680px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>{selectedProvider ? 'Edit Provider' : 'Add New Provider'}</DialogTitle>
-            </DialogHeader>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-              {formError && <Alert variant="destructive">{formError}</Alert>}
+        <EntityModal
+          open={showCreateModal}
+          onOpenChange={(o) => { if (!o) { setShowCreateModal(false); resetForm(); } }}
+          title={selectedProvider ? 'Edit provider' : 'Add provider'}
+          wide
+        >
+          <form onSubmit={handleSubmit} className="em-form">
+            {formError && <div className="em-error">{formError}</div>}
 
-              <FormRow>
-                <Field label="First Name" required htmlFor="prov-first">
-                  <Input id="prov-first" value={formData.first_name} onChange={(e) => setFormData({ ...formData, first_name: e.target.value })} required />
-                </Field>
-                <Field label="Last Name" required htmlFor="prov-last">
-                  <Input id="prov-last" value={formData.last_name} onChange={(e) => setFormData({ ...formData, last_name: e.target.value })} required />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="First name" required htmlFor="prov-first">
+                <input id="prov-first" className="em-input" value={formData.first_name} onChange={(e) => setFormData({ ...formData, first_name: e.target.value })} required />
+              </EmField>
+              <EmField label="Last name" required htmlFor="prov-last">
+                <input id="prov-last" className="em-input" value={formData.last_name} onChange={(e) => setFormData({ ...formData, last_name: e.target.value })} required />
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Title" htmlFor="prov-title">
-                  <Input id="prov-title" value={formData.title} onChange={(e) => setFormData({ ...formData, title: e.target.value })} placeholder="Dr., RN, PT, OT, etc." />
-                </Field>
-                <Field label="Provider Type" required>
-                  <Select value={formData.provider_type} onValueChange={(v) => setFormData({ ...formData, provider_type: v })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      {providerTypeOptions.map(type => (
-                        <SelectItem key={type} value={type}>{type.replace('_', ' ').toUpperCase()}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Title" htmlFor="prov-title">
+                <input id="prov-title" className="em-input" value={formData.title} onChange={(e) => setFormData({ ...formData, title: e.target.value })} placeholder="Dr., RN, PT, OT, etc." />
+              </EmField>
+              <EmField label="Provider type" required htmlFor="prov-type">
+                <EmSelect id="prov-type" value={formData.provider_type} onChange={(e) => setFormData({ ...formData, provider_type: e.target.value })}>
+                  {providerTypeOptions.map(type => (
+                    <option key={type} value={type}>{typeLabel(type)}</option>
+                  ))}
+                </EmSelect>
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Specialty" htmlFor="prov-specialty">
-                  <Input id="prov-specialty" value={formData.specialty} onChange={(e) => setFormData({ ...formData, specialty: e.target.value })} placeholder="Cardiologist, Physical Therapist, etc." />
-                </Field>
-                <Field label="Associated Business">
-                  <Select
-                    value={formData.business_id ? String(formData.business_id) : NONE}
-                    onValueChange={(v) => setFormData({ ...formData, business_id: v === NONE ? '' : v })}
-                  >
-                    <SelectTrigger><SelectValue placeholder="No Business Association" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={NONE}>No Business Association</SelectItem>
-                      {businesses.map(business => (
-                        <SelectItem key={business.id} value={String(business.id)}>
-                          {business.name} ({business.business_type})
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Specialty" htmlFor="prov-specialty">
+                <input id="prov-specialty" className="em-input" value={formData.specialty} onChange={(e) => setFormData({ ...formData, specialty: e.target.value })} placeholder="Cardiologist, Physical Therapist, etc." />
+              </EmField>
+              <EmField label="Associated business" htmlFor="prov-business">
+                <EmSelect
+                  id="prov-business"
+                  value={formData.business_id ? String(formData.business_id) : ''}
+                  onChange={(e) => setFormData({ ...formData, business_id: e.target.value })}
+                >
+                  <option value="">No business association</option>
+                  {businesses.map(business => (
+                    <option key={business.id} value={String(business.id)}>
+                      {business.name} ({business.business_type})
+                    </option>
+                  ))}
+                </EmSelect>
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Phone" htmlFor="prov-phone">
-                  <Input id="prov-phone" type="tel" value={formData.phone} onChange={(e) => setFormData({ ...formData, phone: e.target.value })} />
-                </Field>
-                <Field label="Email" htmlFor="prov-email">
-                  <Input id="prov-email" type="email" value={formData.email} onChange={(e) => setFormData({ ...formData, email: e.target.value })} />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Phone" htmlFor="prov-phone">
+                <input id="prov-phone" className="em-input" type="tel" value={formData.phone} onChange={(e) => setFormData({ ...formData, phone: e.target.value })} />
+              </EmField>
+              <EmField label="Email" htmlFor="prov-email">
+                <input id="prov-email" className="em-input" type="email" value={formData.email} onChange={(e) => setFormData({ ...formData, email: e.target.value })} />
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="Fax" htmlFor="prov-fax">
-                  <Input id="prov-fax" type="tel" value={formData.fax} onChange={(e) => setFormData({ ...formData, fax: e.target.value })} />
-                </Field>
-                <Field label="License Number" htmlFor="prov-license">
-                  <Input id="prov-license" value={formData.license_number} onChange={(e) => setFormData({ ...formData, license_number: e.target.value })} />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="Fax" htmlFor="prov-fax">
+                <input id="prov-fax" className="em-input" type="tel" value={formData.fax} onChange={(e) => setFormData({ ...formData, fax: e.target.value })} />
+              </EmField>
+              <EmField label="License number" htmlFor="prov-license">
+                <input id="prov-license" className="em-input" value={formData.license_number} onChange={(e) => setFormData({ ...formData, license_number: e.target.value })} />
+              </EmField>
+            </EmRow>
 
-              <FormRow>
-                <Field label="NPI Number" htmlFor="prov-npi">
-                  <Input id="prov-npi" value={formData.npi_number} onChange={(e) => setFormData({ ...formData, npi_number: e.target.value })} />
-                </Field>
-                <Field label="Department" htmlFor="prov-dept">
-                  <Input id="prov-dept" value={formData.department} onChange={(e) => setFormData({ ...formData, department: e.target.value })} />
-                </Field>
-              </FormRow>
+            <EmRow>
+              <EmField label="NPI number" htmlFor="prov-npi">
+                <input id="prov-npi" className="em-input" value={formData.npi_number} onChange={(e) => setFormData({ ...formData, npi_number: e.target.value })} />
+              </EmField>
+              <EmField label="Department" htmlFor="prov-dept">
+                <input id="prov-dept" className="em-input" value={formData.department} onChange={(e) => setFormData({ ...formData, department: e.target.value })} />
+              </EmField>
+            </EmRow>
 
-              <Field label="Notes" htmlFor="prov-notes">
-                <Textarea id="prov-notes" rows={3} value={formData.notes} onChange={(e) => setFormData({ ...formData, notes: e.target.value })} />
-              </Field>
+            <EmField label="Notes" htmlFor="prov-notes">
+              <textarea id="prov-notes" className="em-input" rows={3} value={formData.notes} onChange={(e) => setFormData({ ...formData, notes: e.target.value })} />
+            </EmField>
 
-              <label className="flex w-fit cursor-pointer items-center gap-2">
-                <Checkbox checked={formData.is_primary} onCheckedChange={(v) => setFormData({ ...formData, is_primary: v === true })} />
-                <span className="text-sm text-foreground">Primary provider for this type</span>
-              </label>
+            <label className="em-check-row">
+              <input type="checkbox" className="em-check" checked={formData.is_primary} onChange={(e) => setFormData({ ...formData, is_primary: e.target.checked })} />
+              <span className="em-check-label">Primary provider for this type</span>
+            </label>
 
-              <DialogFooter>
-                <Button type="button" variant="secondary" onClick={() => { setShowCreateModal(false); resetForm(); }}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={saving}>
-                  {saving ? 'Saving...' : (selectedProvider ? 'Update Provider' : 'Add Provider')}
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
+            <div className="em-footer">
+              <button type="button" className="em-cancel" onClick={() => { setShowCreateModal(false); resetForm(); }}>
+                Cancel
+              </button>
+              <button type="submit" className="em-submit" disabled={saving}>
+                {saving ? 'Saving…' : (selectedProvider ? 'Update provider' : 'Add provider')}
+              </button>
+            </div>
+          </form>
+        </EntityModal>
       </div>
     </AdminV2Layout>
   );


### PR DESCRIPTION
## Summary
- New shared components in `frontend/src/components/vc/` — `EntityCard`, `EntityModal` (with `EmField`/`EmRow`/`EmSelect` helpers), `EntityToolbar`, and `entity-card.css` — carrying the vc/bedside-monitor aesthetic established in the symptoms work.
- **Providers, Businesses, Diagnoses, and Connections** admin pages are rebuilt on these components, replacing their shadcn `Card`/`Dialog`/`Alert`/`Badge` usage. Status badges become card tags with tones (`complete`/`due`/`accent`/`idle`); row actions move into card menus.
- Connections' page-level alert banner adopts the same vocabulary: a green `em-success` variant, amber `em-error`, and a dismiss button (`em-dismiss`). The other three pages keep the simpler error-only `ec-page-alert` since they never surface a success message.
- A handful of new SVG icons added to `Icons.jsx` for card detail rows (wifi, clock, globe, alert, file-text, etc.).

## Testing
- `npm run lint` clean (0 warnings) and `npm run build` succeeds.
- All four pages and their dialogs visually checked in the dev stack, including the new modals for diagnoses (type/status/category/severity form), notes, and reader connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4t1iK1gSfh6R6oGbaYriY