### PR TITLE
Login + user select rebuilt in the vc aesthetic

### DIFF
--- a/frontend/e2e/smoke.spec.js
+++ b/frontend/e2e/smoke.spec.js
@@ -18,7 +18,7 @@
 // Wave 5 — browser smoke against the live docker-compose stack.
 //
 // The first test is credential-free: it drives the real two-layer auth up to
-// the user picker via "Continue without unlocking" (account-level access).
+// the user picker via "Continue in quick entry" (account-level access).
 //
 // The full login -> /care step needs a real user credential, so it is GATED by
 // env vars and skipped unless provided:
@@ -30,17 +30,17 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('auth smoke', () => {
-  test('login page -> continue without unlocking -> user picker', async ({ page }) => {
+  test('login page -> continue in quick entry -> user picker', async ({ page }) => {
     await page.goto('/login');
 
     // Layer 1: the account sign-in screen.
-    await expect(page.getByRole('heading', { name: 'Sign In' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Unlock Care Record' })).toBeVisible();
 
     // Account-level access (no account password) lands on the user picker.
-    await page.getByRole('button', { name: 'Continue without unlocking' }).click();
+    await page.getByRole('button', { name: 'Continue in quick entry' }).click();
 
     await expect(page).toHaveURL(/\/select-user$/);
-    await expect(page.getByRole('heading', { name: 'Select User' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Who is documenting?' })).toBeVisible();
     // At least one profile card is rendered for the account.
     await expect(page.locator('.user-card').first()).toBeVisible();
   });
@@ -52,7 +52,7 @@ test.describe('auth smoke', () => {
     test.skip(!user || (!password && !pin), 'set E2E_USER + E2E_PASSWORD or E2E_PIN to run');
 
     await page.goto('/login');
-    await page.getByRole('button', { name: 'Continue without unlocking' }).click();
+    await page.getByRole('button', { name: 'Continue in quick entry' }).click();
     await expect(page).toHaveURL(/\/select-user$/);
 
     // Pick the profile (cards show the full name / username).

--- a/frontend/src/components/Icons.jsx
+++ b/frontend/src/components/Icons.jsx
@@ -1020,3 +1020,45 @@ export const MoreVerticalIcon = ({ size = 20 }) => (
     <circle cx="12" cy="19" r="1.6" />
   </svg>
 );
+
+export const LockIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="4" y="11" width="16" height="10" rx="2" />
+    <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+  </svg>
+);
+
+export const UnlockIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="4" y="11" width="16" height="10" rx="2" />
+    <path d="M8 11V7a4 4 0 0 1 7.7-1.5" />
+  </svg>
+);
+
+export const EyeIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M2 12s3.5-6.5 10-6.5S22 12 22 12s-3.5 6.5-10 6.5S2 12 2 12z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+export const EyeOffIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M17.94 17.94A10.9 10.9 0 0 1 12 18.5C5.5 18.5 2 12 2 12a20 20 0 0 1 5.06-5.94" />
+    <path d="M9.9 5.24A10.4 10.4 0 0 1 12 5.5c6.5 0 10 6.5 10 6.5a19.9 19.9 0 0 1-3.22 4.31" />
+    <path d="M14.12 14.12A3 3 0 1 1 9.88 9.88" />
+    <line x1="2" y1="2" x2="22" y2="22" />
+  </svg>
+);
+
+export const BrandMarkIcon = ({ size = 32 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 10.5 12 3l9 7.5V21H3z" />
+    <polyline points="6 14.5 9 14.5 10.5 11 12.5 17 14 14.5 18 14.5" />
+  </svg>
+);

--- a/frontend/src/pages/AuthShell.jsx
+++ b/frontend/src/pages/AuthShell.jsx
@@ -1,0 +1,40 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { BrandMarkIcon } from '../components/Icons';
+import './auth.css';
+
+/* Shared frame for the auth surfaces: brand bar + centered content column. */
+export default function AuthShell({ children }) {
+  return (
+    <div className="vc-auth">
+      <header className="au-brand">
+        <Link to="/" className="au-brand-left">
+          <span className="au-brand-mark" aria-hidden="true"><BrandMarkIcon size={34} /></span>
+          <span>
+            <span className="au-brand-name">Smart Home Health</span>
+            <span className="au-brand-sub">Care System</span>
+          </span>
+        </Link>
+        <span className="au-online"><span className="au-online-dot" aria-hidden="true" />System online</span>
+      </header>
+      <main className="au-main">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -18,8 +18,17 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import logoImage from '../assets/logo2.png';
-import './LoginPage.css';
+import {
+  UnlockIcon,
+  LockIcon,
+  EyeIcon,
+  EyeOffIcon,
+  ClipboardListIcon,
+  ChevronRightIcon,
+  BackArrowIcon,
+} from '../components/Icons';
+import AuthShell from './AuthShell';
+import './auth.css';
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -27,6 +36,7 @@ export default function LoginPage() {
   const { isAuthenticated, isAccountAuthenticated, accountAccess, skipAccountPassword } = useAuth();
 
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [autoSkipTried, setAutoSkipTried] = useState(false);
@@ -72,8 +82,7 @@ export default function LoginPage() {
     }
   };
 
-  const handleContinueWithoutUnlock = async (e) => {
-    e.preventDefault();
+  const handleContinueWithoutUnlock = async () => {
     setError('');
     setLoading(true);
     const result = await accountAccess(null);
@@ -88,70 +97,69 @@ export default function LoginPage() {
   // While the account-password skip is resolving, don't flash the password form.
   if (skipAccountPassword && !error) {
     return (
-      <div className="login-page">
-        <div className="login-container">
-          <Link to="/" className="login-logo">
-            <img src={logoImage} alt="Smart Home Health Logo" />
-            <span>Smart Home Health</span>
-          </Link>
-          <p className="login-subtitle">Continuing…</p>
-        </div>
-      </div>
+      <AuthShell>
+        <p className="au-continuing">Continuing…</p>
+      </AuthShell>
     );
   }
 
   return (
-    <div className="login-page">
-      <div className="login-container">
-        <Link to="/" className="login-logo">
-          <img src={logoImage} alt="Smart Home Health Logo" />
-          <span>Smart Home Health</span>
-        </Link>
+    <AuthShell>
+      <div className="au-eyebrow">Access Control</div>
+      <h2 className="au-title">Unlock Care Record</h2>
+      <p className="au-subtitle">Enter the account password for full access to patient data and settings.</p>
 
-        <div className="login-card">
-          <div className="login-header">
-            <h2>Sign In</h2>
-            <p>Enter account password to view data, or continue without unlocking to log and record only.</p>
-          </div>
+      <form onSubmit={handleUnlockAndContinue} className="au-form">
+        {error && <div className="au-error">{error}</div>}
 
-          <form onSubmit={handleUnlockAndContinue} className="login-form">
-            {error && <div className="error-message">{error}</div>}
-
-            <div className="form-group">
-              <label htmlFor="password">Account password</label>
-              <input
-                type="password"
-                id="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="Enter password to unlock"
-                autoFocus
-              />
-            </div>
-
-            <button type="submit" className="submit-button" disabled={loading}>
-              {loading ? 'Signing in...' : 'Unlock and continue'}
-            </button>
-          </form>
-
-          <div className="login-form login-form-secondary">
-            <button
-              type="button"
-              className="submit-button submit-button-secondary"
-              disabled={loading}
-              onClick={handleContinueWithoutUnlock}
-            >
-              Continue without unlocking
-            </button>
-          </div>
-
-          <div className="login-footer">
-            <Link to="/" className="back-link">
-              ← Back to Home
-            </Link>
-          </div>
+        <label className="au-label" htmlFor="password">Account password</label>
+        <div className="au-input-wrap">
+          <input
+            type={showPassword ? 'text' : 'password'}
+            id="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Enter password"
+            autoFocus
+          />
+          <button
+            type="button"
+            className="au-eye"
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+            onClick={() => setShowPassword(!showPassword)}
+          >
+            {showPassword ? <EyeOffIcon size={18} /> : <EyeIcon size={18} />}
+          </button>
         </div>
+
+        <button type="submit" className="au-primary" disabled={loading}>
+          <UnlockIcon size={18} /> {loading ? 'Unlocking…' : 'Unlock full access'}
+        </button>
+        <div className="au-caps">View · Edit · Export · Settings</div>
+      </form>
+
+      <div className="au-or"><em>or</em></div>
+
+      <div className="au-quick">
+        <span className="au-quick-icon" aria-hidden="true"><ClipboardListIcon size={24} /></span>
+        <div className="au-quick-title">Quick entry</div>
+        <p className="au-quick-body">Record medications, vitals and care tasks without viewing protected history.</p>
+        <button
+          type="button"
+          className="au-quick-btn"
+          disabled={loading}
+          onClick={handleContinueWithoutUnlock}
+        >
+          Continue in quick entry <ChevronRightIcon size={16} />
+        </button>
+        <div className="au-quick-caps"><LockIcon size={13} /> Record only · Patient data locked</div>
       </div>
-    </div>
+
+      <div className="au-footer">
+        <Link to="/" className="au-back">
+          <BackArrowIcon size={16} /> Back to home
+        </Link>
+      </div>
+    </AuthShell>
   );
 }

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -72,6 +72,12 @@ export default function LoginPage() {
   const handleUnlockAndContinue = async (e) => {
     e.preventDefault();
     setError('');
+    // accountAccess() treats a blank password as a request for restricted
+    // access — never what someone clicking "Unlock full access" meant.
+    if (!password.trim()) {
+      setError('Enter the account password, or use quick entry below.');
+      return;
+    }
     setLoading(true);
     const result = await accountAccess(password);
     setLoading(false);
@@ -121,6 +127,7 @@ export default function LoginPage() {
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Enter password"
             autoFocus
+            required
           />
           <button
             type="button"

--- a/frontend/src/pages/UserSelectionPage.jsx
+++ b/frontend/src/pages/UserSelectionPage.jsx
@@ -16,10 +16,26 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import React, { useState, useEffect } from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import logoImage from '../assets/logo2.png';
-import './LoginPage.css';
+import {
+  LockIcon,
+  UnlockIcon,
+  ChevronRightIcon,
+  BackArrowIcon,
+} from '../components/Icons';
+import AuthShell from './AuthShell';
+import './auth.css';
+
+// Credential chips shown next to clinical roles on the picker cards.
+const ROLE_ABBREVIATIONS = {
+  'registered nurse': 'RN',
+  'licensed practical nurse': 'LPN',
+  'certified nursing assistant': 'CNA',
+};
+
+const initialsOf = (name) =>
+  name.split(/\s+/).filter(Boolean).slice(0, 2).map(w => w[0]).join('').toUpperCase();
 
 export default function UserSelectionPage() {
   const navigate = useNavigate();
@@ -31,9 +47,10 @@ export default function UserSelectionPage() {
     getAccountUsers,
     selectUser,
     logout,
-    haIdentity
+    haIdentity,
+    readRestricted
   } = useAuth();
-  
+
   const [users, setUsers] = useState([]);
   const [selectedUser, setSelectedUser] = useState(null);
   const [password, setPassword] = useState('');
@@ -143,136 +160,155 @@ export default function UserSelectionPage() {
     navigate('/login', { replace: true });
   };
 
+  const roleChip = (user) => {
+    for (const role of user.roles || []) {
+      const abbrev = ROLE_ABBREVIATIONS[(role.display_name || role.name || '').toLowerCase()];
+      if (abbrev) return abbrev;
+    }
+    return null;
+  };
+
   return (
-    <div className="login-page">
-      <div className="login-container">
-        <Link to="/" className="login-logo">
-          <img src={logoImage} alt="Smart Home Health Logo" />
-          <span>Smart Home Health</span>
-        </Link>
+    <AuthShell>
+      <div className="au-eyebrow">Care Session</div>
+      <h2 className="au-title">Who is documenting?</h2>
+      <p className="au-subtitle">
+        {haIdentity && !haIdentity.mapped
+          ? `Signed in with Home Assistant as ${haIdentity.display_name || haIdentity.username || 'an unlinked user'} — choose your profile.`
+          : account?.name
+            ? `${account.name} — select your profile. Activity in this session will be recorded under your name.`
+            : 'Select your profile. Activity in this session will be recorded under your name.'}
+      </p>
 
-        <div className="login-card">
-          <div className="login-header">
-            <h2>Select User</h2>
-            <p>
-              {haIdentity && !haIdentity.mapped
-                ? `Signed in with Home Assistant as ${haIdentity.display_name || haIdentity.username || 'an unlinked user'} — choose your profile`
-                : account?.name ? `Account: ${account.name}` : 'Choose your profile to continue'}
-            </p>
-          </div>
+      <div className={`au-access${readRestricted ? '' : ' full'}`}>
+        {readRestricted ? <LockIcon size={16} /> : <UnlockIcon size={16} />}
+        <span className="au-access-label">Access · {readRestricted ? 'Quick entry' : 'Full'}</span>
+        <span className="au-access-sep" aria-hidden="true" />
+        <span className="au-access-state">{readRestricted ? 'Record only' : 'Unlocked'}</span>
+        <button type="button" className="au-access-change" onClick={handleLogout}>Change</button>
+      </div>
 
-          {!selectedUser ? (
-            <div className="user-selection">
-              {users.length === 0 ? (
-                <div className="no-users-message">
-                  <p>No users available. Please contact an administrator.</p>
-                </div>
-              ) : (
-                users.map((user) => (
-                  <button
-                    key={user.id}
-                    className="user-card"
-                    onClick={() => handleUserSelect(user)}
-                  >
-                    <div className="user-avatar">
-                      {(user.full_name || user.username).charAt(0).toUpperCase()}
-                    </div>
-                    <div className="user-info">
-                      <div className="user-name">{user.full_name || user.username}</div>
-                      <div className="user-roles">
-                        {user.roles?.map(r => r.display_name || r.name).join(', ') || 'User'}
-                        {user.ha_linked ? ' · Signs in with Home Assistant' : ''}
-                      </div>
-                    </div>
-                  </button>
-                ))
-              )}
+      {!selectedUser ? (
+        <div className="au-user-list">
+          {users.length === 0 ? (
+            <div className="au-no-users">
+              <p>No users available. Please contact an administrator.</p>
             </div>
           ) : (
-            <form onSubmit={handleSubmit} className="login-form">
-              <div className="selected-user">
-                <div className="user-avatar large">
-                  {(selectedUser.full_name || selectedUser.username).charAt(0).toUpperCase()}
-                </div>
-                <div className="user-name">{selectedUser.full_name || selectedUser.username}</div>
+            users.map((user) => {
+              const name = user.full_name || user.username;
+              const chip = roleChip(user);
+              return (
                 <button
-                  type="button"
-                  className="change-user-button"
-                  onClick={() => setSelectedUser(null)}
+                  key={user.id}
+                  className="user-card"
+                  onClick={() => handleUserSelect(user)}
                 >
-                  Change User
+                  <span className="au-avatar" aria-hidden="true">{initialsOf(name)}</span>
+                  <span className="au-user-info">
+                    <span className="au-user-name">{name}</span>
+                    <span className="au-user-roles">
+                      <span>
+                        {user.roles?.map(r => r.display_name || r.name).join(', ') || 'User'}
+                        {user.ha_linked ? ' · Signs in with Home Assistant' : ''}
+                      </span>
+                      {chip && <span className="au-role-chip">{chip}</span>}
+                    </span>
+                  </span>
+                  <span className="au-user-chev" aria-hidden="true"><ChevronRightIcon size={20} /></span>
                 </button>
-              </div>
-
-              {error && <div className="error-message">{error}</div>}
-
-              {usePassword ? (
-                <div className="form-group">
-                  <label htmlFor="password">Password</label>
-                  <input
-                    type="password"
-                    id="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    placeholder="Enter your password"
-                    autoFocus
-                    required
-                  />
-                  {selectedUser.ha_linked && !selectedUser.has_pin && (
-                    <small className="form-hint">
-                      This profile normally signs in automatically from the Home
-                      Assistant sidebar. To use it here, enter its app password —
-                      if it was never given one, an administrator can set one (or
-                      a PIN) under Configuration → Users.
-                    </small>
-                  )}
-                </div>
-              ) : (
-                <div className="form-group">
-                  <label htmlFor="pin">PIN</label>
-                  <input
-                    type="password"
-                    id="pin"
-                    inputMode="numeric"
-                    value={pin}
-                    onChange={(e) => setPin(e.target.value)}
-                    placeholder="Enter your PIN"
-                    maxLength={8}
-                    pattern="\d*"
-                    autoFocus
-                    required
-                  />
-                </div>
-              )}
-
-              <button type="submit" className="submit-button" disabled={loading}>
-                {loading ? 'Signing in...' : 'Sign In'}
-              </button>
-
-              {selectedUser.has_pin && (
-                <button
-                  type="button"
-                  className="toggle-auth-method"
-                  onClick={() => {
-                    setUsePassword(!usePassword);
-                    setPassword('');
-                    setPin('');
-                    setError('');
-                  }}
-                >
-                  {usePassword ? 'Use PIN instead' : 'Use password instead'}
-                </button>
-              )}
-            </form>
+              );
+            })
           )}
         </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="au-form">
+          <div className="au-selected">
+            <span className="au-avatar large" aria-hidden="true">
+              {initialsOf(selectedUser.full_name || selectedUser.username)}
+            </span>
+            <span className="au-user-name">{selectedUser.full_name || selectedUser.username}</span>
+            <button
+              type="button"
+              className="au-ghost-btn"
+              onClick={() => setSelectedUser(null)}
+            >
+              Change user
+            </button>
+          </div>
 
-        <div className="login-footer">
-          <button className="back-link" onClick={handleLogout} style={{ background: 'none', border: 'none', cursor: 'pointer' }}>
-            ← Sign Out / Change Account
+          {error && <div className="au-error">{error}</div>}
+
+          {usePassword ? (
+            <>
+              <label className="au-label" htmlFor="password">Password</label>
+              <div className="au-input-wrap">
+                <input
+                  type="password"
+                  id="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter your password"
+                  autoFocus
+                  required
+                />
+              </div>
+              {selectedUser.ha_linked && !selectedUser.has_pin && (
+                <small className="au-hint">
+                  This profile normally signs in automatically from the Home
+                  Assistant sidebar. To use it here, enter its app password —
+                  if it was never given one, an administrator can set one (or
+                  a PIN) under Configuration → Users.
+                </small>
+              )}
+            </>
+          ) : (
+            <>
+              <label className="au-label" htmlFor="pin">PIN</label>
+              <div className="au-input-wrap">
+                <input
+                  type="password"
+                  id="pin"
+                  inputMode="numeric"
+                  value={pin}
+                  onChange={(e) => setPin(e.target.value)}
+                  placeholder="Enter your PIN"
+                  maxLength={8}
+                  pattern="\d*"
+                  autoFocus
+                  required
+                />
+              </div>
+            </>
+          )}
+
+          <button type="submit" className="au-primary" disabled={loading}>
+            {loading ? 'Signing in...' : 'Sign In'}
           </button>
-        </div>
+
+          {selectedUser.has_pin && (
+            <button
+              type="button"
+              className="au-toggle"
+              onClick={() => {
+                setUsePassword(!usePassword);
+                setPassword('');
+                setPin('');
+                setError('');
+              }}
+            >
+              {usePassword ? 'Use PIN instead' : 'Use password instead'}
+            </button>
+          )}
+        </form>
+      )}
+
+      <div className="au-footer">
+        <button type="button" className="au-account-btn" onClick={handleLogout}>
+          <BackArrowIcon size={16} /> Change account
+        </button>
+        <div className="au-footnote">Session locks after inactivity</div>
       </div>
-    </div>
+    </AuthShell>
   );
 }

--- a/frontend/src/pages/auth.css
+++ b/frontend/src/pages/auth.css
@@ -1,0 +1,509 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Auth surfaces (login / user select) — bedside-monitor aesthetic.
+ * Full-page dark by design, both app themes. Tokens only. */
+@import '../styles/vc-tokens.css';
+
+.vc-auth {
+  min-height: 100dvh;
+  background: var(--vc-bg-base);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  display: flex;
+  flex-direction: column;
+}
+.vc-auth *,
+.vc-auth *::before,
+.vc-auth *::after { box-sizing: border-box; }
+.vc-auth button {
+  appearance: none;
+  -webkit-appearance: none;
+  font-family: inherit;
+}
+
+/* ---- Brand bar ---- */
+.au-brand {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.au-brand-left {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  color: inherit;
+  text-decoration: none;
+}
+.au-brand-mark { display: grid; place-content: center; color: var(--vc-data-live); }
+.au-brand-name {
+  display: block;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.au-brand-sub {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.au-online {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-state-complete);
+  white-space: nowrap;
+}
+.au-online-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--vc-state-complete);
+}
+
+/* ---- Main column ---- */
+.au-main {
+  flex: 1;
+  width: 100%;
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem 2rem;
+}
+
+.au-eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--vc-data-live);
+}
+.au-title {
+  margin: 0.5rem 0 0;
+  font-family: var(--vc-font-sans);
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+  line-height: 1.15;
+}
+.au-subtitle {
+  margin: 0.7rem 0 0;
+  font-family: var(--vc-font-sans);
+  font-size: 15.5px;
+  line-height: 1.5;
+  color: var(--vc-text-secondary);
+  max-width: 34rem;
+}
+
+/* ---- Form bits ---- */
+.au-form { margin-top: 1.4rem; display: flex; flex-direction: column; gap: 0.9rem; }
+.au-label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.au-input-wrap { position: relative; }
+.vc-auth input[type='password'],
+.vc-auth input[type='text'] {
+  width: 100%;
+  padding: 0.85rem 2.9rem 0.85rem 0.95rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 15px;
+  letter-spacing: 0.03em;
+}
+.vc-auth input:focus {
+  outline: none;
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 1px var(--vc-data-live);
+}
+.vc-auth input::placeholder { color: var(--vc-text-tertiary); }
+.au-eye {
+  position: absolute;
+  top: 50%;
+  right: 0.6rem;
+  transform: translateY(-50%);
+  display: grid;
+  place-content: center;
+  padding: 0.35rem;
+  border: none;
+  background: transparent;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+.au-eye:hover { color: var(--vc-text-primary); }
+
+.au-error {
+  border: 1px solid var(--vc-state-due);
+  background: color-mix(in srgb, var(--vc-state-due) 10%, transparent);
+  border-radius: 8px;
+  padding: 0.6rem 0.8rem;
+  font-family: var(--vc-font-sans);
+  font-size: 13.5px;
+  color: var(--vc-text-primary);
+}
+
+.au-primary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.95rem 1rem;
+  border: none;
+  border-radius: 10px;
+  background: var(--vc-data-live);
+  color: var(--vc-bg-base);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.au-primary:hover { filter: brightness(1.08); }
+.au-primary:disabled { opacity: 0.55; cursor: default; }
+.au-caps {
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--vc-data-live);
+}
+
+/* OR divider */
+.au-or {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin: 1.4rem 0;
+  color: var(--vc-text-secondary);
+}
+.au-or::before,
+.au-or::after {
+  content: '';
+  flex: 1;
+  border-top: 1px solid var(--vc-line-hairline);
+}
+.au-or em {
+  font-style: normal;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 6px;
+}
+
+/* ---- Quick entry panel ---- */
+.au-quick {
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 12px;
+  padding: 1.1rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 0.9rem;
+}
+.au-quick-icon {
+  grid-row: span 2;
+  display: grid;
+  place-content: center;
+  width: 52px;
+  height: 52px;
+  border: 1px solid var(--vc-state-due);
+  border-radius: 50%;
+  color: var(--vc-state-due);
+}
+.au-quick-title {
+  align-self: end;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-state-due);
+}
+.au-quick-body {
+  margin: 0;
+  font-family: var(--vc-font-sans);
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--vc-text-secondary);
+}
+.au-quick-btn {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 0.55rem;
+  padding: 0.8rem 1rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--vc-state-due);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.au-quick-btn:hover { border-color: var(--vc-state-due); }
+.au-quick-btn:disabled { opacity: 0.55; cursor: default; }
+.au-quick-caps {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-state-due);
+}
+
+/* ---- Access banner (user select) ---- */
+.au-access {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  margin-top: 1.3rem;
+  padding: 0.75rem 0.95rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.au-access > svg { flex-shrink: 0; color: var(--vc-state-due); }
+.au-access.full > svg { color: var(--vc-state-complete); }
+.au-access-label { color: var(--vc-text-secondary); white-space: nowrap; }
+.au-access-state { white-space: nowrap; }
+.au-access-sep { align-self: stretch; border-left: 1px solid var(--vc-line-strong); }
+.au-access-state { color: var(--vc-state-due); }
+.au-access.full .au-access-state { color: var(--vc-state-complete); }
+.au-access-change {
+  margin-left: auto;
+  border: none;
+  background: transparent;
+  color: var(--vc-data-live);
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  cursor: pointer;
+  padding: 0.2rem;
+}
+.au-access-change:hover { text-decoration: underline; }
+
+/* ---- User cards ---- */
+.au-user-list { display: flex; flex-direction: column; gap: 0.8rem; margin-top: 1.3rem; }
+.vc-auth .user-card {
+  display: flex;
+  align-items: center;
+  gap: 0.95rem;
+  width: 100%;
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 12px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+.vc-auth .user-card:hover { border-color: var(--vc-line-strong); background: var(--vc-bg-raised); }
+.au-avatar {
+  flex-shrink: 0;
+  display: grid;
+  place-content: center;
+  width: 52px;
+  height: 52px;
+  border: 1px solid var(--vc-data-live);
+  border-radius: 10px;
+  color: var(--vc-data-live);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.au-avatar.large { width: 64px; height: 64px; font-size: 22px; }
+.au-user-info { flex: 1; min-width: 0; }
+.au-user-name {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  overflow-wrap: break-word;
+}
+.au-user-roles {
+  margin-top: 0.3rem;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.au-role-chip {
+  padding: 0.1rem 0.45rem;
+  border: 1px solid var(--vc-state-due);
+  border-radius: 6px;
+  color: var(--vc-state-due);
+  font-weight: 700;
+}
+.au-user-chev { flex-shrink: 0; color: var(--vc-text-secondary); }
+.au-no-users {
+  margin-top: 1.3rem;
+  padding: 1rem;
+  border: 1px dashed var(--vc-line-strong);
+  border-radius: 12px;
+  font-family: var(--vc-font-sans);
+  font-size: 14px;
+  color: var(--vc-text-secondary);
+}
+
+/* ---- Credential mode ---- */
+.au-selected {
+  display: flex;
+  align-items: center;
+  gap: 0.95rem;
+  margin-top: 1.3rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 12px;
+  background: var(--vc-bg-surface);
+}
+.au-selected .au-user-name { flex: 1; min-width: 0; }
+.au-ghost-btn {
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--vc-text-secondary);
+  padding: 0.45rem 0.75rem;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.au-ghost-btn:hover { border-color: var(--vc-line-strong); color: var(--vc-text-primary); }
+.au-hint {
+  display: block;
+  margin-top: 0.5rem;
+  font-family: var(--vc-font-sans);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--vc-text-secondary);
+}
+.au-toggle {
+  align-self: center;
+  border: none;
+  background: transparent;
+  color: var(--vc-data-live);
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  padding: 0.3rem;
+}
+.au-toggle:hover { text-decoration: underline; }
+
+/* ---- Footer ---- */
+.au-footer { margin-top: 1.6rem; display: flex; flex-direction: column; align-items: center; gap: 0.9rem; }
+.au-account-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--vc-data-live);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--vc-data-live);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.au-account-btn:hover { background: color-mix(in srgb, var(--vc-data-live) 10%, transparent); }
+.au-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: none;
+  background: transparent;
+  color: var(--vc-text-secondary);
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-decoration: none;
+  padding: 0.3rem;
+}
+.au-back:hover { color: var(--vc-text-primary); }
+.au-footnote {
+  font-size: 11.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  text-align: center;
+}
+.au-continuing {
+  margin-top: 2.5rem;
+  text-align: center;
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+@media (max-width: 480px) {
+  .au-title { font-size: 25px; }
+  .au-brand-name { font-size: 12.5px; letter-spacing: 0.14em; }
+  .au-brand-sub { font-size: 10px; letter-spacing: 0.14em; }
+  .au-brand { padding: 0.85rem 1rem; }
+  .au-main { padding: 1.2rem 1rem 1.6rem; }
+  .au-access { gap: 0.5rem; padding: 0.7rem 0.7rem; font-size: 11px; letter-spacing: 0.07em; }
+}


### PR DESCRIPTION
## Summary
- Both auth surfaces rebuilt from the mockup bones on vc tokens: new shared `AuthShell` (brand bar with an inline SVG house-pulse mark replacing the 1.6MB logo PNG, system-online indicator) and `auth.css`, replacing the `LoginPage.css` look on these two pages.
- **Login** (`/login`): "Access Control / Unlock Care Record" — account password with a show/hide toggle, filled "Unlock full access" primary with the View · Edit · Export · Settings caption, OR divider, and an amber quick-entry panel ("Continue in quick entry" = the old "Continue without unlocking" record-only path, captioned "Record only · Patient data locked").
- **User picker** (`/select-user`): "Care Session / Who is documenting?" — access-mode banner wired to `readRestricted` (amber "Quick entry / Record only" vs green "Full / Unlocked", with a Change action that re-runs the account step), initials-tile user cards with chevrons and clinical role chips (RN/LPN/CNA map), "Change account" button, and a session-locks footnote.
- All auth flows preserved: skip-account-password "Continuing…" guard, HA-identity subtitle and hint, PIN vs password modes, daily-password-requirement flip, forced first-login reset routing, redirect handling.
- Five new icons in `Icons.jsx` (lock, unlock, eye, eye-off, brand mark).
- `PasswordResetPage` intentionally keeps the old style for now (it imports `LoginPage.css` itself); converting it is a natural follow-up.

## Testing
- `npm run lint` clean, `npm run build` succeeds, all 361 unit tests pass.
- e2e smoke spec updated for the new headings/button names ("Unlock Care Record", "Continue in quick entry", "Who is documenting?"); the credential-free auth smoke test passes against the live stack. `.user-card`, `#password`/`#pin`, "Sign In", and "Use password instead" selectors kept stable. (The env-gated full-login e2e fails only with the hidden `claude` test user — pre-existing, passes with a picker-visible user.)
- Visually verified at 390px: login, quick-entry → picker with record-only banner, and PIN credential mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4t1iK1gSfh6R6oGbaYriY