### PR TITLE
Config forms rebuilt in the vc aesthetic

### DIFF
--- a/frontend/src/components/ui/alert.jsx
+++ b/frontend/src/components/ui/alert.jsx
@@ -42,6 +42,7 @@ const Alert = React.forwardRef(function Alert({ className, variant, ...props }, 
       ref={ref}
       role="alert"
       data-slot="alert"
+      data-variant={variant || 'default'}
       className={cn(alertVariants({ variant }), className)}
       {...props}
     />

--- a/frontend/src/components/ui/badge.jsx
+++ b/frontend/src/components/ui/badge.jsx
@@ -41,7 +41,14 @@ const badgeVariants = cva(
 );
 
 function Badge({ className, variant, ...props }) {
-  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
+  return (
+    <span
+      data-slot="badge"
+      data-variant={variant || 'default'}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
 }
 
 export { Badge, badgeVariants };

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -21,7 +21,10 @@ import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  // border/bg-transparent are load-bearing: Preflight is not loaded globally
+  // (see tailwind.css), so a variant that sets neither would fall back to the
+  // UA button styling — a 2px outset white bevel and grey ButtonFace.
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-transparent bg-transparent text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -54,6 +57,10 @@ const Button = React.forwardRef(function Button(
   return (
     <Comp
       data-slot="button"
+      // Variant/size are exposed as attributes so skins (e.g. the vc
+      // Configuration form skin) can restyle per-variant from CSS.
+      data-variant={variant || 'default'}
+      data-size={size || 'default'}
       className={cn(buttonVariants({ variant, size, className }))}
       ref={ref}
       {...props}

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -54,7 +54,7 @@ const DialogContent = React.forwardRef(function DialogContent({ className, child
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-muted-foreground opacity-80 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring disabled:pointer-events-none">
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm border border-transparent bg-transparent text-muted-foreground opacity-80 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring disabled:pointer-events-none">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
             <path d="M18 6 6 18M6 6l12 12" />
           </svg>
@@ -83,6 +83,7 @@ const DialogTitle = React.forwardRef(function DialogTitle({ className, ...props 
   return (
     <DialogPrimitive.Title
       ref={ref}
+      data-slot="dialog-title"
       className={cn("text-lg font-semibold leading-none tracking-tight text-foreground", className)}
       {...props}
     />
@@ -90,7 +91,14 @@ const DialogTitle = React.forwardRef(function DialogTitle({ className, ...props 
 });
 
 const DialogDescription = React.forwardRef(function DialogDescription({ className, ...props }, ref) {
-  return <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />;
+  return (
+    <DialogPrimitive.Description
+      ref={ref}
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
 });
 
 export {

--- a/frontend/src/components/ui/select.jsx
+++ b/frontend/src/components/ui/select.jsx
@@ -63,7 +63,7 @@ const SelectTrigger = React.forwardRef(function SelectTrigger({ className, child
 
 const SelectScrollUpButton = React.forwardRef(function SelectScrollUpButton({ className, ...props }, ref) {
   return (
-    <SelectPrimitive.ScrollUpButton ref={ref} className={cn("flex cursor-default items-center justify-center py-1", className)} {...props}>
+    <SelectPrimitive.ScrollUpButton ref={ref} className={cn("flex cursor-default items-center justify-center border-none bg-transparent py-1 text-inherit", className)} {...props}>
       <ChevronUp className="h-4 w-4" />
     </SelectPrimitive.ScrollUpButton>
   );
@@ -71,7 +71,7 @@ const SelectScrollUpButton = React.forwardRef(function SelectScrollUpButton({ cl
 
 const SelectScrollDownButton = React.forwardRef(function SelectScrollDownButton({ className, ...props }, ref) {
   return (
-    <SelectPrimitive.ScrollDownButton ref={ref} className={cn("flex cursor-default items-center justify-center py-1", className)} {...props}>
+    <SelectPrimitive.ScrollDownButton ref={ref} className={cn("flex cursor-default items-center justify-center border-none bg-transparent py-1 text-inherit", className)} {...props}>
       <ChevronDown className="h-4 w-4" />
     </SelectPrimitive.ScrollDownButton>
   );

--- a/frontend/src/pages/admin-v2/AdminV2AccountSettings.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2AccountSettings.jsx
@@ -24,6 +24,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Alert } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
 import { Field } from '@/components/ui/field';
 import {
   Select,
@@ -379,16 +380,9 @@ export default function AdminV2AccountSettings() {
                 <div className="flex items-center justify-between py-2">
                   <dt className="text-muted-foreground">Status</dt>
                   <dd>
-                    <span
-                      className={
-                        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium " +
-                        (accountData?.is_active
-                          ? "bg-success/20 text-[#3fb950]"
-                          : "bg-destructive/20 text-[#ff7b72]")
-                      }
-                    >
+                    <Badge variant={accountData?.is_active ? 'success' : 'danger'}>
                       {accountData?.is_active ? 'Active' : 'Inactive'}
-                    </span>
+                    </Badge>
                   </dd>
                 </div>
                 {accountData?.organization && (

--- a/frontend/src/pages/admin-v2/AdminV2Layout.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Layout.jsx
@@ -61,6 +61,7 @@ import './admin-nav.css'; // grouped-nav structure (both themes)
 import '../../styles/vcFonts';
 import './vc-shell.css';
 import './vc-content.css';
+import './vc-forms.css';
 import ConnectionChip from '../../components/ConnectionChip';
 import useConnectionStatus from '../../hooks/useConnectionStatus';
 
@@ -354,6 +355,16 @@ const AdminV2Layout = ({ children }) => {
     const delta = (activeRect.left - navRect.left) - (nav.clientWidth - active.clientWidth) / 2;
     nav.scrollBy({ left: delta, behavior: 'smooth' });
   }, [location.pathname, topNavItems.length]);
+
+  // vc form skin (vc-forms.css) is opt-in per section while the rebuild rolls
+  // out. The class goes on <body> rather than the page wrapper so it also
+  // covers Radix's portalled Select/Dialog content. Widen this test as more
+  // sections are rebuilt.
+  useEffect(() => {
+    if (!location.pathname.startsWith('/care/configuration')) return undefined;
+    document.body.classList.add('vc-form-skin');
+    return () => document.body.classList.remove('vc-form-skin');
+  }, [location.pathname]);
 
   // Chevron scroll hints: shown at whichever edge has more tabs off-screen.
   const [navScroll, setNavScroll] = useState({ left: false, right: false });

--- a/frontend/src/pages/admin-v2/AdminV2UserDetail.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2UserDetail.jsx
@@ -28,6 +28,7 @@ import {
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import { Alert } from '@/components/ui/alert';
 import { Field, FormRow } from '@/components/ui/field';
@@ -499,11 +500,10 @@ export default function AdminV2UserDetail() {
                   placeholder="Re-enter new password"
                 />
               </Field>
-              <label className="flex items-center gap-2 text-sm text-foreground">
-                <input
-                  type="checkbox"
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-foreground">
+                <Checkbox
                   checked={requireChange}
-                  onChange={e => setRequireChange(e.target.checked)}
+                  onCheckedChange={(v) => setRequireChange(v === true)}
                 />
                 Require the user to choose a new password at next sign-in
               </label>

--- a/frontend/src/pages/admin-v2/settings/AdminV2SettingsGeneral.jsx
+++ b/frontend/src/pages/admin-v2/settings/AdminV2SettingsGeneral.jsx
@@ -20,7 +20,8 @@ import AdminV2Layout from '../AdminV2Layout';
 import { useAdminPatient } from '../../../contexts/AdminPatientContext';
 import { getSettings, setSetting, updateSettings } from '../../../services/settings';
 import config from '../../../config';
-import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { ConfigIcon, PatientsIcon, InfoIcon } from '../../../components/Icons';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -43,13 +44,13 @@ const SectionHeader = ({ icon, title, subtitle, saved }) => (
   <CardHeader>
     <div className="flex items-center justify-between gap-3">
       <div className="flex items-center gap-3">
-        <span className="text-xl" aria-hidden>{icon}</span>
+        <span className="text-muted-foreground" aria-hidden>{icon}</span>
         <div className="flex flex-col gap-0.5">
           <CardTitle>{title}</CardTitle>
-          {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
+          {subtitle && <CardDescription>{subtitle}</CardDescription>}
         </div>
       </div>
-      {saved && <span className="text-sm font-medium text-[#3fb950]">Saved!</span>}
+      {saved && <span className="text-sm font-medium text-success">Saved!</span>}
     </div>
   </CardHeader>
 );
@@ -287,7 +288,7 @@ const AdminV2SettingsGeneral = () => {
           {/* Application Settings */}
           <Card>
             <SectionHeader
-              icon="⚙️"
+              icon={<ConfigIcon size={20} />}
               title="Application Settings"
               subtitle="These settings apply to the entire application"
               saved={successApp}
@@ -387,7 +388,7 @@ const AdminV2SettingsGeneral = () => {
           {/* Patient Settings */}
           <Card>
             <SectionHeader
-              icon="👤"
+              icon={<PatientsIcon size={20} />}
               title="Patient Settings"
               subtitle={selectedPatient
                 ? `Settings for ${selectedPatient.first_name} ${selectedPatient.last_name}`
@@ -441,7 +442,7 @@ const AdminV2SettingsGeneral = () => {
 
           {/* About */}
           <Card>
-            <SectionHeader icon="ℹ️" title="About" subtitle="Smart Home Health" />
+            <SectionHeader icon={<InfoIcon size={20} />} title="About" subtitle="Smart Home Health" />
             <CardContent className="flex flex-col gap-2 text-sm text-muted-foreground">
               <p>
                 This software is free and open source, licensed under the{' '}

--- a/frontend/src/pages/admin-v2/vc-forms.css
+++ b/frontend/src/pages/admin-v2/vc-forms.css
@@ -1,0 +1,358 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Bedside-monitor ("vc") skin for the SHARED FORM vocabulary — the shadcn
+ * primitives in src/components/ui (card, label, input, textarea, select,
+ * button, badge, checkbox, alert, dialog).
+ *
+ * OPT-IN BY SECTION. AdminV2Layout puts `vc-form-skin` on <body> only while
+ * the route is under /care/configuration, so the Configuration section reads
+ * as bedside-monitor while every other admin section keeps today's look until
+ * its own pass. The class lives on <body> (not a page wrapper) so it also
+ * reaches Radix's portalled Select/Dialog content, which renders outside the
+ * page tree. To bring a future section in, widen the route test in the layout.
+ *
+ * DARK THEME ONLY (scoped :root:not(.light)) — the vc aesthetic is dark by
+ * design and the light theme keeps the stock shadcn palette.
+ *
+ * Hooks: every primitive carries data-slot, and button/badge/alert also carry
+ * data-variant / data-size, so nothing here depends on utility class names.
+ * Tokens from src/styles/vc-tokens.css; no raw hex.
+ *
+ * Color roles: cyan is the primary action and focus accent, green means
+ * done/healthy, amber needs attention, red is clinical concern or a
+ * destructive action. */
+@import '../../styles/vc-tokens.css';
+
+/* ---------- Island token overrides ---------- */
+/* vc-content.css already remaps the shared palette for every .tw island.
+ * Destructive is deliberately left on the stock red there (it is still the
+ * legacy admin language); inside the skin it moves onto the vc alert token. */
+:root:not(.light) body.vc-form-skin .tw,
+:root:not(.light) body.vc-form-skin [data-slot='dialog-content'],
+:root:not(.light) body.vc-form-skin [data-slot='select-content'] {
+  --destructive: var(--vc-state-alert);
+}
+
+/* ---------- Cards / panels ---------- */
+:root:not(.light) body.vc-form-skin [data-slot='card'] {
+  background: var(--vc-bg-surface);
+  border-color: var(--vc-line-hairline);
+  border-radius: 12px;
+  box-shadow: none;
+  font-family: var(--vc-font-sans);
+}
+:root:not(.light) body.vc-form-skin [data-slot='card-header'] {
+  border-bottom-color: var(--vc-line-hairline);
+}
+:root:not(.light) body.vc-form-skin [data-slot='card-footer'] {
+  border-top-color: var(--vc-line-hairline);
+}
+:root:not(.light) body.vc-form-skin [data-slot='card-title'],
+:root:not(.light) body.vc-form-skin [data-slot='dialog-title'] {
+  font-family: var(--vc-font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  line-height: 1.35;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) body.vc-form-skin [data-slot='card-description'],
+:root:not(.light) body.vc-form-skin [data-slot='dialog-description'] {
+  font-family: var(--vc-font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--vc-text-secondary);
+}
+
+/* Group headings inside a panel ("Dashboard Display", "Vital Sign Alert
+ * Thresholds"): one step quieter than the panel title. tailwind.css zeroes
+ * .tw h1–h6, so these carry no UA styling to fight. */
+:root:not(.light) body.vc-form-skin .tw h3,
+:root:not(.light) body.vc-form-skin .tw h4,
+:root:not(.light) body.vc-form-skin [data-slot='dialog-content'] h3,
+:root:not(.light) body.vc-form-skin [data-slot='dialog-content'] h4 {
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+
+/* ---------- Labels ---------- */
+:root:not(.light) body.vc-form-skin [data-slot='label'] {
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* ---------- Text inputs / textareas / select triggers ---------- */
+/* Controls sit on the base surface so they read as wells inside a panel. */
+:root:not(.light) body.vc-form-skin [data-slot='input'],
+:root:not(.light) body.vc-form-skin [data-slot='textarea'],
+:root:not(.light) body.vc-form-skin [data-slot='select-trigger'] {
+  min-height: 40px;
+  background: var(--vc-bg-base);
+  border-color: var(--vc-line-strong);
+  border-radius: 8px;
+  box-shadow: none;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 13.5px;
+  letter-spacing: 0.03em;
+}
+:root:not(.light) body.vc-form-skin [data-slot='textarea'] {
+  line-height: 1.5;
+  padding-block: 0.55rem;
+}
+:root:not(.light) body.vc-form-skin [data-slot='input']::placeholder,
+:root:not(.light) body.vc-form-skin [data-slot='textarea']::placeholder {
+  color: var(--vc-text-tertiary);
+  letter-spacing: 0.06em;
+}
+:root:not(.light) body.vc-form-skin [data-slot='select-trigger'][data-placeholder] {
+  color: var(--vc-text-tertiary);
+}
+:root:not(.light) body.vc-form-skin [data-slot='input']:focus-visible,
+:root:not(.light) body.vc-form-skin [data-slot='textarea']:focus-visible,
+:root:not(.light) body.vc-form-skin [data-slot='select-trigger']:focus {
+  outline: none;
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 1px var(--vc-data-live);
+}
+:root:not(.light) body.vc-form-skin [data-slot='input']:disabled,
+:root:not(.light) body.vc-form-skin [data-slot='textarea']:disabled,
+:root:not(.light) body.vc-form-skin [data-slot='select-trigger']:disabled {
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-tertiary);
+}
+/* File pickers (backup restore) keep the mono language on their button half. */
+:root:not(.light) body.vc-form-skin [data-slot='input']::file-selector-button {
+  color: var(--vc-data-live);
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/* Native <select> is kept on purpose in a few places (the per-patient MQTT
+ * permission rows — the OS picker is the friendliest control on a phone), so
+ * bring it onto the same type scale. `appearance: none` only drops the UA
+ * chrome (which paints its own light field over background-color); tapping
+ * still opens the OS picker, and the option list stays OS-drawn. The chevron
+ * is two gradient wedges rather than an SVG so it can ride on currentColor. */
+:root:not(.light) body.vc-form-skin .tw select {
+  appearance: none;
+  -webkit-appearance: none;
+  min-height: 40px;
+  padding-right: 1.75rem;
+  border-radius: 8px;
+  background-color: var(--vc-bg-base);
+  background-image:
+    linear-gradient(45deg, transparent 50%, currentColor 50%),
+    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position: calc(100% - 15px) calc(50% + 1px), calc(100% - 10px) calc(50% + 1px);
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  border-color: var(--vc-line-strong);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  letter-spacing: 0.03em;
+}
+:root:not(.light) body.vc-form-skin .tw select:focus {
+  outline: none;
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 1px var(--vc-data-live);
+}
+
+/* ---------- Select menu (portalled) ---------- */
+:root:not(.light) body.vc-form-skin [data-slot='select-content'] {
+  background: var(--vc-bg-raised);
+  border-color: var(--vc-line-strong);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+:root:not(.light) body.vc-form-skin [data-slot='select-item'] {
+  min-height: 38px;
+  border-radius: 6px;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  letter-spacing: 0.03em;
+}
+/* --accent is bg-raised in the vc remap, i.e. the menu's own background, so
+ * the stock focus style was invisible — highlight with the live accent. */
+:root:not(.light) body.vc-form-skin [data-slot='select-item']:focus,
+:root:not(.light) body.vc-form-skin [data-slot='select-item'][data-highlighted] {
+  background: color-mix(in srgb, var(--vc-data-live) 18%, transparent);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) body.vc-form-skin [data-slot='select-item'][data-state='checked'] {
+  color: var(--vc-data-live);
+}
+
+/* ---------- Buttons ---------- */
+:root:not(.light) body.vc-form-skin [data-slot='button'] {
+  border-radius: 8px;
+  font-family: var(--vc-font-mono);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-size='default'] { min-height: 38px; }
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-size='lg'] { min-height: 42px; }
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-size='sm'] { font-size: 10.5px; }
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='default'] {
+  background: var(--vc-data-live);
+  color: var(--vc-bg-base);
+}
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='default']:hover {
+  background: var(--vc-data-live);
+  filter: brightness(1.08);
+}
+/* Secondary/outline read as quiet outlines rather than filled grey chips. */
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='secondary'],
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='outline'] {
+  background: transparent;
+  border: 1px solid var(--vc-line-strong);
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='secondary']:hover,
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='outline']:hover {
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='ghost'] {
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='ghost']:hover {
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='link'] {
+  color: var(--vc-data-live);
+  letter-spacing: 0.1em;
+}
+:root:not(.light) body.vc-form-skin [data-slot='button']:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--vc-bg-base), 0 0 0 4px var(--vc-data-live);
+}
+
+/* ---------- Checkbox ---------- */
+:root:not(.light) body.vc-form-skin [data-slot='checkbox'] {
+  border-radius: 4px;
+  border-color: var(--vc-line-strong);
+  background: var(--vc-bg-base);
+}
+:root:not(.light) body.vc-form-skin [data-slot='checkbox'][data-state='checked'] {
+  background: var(--vc-data-live);
+  border-color: var(--vc-data-live);
+  color: var(--vc-bg-base);
+}
+:root:not(.light) body.vc-form-skin [data-slot='checkbox']:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--vc-bg-base), 0 0 0 4px var(--vc-data-live);
+}
+
+/* ---------- Badges ---------- */
+/* The stock variants carry GitHub-palette hex; restate them on the vc scale
+ * so a badge next to a skinned control belongs to the same system. */
+:root:not(.light) body.vc-form-skin [data-slot='badge'] {
+  border-radius: 999px;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='default'] {
+  background: color-mix(in srgb, var(--vc-data-live) 18%, transparent);
+  border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
+  color: var(--vc-data-live);
+}
+:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='success'] {
+  background: color-mix(in srgb, var(--vc-state-complete) 15%, transparent);
+  border-color: color-mix(in srgb, var(--vc-state-complete) 55%, transparent);
+  color: var(--vc-state-complete);
+}
+:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='warning'] {
+  background: color-mix(in srgb, var(--vc-state-due) 15%, transparent);
+  border-color: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
+  color: var(--vc-state-due);
+}
+:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='danger'] {
+  background: color-mix(in srgb, var(--vc-state-alert) 15%, transparent);
+  border-color: color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
+  color: var(--vc-state-alert);
+}
+:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='info'] {
+  background: color-mix(in srgb, var(--vc-data-live) 15%, transparent);
+  border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
+  color: var(--vc-data-live);
+}
+:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='secondary'],
+:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='muted'],
+:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='outline'] {
+  background: transparent;
+  border-color: var(--vc-line-strong);
+  color: var(--vc-text-secondary);
+}
+
+/* ---------- Alerts ---------- */
+:root:not(.light) body.vc-form-skin [data-slot='alert'] {
+  border-radius: 8px;
+  font-family: var(--vc-font-sans);
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='default'] {
+  background: var(--vc-bg-raised);
+  border-color: var(--vc-line-hairline);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='destructive'] {
+  background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
+  border-color: color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='success'] {
+  background: color-mix(in srgb, var(--vc-state-complete) 12%, transparent);
+  border-color: color-mix(in srgb, var(--vc-state-complete) 55%, transparent);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='warning'] {
+  background: color-mix(in srgb, var(--vc-state-due) 12%, transparent);
+  border-color: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
+  color: var(--vc-text-primary);
+}
+
+/* ---------- Dialogs ---------- */
+:root:not(.light) body.vc-form-skin [data-slot='dialog-content'] {
+  background: var(--vc-bg-sheet);
+  border-color: var(--vc-line-strong);
+  border-radius: 12px;
+  font-family: var(--vc-font-sans);
+}

--- a/frontend/src/tailwind.css
+++ b/frontend/src/tailwind.css
@@ -148,6 +148,15 @@
     color: inherit;
     letter-spacing: inherit;
   }
+  /* Same story for bare <button>s (card wrappers, list rows, close buttons):
+     without Preflight they fall back to UA styling — grey ButtonFace, a 2px
+     outset bevel and ButtonText, which reads as a light frame around dark
+     cards. Font is deliberately left alone; only the paint is reset. */
+  .tw button {
+    background-color: transparent;
+    border: 0 solid transparent;
+    color: inherit;
+  }
   /* Without Preflight, headings/paragraphs keep default UA margins (which, as
      flex items, don't even collapse) — zero them so component spacing wins. */
   .tw h1, .tw h2, .tw h3, .tw h4, .tw h5, .tw h6,


### PR DESCRIPTION
The Configuration section still rendered its forms in stock shadcn — sans title-case card titles and labels, title-case buttons — inside an admin shell that is already bedside-monitor. This puts the form vocabulary on the same language.

## What changed

**`vc-forms.css`** skins the shared `ui/` primitives (card, label, input, textarea, select, button, badge, checkbox, alert, dialog) from the vc tokens:

- mono uppercase panel titles and field labels
- controls sit on the base surface as wells, cyan focus edge
- uppercase tracked buttons; secondaries read as quiet outlines
- badges and alerts restated on the vc scale (they carried GitHub-palette hex)

It is **opt-in per section**: `AdminV2Layout` adds `vc-form-skin` to `<body>` only under `/care/configuration`, so every other admin section keeps today's look until its own pass. The class is on `<body>` rather than a page wrapper so it also reaches Radix's portalled Select/Dialog content. To bring a future section in, widen the route test in the layout.

To give it stable hooks, `button`/`badge`/`alert` now carry `data-variant` (and button `data-size`), and `DialogTitle`/`DialogDescription` carry `data-slot` — the skin never keys off utility class names.

## Defects fixed along the way

All from Preflight not being loaded globally (by design, see `tailwind.css`):

- `default`/`ghost` **Buttons set neither background nor border**, so they fell back to UA styling — that's the `2px outset white` bevel around every primary button, and the grey `ButtonFace` boxes on the Home Assistant row actions. Fixed in the primitive (`border border-transparent bg-transparent`).
- Same gap for **bare `<button>`s inside an island** — the patient/user card wrappers were drawing a light UA frame around each card. Reset in the `.tw` base layer (paint only; font left alone).
- Select's scroll buttons and the dialog close button had the same gap.
- **Select menu items highlighted with `--accent`**, which the vc remap makes equal to the menu's own background — the focused option was invisible. Now a cyan tint.
- The per-patient MQTT permission `<select>`s are deliberately native (OS picker on a phone); `appearance: none` lets them take the dark field, picker behaviour unchanged.

## Page-level cleanup

- General settings section headers used emoji (⚙️/👤/ℹ️) → SVG icons from `Icons.jsx`
- account status pill → `Badge`, "Saved!" flash → `text-success` (both were raw `#3fb950`/`#ff7b72`)
- reset-password dialog's native checkbox → `Checkbox` primitive

## Verification

Playwright at 1440px and 390px across all 14 config pages, plus the add-user, add-patient, add-role, change-password and HA-mapping dialogs and an open select menu. Light theme and the non-config sections (medications, vitals, schedule, live dashboard) spot-checked unchanged. `npm run lint`, `vite build` and 358 frontend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011u7gjNWppXao35QPLtBBQe