### PR TITLE
Live dashboard: stable chart axes, docked modals

### DIFF
--- a/frontend/src/components/ChartBlock.jsx
+++ b/frontend/src/components/ChartBlock.jsx
@@ -15,48 +15,79 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+import React, { useMemo } from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import { CHART_CHROME } from "../contexts/DashboardThemeContext";
+import { pickTimeStep, buildTimeTicks, niceYDomain } from "../utils/chartAxis";
 
-export default function ChartBlock({ yLabel, color, dataset, showXaxis = true, showYaxis = true, chrome = CHART_CHROME, windowMs = 5 * 60 * 1000 }) {
-  // Series colors follow the vc state tokens (literals — recharts needs them)
-  const getColor = (colorName) => {
-    switch (colorName.toLowerCase()) {
-      case 'blue':
-        return '#4da7bd';
-      case 'green':
-        return '#3fbf6a';
-      case 'orange':
-        return '#f0a52e';
-      default:
-        return colorName;
-    }
-  };
-  
+// Series colors follow the vc state tokens (literals — recharts needs them)
+const SERIES_COLORS = {
+  blue: '#4da7bd',
+  green: '#3fbf6a',
+  orange: '#f0a52e',
+};
+const getColor = (colorName) => SERIES_COLORS[String(colorName).toLowerCase()] || colorName;
+
+const pad2 = (n) => String(n).padStart(2, '0');
+
+/* Streaming line chart for the live dashboard.
+ *
+ * The x domain is the wall-clock window [now - windowMs, now] with ticks on
+ * round boundaries (see utils/chartAxis) rather than recharts' data-derived
+ * default: labels then keep their text and slide, instead of renumbering on
+ * every incoming sample. `now` is supplied by the caller (useLiveVitalsBuffer's
+ * 1 Hz clock) so this component renders purely from its props.
+ *
+ * `dataset` is already trimmed to the window by the buffer hook — don't
+ * re-filter it here. */
+function ChartBlock({
+  yLabel,
+  color,
+  dataset,
+  showXaxis = true,
+  showYaxis = true,
+  chrome = CHART_CHROME,
+  windowMs = 5 * 60 * 1000,
+  now,
+}) {
   const chartColor = getColor(color);
-  
-  // Filter dataset to the chart's time window
-  const windowStart = Date.now() - windowMs;
-  const filteredData = dataset.filter(point => point.x >= windowStart);
-  // Seconds only add noise once a tick spans minutes
-  const coarseTicks = windowMs > 60 * 60 * 1000;
-  
-  // Calculate min and max values for auto-scaling Y axis
-  const calculateYDomain = () => {
-    if (filteredData.length === 0) return [0, 10]; // Default values if no data
-    
-    const yValues = filteredData.map(d => d.y);
-    let min = Math.min(...yValues);
-    let max = Math.max(...yValues);
-    
-    // Add some padding to the min/max values for better visualization
-    const padding = (max - min) * 0.1; // 10% padding
-    min = Math.max(0, min - padding); // Don't go below 0 for most medical metrics
-    max = max + padding;
-    
-    return [min, max];
+  const domainEnd = now ?? Date.now();
+  const domainStart = domainEnd - windowMs;
+
+  const step = pickTimeStep(windowMs);
+  const ticks = useMemo(
+    () => buildTimeTicks(domainStart, domainEnd, step),
+    [domainStart, domainEnd, step]
+  );
+  // Seconds only carry information when the ticks are closer together than a
+  // minute; above that they're noise that changes on every render.
+  const showSeconds = step < 60 * 1000;
+  const formatTick = (unixTime) => {
+    const d = new Date(unixTime);
+    const hm = `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+    return showSeconds ? `${hm}:${pad2(d.getSeconds())}` : hm;
   };
-  
+
+  const yDomain = useMemo(() => niceYDomain(dataset.map(d => d.y)), [dataset]);
+
+  // Stable identities for the axis style objects (fresh literals would make
+  // every render look like a prop change to recharts).
+  const axisStyles = useMemo(() => ({
+    line: { stroke: chrome.grid },
+    tick: { fill: chrome.axis, fontSize: 10 },
+    tooltipContent: {
+      backgroundColor: chrome.tooltipBg,
+      border: `1px solid ${chrome.tooltipBorder}`,
+      borderRadius: '4px',
+    },
+    tooltipLabel: { color: chrome.tooltipText },
+  }), [chrome]);
+  const yAxisLabel = useMemo(
+    () => ({ value: yLabel, angle: -90, position: 'insideLeft', fill: chrome.axis, fontSize: 12 }),
+    [yLabel, chrome]
+  );
+  const seriesStyle = useMemo(() => ({ color: chartColor }), [chartColor]);
+
   return (
     <div style={{
       width: "100%",
@@ -65,9 +96,7 @@ export default function ChartBlock({ yLabel, color, dataset, showXaxis = true, s
       backgroundColor: chrome.bg,
       borderRadius: "0px"
     }}>
-      {/* Removed the title div that was here */}
-
-      {filteredData.length === 0 ? (
+      {dataset.length === 0 ? (
         <div style={{
           display: 'flex',
           justifyContent: 'center',
@@ -79,47 +108,50 @@ export default function ChartBlock({ yLabel, color, dataset, showXaxis = true, s
         </div>
       ) : (
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={filteredData} margin={{ top: 5, right: 22, bottom: 5, left: 0 }}>
+          <LineChart data={dataset} margin={{ top: 5, right: 22, bottom: 5, left: 0 }}>
             {showXaxis && (
               <XAxis
                 dataKey="x"
                 type="number"
-                domain={['dataMin', 'dataMax']}
-                tickFormatter={(unixTime) => {
-                  const d = new Date(unixTime);
-                  const hm = `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
-                  return coarseTicks ? hm : `${hm}:${d.getSeconds().toString().padStart(2, '0')}`;
-                }}
-                axisLine={{ stroke: chrome.grid }}
-                tickLine={{ stroke: chrome.grid }}
-                tick={{ fill: chrome.axis, fontSize: 10 }}
+                domain={[domainStart, domainEnd]}
+                ticks={ticks}
+                interval={0}
+                allowDataOverflow
+                tickFormatter={formatTick}
+                axisLine={axisStyles.line}
+                tickLine={axisStyles.line}
+                tick={axisStyles.tick}
               />
             )}
             {showYaxis && (
               <YAxis
-                domain={calculateYDomain()}
-                label={{ value: yLabel, angle: -90, position: 'insideLeft', fill: chrome.axis, fontSize: 12 }}
-                axisLine={{ stroke: chrome.grid }}
-                tickLine={{ stroke: chrome.grid }}
-                tick={{ fill: chrome.axis, fontSize: 10 }}
+                domain={yDomain}
+                allowDataOverflow
+                label={yAxisLabel}
+                axisLine={axisStyles.line}
+                tickLine={axisStyles.line}
+                tick={axisStyles.tick}
               />
             )}
             <Tooltip
               labelFormatter={(unixTime) => new Date(unixTime).toLocaleTimeString()}
-              contentStyle={{ backgroundColor: chrome.tooltipBg, border: `1px solid ${chrome.tooltipBorder}`, borderRadius: '4px' }}
-              itemStyle={{ color: chartColor }}
-              labelStyle={{ color: chrome.tooltipText }}
+              contentStyle={axisStyles.tooltipContent}
+              itemStyle={seriesStyle}
+              labelStyle={axisStyles.tooltipLabel}
             />
-            <Line 
-              type="monotone" 
-              dataKey="y" 
+            <Line
+              type="monotone"
+              dataKey="y"
               stroke={chartColor}
               dot={false}
               isAnimationActive={false}
-              strokeWidth={2.5} // Keep only one strokeWidth property
+              strokeWidth={2.5}
             />
           </LineChart>
         </ResponsiveContainer>
       )}
     </div>
-  );}
+  );
+}
+
+export default React.memo(ChartBlock);

--- a/frontend/src/components/DynamicVitalsCard.jsx
+++ b/frontend/src/components/DynamicVitalsCard.jsx
@@ -15,275 +15,299 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { LineChart, Line, ResponsiveContainer, YAxis, XAxis, Tooltip } from "recharts";
 import NutritionGaugeCard from './dashboard/NutritionGaugeCard';
 import QuickAddVitalModal from './vitals/QuickAddVitalModal';
 import { CHART_CHROME } from '../contexts/DashboardThemeContext';
 
+/* Everything below the component is pure and lives at module scope on purpose.
+ * This card sits on the live dashboard, which re-renders at ~1 Hz; helpers
+ * (and especially the tooltip) declared inside the render body get a new
+ * identity every tick, and a new *component type* makes recharts tear down and
+ * remount the tooltip subtree each time. The card itself is memoized, so with
+ * stable props it now only re-renders when its data actually changes. */
+
+// ---- Formatting helpers ---------------------------------------------------
+
+// Bathroom size mapping for display
+const getBathroomSizeDisplay = (value, vitalGroup) => {
+  // Check if this is a bathroom-related group
+  const bathroomGroups = ['bathroom', 'mix', 'wet', 'dry', 'solid', 'liquid'];
+  const isBathroomGroup = vitalGroup && bathroomGroups.includes(vitalGroup.toLowerCase());
+
+  if (isBathroomGroup && value !== null && value !== undefined && typeof value === 'number') {
+    const sizeMap = {
+      0: 'Smear',
+      1: 'Small',
+      2: 'Medium',
+      3: 'Large',
+      4: 'Extra Large'
+    };
+    return sizeMap[value] || value;
+  }
+  return value;
+};
+
+// Group display formatting
+const getGroupDisplay = (vitalGroup) => {
+  if (!vitalGroup) return '-';
+  return vitalGroup.charAt(0).toUpperCase() + vitalGroup.slice(1);
+};
+
+// Format display value based on vital type
+const formatDisplayValue = (item, vitalType) => {
+  if (!item) return '--';
+
+  switch (vitalType) {
+    case 'blood_pressure':
+      if (item.systolic && item.diastolic) {
+        // Show "systolic/diastolic (MAP)" format
+        return `${item.systolic}/${item.diastolic}${item.map ? ` (${item.map})` : ''}`;
+      }
+      return item.map ? `MAP: ${item.map}` : '--';
+    case 'temperature':
+      if (item.body) {
+        return `${item.body}°F${item.skin ? ` (Skin: ${item.skin}°F)` : ''}`;
+      }
+      return item.value ? `${item.value}°F` : '--';
+    case 'weight':
+      return item.value ? `${item.value} lbs` : '--';
+    case 'calories':
+      return item.value ? `${item.value} cal` : '--';
+    case 'water':
+      return item.value ? `${item.value} ml` : '--';
+    case 'bathroom':
+      // For bathroom, show the mapped size
+      return getBathroomSizeDisplay(item.value, item.vital_group) || '--';
+    default:
+      return item.value ? `${item.value}` : '--';
+  }
+};
+
+// Format time display as time delta from now
+const formatDateTime = (dateTimeStr) => {
+  if (!dateTimeStr) return "Unknown";
+
+  try {
+    let date;
+
+    // Handle different datetime formats from backend
+    if (typeof dateTimeStr === 'string') {
+      // All datetime strings should now be consistent from backend
+      date = new Date(dateTimeStr);
+    } else if (typeof dateTimeStr === 'object' && dateTimeStr !== null) {
+      // Handle objects (could be a Date or datetime-like object)
+      if (dateTimeStr instanceof Date) {
+        date = dateTimeStr;
+      } else {
+        // Try to extract date info from object structure
+        date = new Date(dateTimeStr.toString());
+      }
+    } else if (typeof dateTimeStr === 'number') {
+      // Handle timestamp
+      date = new Date(dateTimeStr);
+    } else {
+      // Fallback: try direct conversion
+      date = new Date(dateTimeStr);
+    }
+
+    // Ensure we have a valid date
+    if (!date || isNaN(date.getTime())) {
+      return "Unknown time";
+    }
+
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+
+    // Convert to different time units
+    const diffMinutes = Math.floor(diffMs / (1000 * 60));
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    // Return appropriate format based on time difference
+    if (Math.abs(diffMinutes) < 1) {
+      return "Just now";
+    } else if (diffMinutes < 0) {
+      // Future date
+      return `In ${Math.abs(diffMinutes)}m`;
+    } else if (diffMinutes < 60) {
+      return `${diffMinutes}m ago`;
+    } else if (diffHours < 24) {
+      return `${diffHours}h ago`;
+    } else {
+      return `${diffDays}d ago`;
+    }
+  } catch {
+    return "Time error";
+  }
+};
+
+// Get chart color based on vital type
+const getChartColor = (vitalType, group = null) => {
+  if (vitalType === 'bathroom' && group) {
+    // Use group-specific colors for bathroom vitals
+    const groupColors = {
+      'mix': '#8B4513',      // Brown
+      'wet': '#4169E1',      // Royal Blue
+      'dry': '#DAA520',      // Goldenrod
+      'solid': '#8B4513',    // Brown
+      'liquid': '#4169E1',   // Royal Blue
+      'bathroom': '#6B46C1', // Purple
+      'unknown': '#6B7280'   // Gray
+    };
+    return groupColors[group.toLowerCase()] || '#6B7280';
+  }
+
+  // vc-aligned accents (literals — recharts needs them)
+  const colors = {
+    'blood_pressure': '#f0563c',
+    'temperature': '#b48ce0',
+    'weight': '#3fbf6a',
+    'calories': '#f0a52e',
+    'water': '#4da7bd',
+    'bathroom': '#a1887f'
+  };
+  return colors[vitalType] || '#6b7987';
+};
+
+// ---- Chart data -----------------------------------------------------------
+
+// Format the data for the chart based on vital type
+const formatChartData = (data, vitalType) => {
+  if (!data || data.length === 0) return [];
+
+  // Data arrives newest-first from the API. Take the newest 5 and reverse
+  // so the chart renders oldest → newest left-to-right.
+  const recent = data.slice(0, 5).slice().reverse();
+
+  // For bathroom vitals, we want to keep the numeric values for charting
+  // but we may want to group by vital_group for different colors
+  if (vitalType === 'bathroom') {
+    return recent.map((item, index) => ({
+      index,
+      value: item.value, // Keep numeric value for chart
+      originalItem: item,
+      group: item.vital_group || 'unknown' // Add group for potential color coding
+    }));
+  }
+
+  return recent.map((item, index) => {
+    let value = item.value;
+
+    // Handle different data structures
+    if (vitalType === 'blood_pressure') {
+      // For blood pressure, use MAP for charting, but show systolic/diastolic in table
+      value = item.map || item.value; // Use MAP if available, fallback to value
+    } else if (vitalType === 'temperature') {
+      // For temperature, use body temp for charting
+      value = item.body || item.value; // Use body temp if available, fallback to value
+    }
+
+    return {
+      index,
+      value: value,
+      originalItem: item
+    };
+  });
+};
+
+// Calculate Y domain for chart
+const calculateYDomain = (chartData, vitalType) => {
+  if (chartData.length === 0) return [0, 100];
+
+  const values = chartData.map(d => d.value).filter(v => v !== null && v !== undefined && !isNaN(v));
+  if (values.length === 0) return [0, 100];
+
+  let min = Math.min(...values);
+  let max = Math.max(...values);
+
+  // Special handling for different vital types
+  if (vitalType === 'temperature') {
+    // For temperature, use a more reasonable range around body temperature
+    min = Math.max(95, min - 2); // Don't go below 95°F
+    max = Math.min(110, max + 2); // Don't go above 110°F
+  } else if (vitalType === 'bathroom') {
+    // For bathroom vitals (0-4 scale), ensure we show the full range
+    min = 0;
+    max = Math.max(4, max);
+  } else {
+    // Add padding for other vital types
+    const padding = (max - min) * 0.1 || 10;
+    min = Math.max(0, min - padding);
+    max = max + padding;
+  }
+
+  return [min, max];
+};
+
+// ---- Tooltip --------------------------------------------------------------
+
+/* Module-level so the component type is stable across renders. recharts clones
+ * the element it's given, injecting `active`/`payload`. */
+const VitalsTooltip = ({ active, payload, vitalType, chrome }) => {
+  if (!active || !payload || !payload.length) return null;
+  const item = payload[0].payload.originalItem;
+  if (!item) return null;
+
+  return (
+    <div style={{
+      backgroundColor: chrome.tooltipBg,
+      padding: '8px 12px',
+      borderRadius: '4px',
+      border: `1px solid ${chrome.tooltipBorder}`,
+      color: chrome.tooltipText,
+      fontSize: '12px',
+      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.3)'
+    }}>
+      <div style={{ marginBottom: '4px', fontWeight: '500' }}>
+        {formatDisplayValue(item, vitalType)}
+      </div>
+      <div style={{ color: chrome.textMuted, fontSize: '10px' }}>
+        {formatDateTime(item.datetime)}
+      </div>
+      {vitalType === 'bathroom' && item.vital_group && (
+        <div style={{
+          color: getChartColor(vitalType, item.vital_group),
+          fontSize: '10px',
+          marginTop: '2px'
+        }}>
+          {getGroupDisplay(item.vital_group)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---- Component ------------------------------------------------------------
+
 const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, chrome = CHART_CHROME }) => {
   const [isFlipped, setIsFlipped] = useState(false);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
+
+  // All hooks run before the nutrition early-return below.
+  const chartData = useMemo(() => formatChartData(data, vitalType), [data, vitalType]);
+  const yDomain = useMemo(() => calculateYDomain(chartData, vitalType), [chartData, vitalType]);
+  const axisTick = useMemo(() => ({ fontSize: 9, fill: chrome.axis }), [chrome]);
 
   // Special case for nutrition - render dedicated gauge component
   if (vitalType === 'nutrition') {
     return <NutritionGaugeCard />;
   }
 
-  // Format the data for the chart based on vital type
-  const formatChartData = (data, vitalType) => {
-    if (!data || data.length === 0) return [];
-    
-    // Data arrives newest-first from the API. Take the newest 5 and reverse
-    // so the chart renders oldest → newest left-to-right.
-    const recent = data.slice(0, 5).slice().reverse();
-
-    // For bathroom vitals, we want to keep the numeric values for charting
-    // but we may want to group by vital_group for different colors
-    if (vitalType === 'bathroom') {
-      return recent.map((item, index) => ({
-        index,
-        value: item.value, // Keep numeric value for chart
-        originalItem: item,
-        group: item.vital_group || 'unknown' // Add group for potential color coding
-      }));
-    }
-
-    return recent.map((item, index) => {
-      let value = item.value;
-      
-      // Handle different data structures
-      if (vitalType === 'blood_pressure') {
-        // For blood pressure, use MAP for charting, but show systolic/diastolic in table
-        value = item.map || item.value; // Use MAP if available, fallback to value
-      } else if (vitalType === 'temperature') {
-        // For temperature, use body temp for charting
-        value = item.body || item.value; // Use body temp if available, fallback to value
-      }
-      
-      return {
-        index,
-        value: value,
-        originalItem: item
-      };
-    });
-  };
-
-  const chartData = formatChartData(data, vitalType);
-  
-  // Custom tooltip for chart hover
-  const CustomTooltip = ({ active, payload }) => {
-    if (active && payload && payload.length) {
-      const data = payload[0].payload.originalItem;
-      if (!data) return null;
-      
-      return (
-        <div style={{
-          backgroundColor: chrome.tooltipBg,
-          padding: '8px 12px',
-          borderRadius: '4px',
-          border: `1px solid ${chrome.tooltipBorder}`,
-          color: chrome.tooltipText,
-          fontSize: '12px',
-          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.3)'
-        }}>
-          <div style={{ marginBottom: '4px', fontWeight: '500' }}>
-            {formatDisplayValue(data, vitalType)}
-          </div>
-          <div style={{ color: chrome.textMuted, fontSize: '10px' }}>
-            {formatDateTime(data.datetime)}
-          </div>
-          {vitalType === 'bathroom' && data.vital_group && (
-            <div style={{ 
-              color: getChartColor(vitalType, data.vital_group), 
-              fontSize: '10px',
-              marginTop: '2px'
-            }}>
-              {getGroupDisplay(data.vital_group)}
-            </div>
-          )}
-        </div>
-      );
-    }
-    return null;
-  };
-  
-  // Bathroom size mapping for display
-  const getBathroomSizeDisplay = (value, vitalGroup) => {
-    // Check if this is a bathroom-related group
-    const bathroomGroups = ['bathroom', 'mix', 'wet', 'dry', 'solid', 'liquid'];
-    const isBathroomGroup = vitalGroup && bathroomGroups.includes(vitalGroup.toLowerCase());
-    
-    if (isBathroomGroup && value !== null && value !== undefined && typeof value === 'number') {
-      const sizeMap = {
-        0: 'Smear',
-        1: 'Small',
-        2: 'Medium', 
-        3: 'Large',
-        4: 'Extra Large'
-      };
-      return sizeMap[value] || value;
-    }
-    return value;
-  };
-
-  // Group display formatting
-  const getGroupDisplay = (vitalGroup) => {
-    if (!vitalGroup) return '-';
-    return vitalGroup.charAt(0).toUpperCase() + vitalGroup.slice(1);
-  };
-
-  // Format display value based on vital type
-  const formatDisplayValue = (item, vitalType) => {
-    if (!item) return '--';
-    
-    switch (vitalType) {
-      case 'blood_pressure':
-        if (item.systolic && item.diastolic) {
-          // Show "systolic/diastolic (MAP)" format
-          return `${item.systolic}/${item.diastolic}${item.map ? ` (${item.map})` : ''}`;
-        }
-        return item.map ? `MAP: ${item.map}` : '--';
-      case 'temperature':
-        if (item.body) {
-          return `${item.body}°F${item.skin ? ` (Skin: ${item.skin}°F)` : ''}`;
-        }
-        return item.value ? `${item.value}°F` : '--';
-      case 'weight':
-        return item.value ? `${item.value} lbs` : '--';
-      case 'calories':
-        return item.value ? `${item.value} cal` : '--';
-      case 'water':
-        return item.value ? `${item.value} ml` : '--';
-      case 'bathroom':
-        // For bathroom, show the mapped size
-        return getBathroomSizeDisplay(item.value, item.vital_group) || '--';
-      default:
-        return item.value ? `${item.value}` : '--';
-    }
-  };
-
-  // Format time display as time delta from now
-  const formatDateTime = (dateTimeStr) => {
-    if (!dateTimeStr) return "Unknown";
-    
-    try {
-      let date;
-      
-      // Handle different datetime formats from backend
-      if (typeof dateTimeStr === 'string') {
-        // All datetime strings should now be consistent from backend
-        date = new Date(dateTimeStr);
-      } else if (typeof dateTimeStr === 'object' && dateTimeStr !== null) {
-        // Handle objects (could be a Date or datetime-like object)
-        if (dateTimeStr instanceof Date) {
-          date = dateTimeStr;
-        } else {
-          // Try to extract date info from object structure
-          date = new Date(dateTimeStr.toString());
-        }
-      } else if (typeof dateTimeStr === 'number') {
-        // Handle timestamp
-        date = new Date(dateTimeStr);
-      } else {
-        // Fallback: try direct conversion
-        date = new Date(dateTimeStr);
-      }
-      
-      // Ensure we have a valid date
-      if (!date || isNaN(date.getTime())) {
-        return "Unknown time";
-      }
-      
-      const now = new Date();
-      const diffMs = now.getTime() - date.getTime();
-      
-      // Convert to different time units
-      const diffMinutes = Math.floor(diffMs / (1000 * 60));
-      const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-      const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-      
-      // Return appropriate format based on time difference
-      if (Math.abs(diffMinutes) < 1) {
-        return "Just now";
-      } else if (diffMinutes < 0) {
-        // Future date
-        return `In ${Math.abs(diffMinutes)}m`;
-      } else if (diffMinutes < 60) {
-        return `${diffMinutes}m ago`;
-      } else if (diffHours < 24) {
-        return `${diffHours}h ago`;
-      } else {
-        return `${diffDays}d ago`;
-      }
-    } catch {
-      return "Time error";
-    }
-  };
-
-  // Calculate Y domain for chart
-  const calculateYDomain = () => {
-    if (chartData.length === 0) return [0, 100];
-    
-    const values = chartData.map(d => d.value).filter(v => v !== null && v !== undefined && !isNaN(v));
-    if (values.length === 0) return [0, 100];
-    
-    let min = Math.min(...values);
-    let max = Math.max(...values);
-    
-    // Special handling for different vital types
-    if (vitalType === 'temperature') {
-      // For temperature, use a more reasonable range around body temperature
-      min = Math.max(95, min - 2); // Don't go below 95°F
-      max = Math.min(110, max + 2); // Don't go above 110°F
-    } else if (vitalType === 'bathroom') {
-      // For bathroom vitals (0-4 scale), ensure we show the full range
-      min = 0;
-      max = Math.max(4, max);
-    } else {
-      // Add padding for other vital types
-      const padding = (max - min) * 0.1 || 10;
-      min = Math.max(0, min - padding);
-      max = max + padding;
-    }
-    
-    return [min, max];
-  };
-
-  // Get chart color based on vital type
-  const getChartColor = (vitalType, group = null) => {
-    if (vitalType === 'bathroom' && group) {
-      // Use group-specific colors for bathroom vitals
-      const groupColors = {
-        'mix': '#8B4513',      // Brown
-        'wet': '#4169E1',      // Royal Blue  
-        'dry': '#DAA520',      // Goldenrod
-        'solid': '#8B4513',    // Brown
-        'liquid': '#4169E1',   // Royal Blue
-        'bathroom': '#6B46C1', // Purple
-        'unknown': '#6B7280'   // Gray
-      };
-      return groupColors[group.toLowerCase()] || '#6B7280';
-    }
-    
-    // vc-aligned accents (literals — recharts needs them)
-    const colors = {
-      'blood_pressure': '#f0563c',
-      'temperature': '#b48ce0',
-      'weight': '#3fbf6a',
-      'calories': '#f0a52e',
-      'water': '#4da7bd',
-      'bathroom': '#a1887f'
-    };
-    return colors[vitalType] || '#6b7987';
-  };
-
   const displayTitle = title || vitalType.charAt(0).toUpperCase() + vitalType.slice(1);
-  
+
   // Get the primary group for bathroom vitals to determine title color
   // (data is newest-first, so the most recent entry is at index 0)
   const primaryGroup = vitalType === 'bathroom' && data && data.length > 0 ?
     data[0]?.vital_group : null;
+
+  const seriesColor = vitalType === 'bathroom' && chartData[0]?.group
+    ? getChartColor(vitalType, chartData[0].group)
+    : getChartColor(vitalType);
+  const titleColor = vitalType === 'bathroom' && primaryGroup
+    ? getChartColor(vitalType, primaryGroup)
+    : getChartColor(vitalType);
 
   return (
     <div style={{
@@ -315,9 +339,7 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
           {/* Quick-add lives on the flipped (details) side, not here — keeps the
               chart view clean. See the back side below. */}
           <h3 style={{
-            color: vitalType === 'bathroom' && primaryGroup ?
-              getChartColor(vitalType, primaryGroup) :
-              getChartColor(vitalType),
+            color: titleColor,
             margin: '0 0 10px 0',
             fontSize: '13px',
             fontWeight: '700',
@@ -338,7 +360,7 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
                     type="number"
                     domain={[0, Math.max(0, chartData.length - 1)]}
                     height={16}
-                    tick={{ fontSize: 9, fill: chrome.axis }}
+                    tick={axisTick}
                     axisLine={false}
                     tickLine={false}
                     interval="preserveStartEnd"
@@ -351,27 +373,23 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
                     }}
                   />
                   <YAxis
-                    domain={calculateYDomain()}
+                    domain={yDomain}
                     width={38}
-                    tick={{ fontSize: 9, fill: chrome.axis }}
+                    tick={axisTick}
                     axisLine={false}
                     tickLine={false}
                     tickCount={3}
                   />
-                  <Tooltip content={<CustomTooltip />} />
+                  <Tooltip content={<VitalsTooltip vitalType={vitalType} chrome={chrome} />} />
                   <Line
                     type="monotone"
                     dataKey="value"
-                    stroke={vitalType === 'bathroom' && chartData[0]?.group ?
-                      getChartColor(vitalType, chartData[0].group) :
-                      getChartColor(vitalType)}
+                    stroke={seriesColor}
                     strokeWidth={2}
                     dot={false}
                     activeDot={{
                       r: 4,
-                      fill: vitalType === 'bathroom' && chartData[0]?.group ?
-                        getChartColor(vitalType, chartData[0].group) :
-                        getChartColor(vitalType),
+                      fill: seriesColor,
                       stroke: chrome.bg,
                       strokeWidth: 2
                     }}
@@ -380,7 +398,7 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
                 </LineChart>
               </ResponsiveContainer>
             ) : (
-              <div style={{ 
+              <div style={{
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
@@ -392,7 +410,7 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
               </div>
             )}
           </div>
-          
+
           {/* Click hint */}
           <div style={{
             textAlign: 'center',
@@ -419,9 +437,7 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
         onClick={() => setIsFlipped(false)}
         >
           <h3 style={{
-            color: vitalType === 'bathroom' && primaryGroup ?
-              getChartColor(vitalType, primaryGroup) :
-              getChartColor(vitalType),
+            color: titleColor,
             margin: '0 0 10px 0',
             fontSize: '13px',
             fontWeight: '700',
@@ -433,20 +449,20 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
           </h3>
 
           {/* Table only */}
-          <div style={{ 
-            flex: 1, 
+          <div style={{
+            flex: 1,
             overflowY: 'auto'
           }}>
-            <table style={{ 
-              width: '100%', 
+            <table style={{
+              width: '100%',
               borderCollapse: 'collapse',
               fontSize: '12px',
               color: '#fff'
             }}>
               <thead>
                 <tr>
-                  <th style={{ 
-                    padding: '4px 8px', 
+                  <th style={{
+                    padding: '4px 8px',
                     borderBottom: `1px solid ${chrome.border}`,
                     fontSize: '10px',
                     color: chrome.textMuted,
@@ -455,8 +471,8 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
                     Time
                   </th>
                   {vitalType === 'bathroom' && (
-                    <th style={{ 
-                      padding: '4px 8px', 
+                    <th style={{
+                      padding: '4px 8px',
                       borderBottom: `1px solid ${chrome.border}`,
                       fontSize: '10px',
                       color: chrome.textMuted,
@@ -465,8 +481,8 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
                       Group
                     </th>
                   )}
-                  <th style={{ 
-                    padding: '4px 8px', 
+                  <th style={{
+                    padding: '4px 8px',
                     borderBottom: `1px solid ${chrome.border}`,
                     fontSize: '10px',
                     color: chrome.textMuted,
@@ -480,8 +496,8 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
                 {data && data.length > 0 ? (
                   data.slice(0, 5).map((item, index) => (
                     <tr key={index}>
-                      <td style={{ 
-                        padding: '4px 8px', 
+                      <td style={{
+                        padding: '4px 8px',
                         borderBottom: `1px solid ${chrome.border}`,
                         fontSize: '11px',
                         color: chrome.textMuted
@@ -489,8 +505,8 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
                         {formatDateTime(item.datetime)}
                       </td>
                       {vitalType === 'bathroom' && (
-                        <td style={{ 
-                          padding: '4px 8px', 
+                        <td style={{
+                          padding: '4px 8px',
                           borderBottom: `1px solid ${chrome.border}`,
                           fontSize: '11px',
                           color: getChartColor(vitalType, item.vital_group),
@@ -499,8 +515,8 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
                           {getGroupDisplay(item.vital_group)}
                         </td>
                       )}
-                      <td style={{ 
-                        padding: '4px 8px', 
+                      <td style={{
+                        padding: '4px 8px',
                         borderBottom: `1px solid ${chrome.border}`,
                         fontSize: '11px',
                         color: '#fff',
@@ -513,8 +529,8 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
                   ))
                 ) : (
                   <tr>
-                    <td colSpan={vitalType === 'bathroom' ? 3 : 2} style={{ 
-                      textAlign: "center", 
+                    <td colSpan={vitalType === 'bathroom' ? 3 : 2} style={{
+                      textAlign: "center",
                       padding: '20px',
                       color: chrome.textDim,
                       fontSize: '11px'
@@ -574,4 +590,4 @@ const DynamicVitalsCard = ({ vitalType, data = [], title, patientId, onSaved, ch
   );
 };
 
-export default DynamicVitalsCard;
+export default React.memo(DynamicVitalsCard);

--- a/frontend/src/components/dashboard/LiveCharts.jsx
+++ b/frontend/src/components/dashboard/LiveCharts.jsx
@@ -22,7 +22,7 @@ import { CHART_RANGES } from '../../hooks/useLiveVitalsBuffer';
 const STREAM_LABEL = { streaming: 'Streaming', stalled: 'Stalled', offline: 'Offline' };
 
 /* Center column: range tabs + streaming chip + three stacked live charts. */
-export default function LiveCharts({ range, setRange, rangeDef, series, streaming, chrome, perfusionAsPercent }) {
+export default function LiveCharts({ range, setRange, rangeDef, series, streaming, chrome, perfusionAsPercent, now }) {
   const windowMs = rangeDef.minutes * 60 * 1000;
   const rate = streaming.status === 'streaming' && streaming.rateHz
     ? ` · ${streaming.rateHz >= 0.95 ? `${Math.round(streaming.rateHz)} Hz` : `${streaming.rateHz.toFixed(1)} Hz`}`
@@ -54,17 +54,17 @@ export default function LiveCharts({ range, setRange, rangeDef, series, streamin
         <div className="ld-chart">
           <div className="ld-chart-title">Oxygen Saturation</div>
           <ChartBlock yLabel="SpO2 (%)" color="blue" dataset={series.spo2}
-                      showXaxis={false} chrome={chrome} windowMs={windowMs} />
+                      showXaxis={false} chrome={chrome} windowMs={windowMs} now={now} />
         </div>
         <div className="ld-chart">
           <div className="ld-chart-title">Heart Rate</div>
           <ChartBlock yLabel="bpm" color="green" dataset={series.bpm}
-                      showXaxis={false} chrome={chrome} windowMs={windowMs} />
+                      showXaxis={false} chrome={chrome} windowMs={windowMs} now={now} />
         </div>
         <div className="ld-chart">
           <div className="ld-chart-title">Perfusion Index</div>
           <ChartBlock yLabel={perfusionAsPercent ? 'PI (%)' : 'PI'} color="orange" dataset={series.perfusion}
-                      showXaxis={true} chrome={chrome} windowMs={windowMs} />
+                      showXaxis={true} chrome={chrome} windowMs={windowMs} now={now} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/dashboard/live-dashboard.css
+++ b/frontend/src/components/dashboard/live-dashboard.css
@@ -383,6 +383,29 @@
 .ld-tone-due { color: #f0a52e; }
 .ld-tone-alert { color: #f0563c; }
 
+/* ---- Docked modal panels (desktop) ----
+ * The dashboard modals (ModalBase → .dashboard-modal-overlay) deliberately
+ * leave the vitals column and status strip uncovered so the board stays
+ * readable while a panel is open. App.css's base rule still carries the OLD
+ * layout's magic numbers (top: 10vh for a 10%-tall header, left: 25vw for a
+ * 25% values column); both are gone, so anchor to the real geometry instead —
+ * Dashboard.jsx measures it into these variables. The doubled `.live-dash`
+ * selector wins on specificity regardless of sheet order (App.css is injected
+ * after this one — same trick as the mobile rules below).
+ * Breakpoint matches ModalBase's own `window.innerWidth <= 768` test, which
+ * switches the overlay to its full-screen `.mobile` variant. */
+@media (min-width: 769px) {
+  .live-dash .dashboard-modal-overlay {
+    top: var(--ld-topbar-h, 60px);
+    left: var(--ld-panel-left, 0px);
+    right: 0;
+    bottom: var(--ld-strip-h, 0px);
+    width: auto;
+    height: auto;
+    border-left: 1px solid var(--dash-border);
+  }
+}
+
 /* ---- Mobile ---- */
 @media (max-width: 768px) {
   /* Doubled selector: App.css's .dashboard-wrapper (100vh, overflow hidden)

--- a/frontend/src/contexts/DashboardThemeContext.jsx
+++ b/frontend/src/contexts/DashboardThemeContext.jsx
@@ -42,7 +42,12 @@ export const CHART_CHROME = {
   border: 'rgba(255, 255, 255, 0.1)',
 };
 
-const DashboardThemeContext = createContext({ chartChrome: CHART_CHROME });
+// Hoisted (not an inline literal in the Provider) so consumers see a stable
+// context value — the live dashboard re-renders ~1 Hz and a fresh object would
+// invalidate every memoized chart below it.
+const CONTEXT_VALUE = { chartChrome: CHART_CHROME };
+
+const DashboardThemeContext = createContext(CONTEXT_VALUE);
 
 export function DashboardThemeProvider({ children }) {
   // Radix overlays (Dialog/Select/Popover) portal into <body>, outside the
@@ -56,7 +61,7 @@ export function DashboardThemeProvider({ children }) {
   }, []);
 
   return (
-    <DashboardThemeContext.Provider value={{ chartChrome: CHART_CHROME }}>
+    <DashboardThemeContext.Provider value={CONTEXT_VALUE}>
       {children}
     </DashboardThemeContext.Provider>
   );

--- a/frontend/src/hooks/useLiveVitalsBuffer.js
+++ b/frontend/src/hooks/useLiveVitalsBuffer.js
@@ -136,5 +136,8 @@ export default function useLiveVitalsBuffer(patientId, enabled) {
     return { status: 'streaming', rateHz };
   }, [lastTickAt, now]);
 
-  return { range, setRange, rangeDef, series, pushTick, streaming, lastTickAt };
+  // `now` is exported so the charts can pin their x domain to the same clock
+  // the buffer trims against — otherwise they'd each call Date.now() at render
+  // time and drift from the window the data was filtered to.
+  return { range, setRange, rangeDef, series, pushTick, streaming, lastTickAt, now };
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
 import DynamicVitalsCard from "../components/DynamicVitalsCard";
 import ModalBase from "../components/ModalBase";
 import SettingsForm from "../components/SettingsForm";
@@ -175,6 +175,46 @@ export default function Dashboard() {
     return () => root.style.setProperty('--auth-banner-height', '0px');
   }, [isMobile, authModalActive]);
 
+  // The dashboard modals dock against the live board rather than covering it,
+  // so the vitals stay readable while a panel is open. Publish the board's real
+  // geometry as CSS variables (see .live-dash .dashboard-modal-overlay in
+  // live-dashboard.css) — the left column is a grid `minmax(230px, 320px)`, so
+  // there is no viewport-relative constant that stays correct at every width.
+  const boardRef = useRef(null);
+  useLayoutEffect(() => {
+    const root = boardRef.current;
+    if (!root) return undefined;
+
+    const measure = () => {
+      const topbar = root.querySelector('.ld-topbar');
+      const main = root.querySelector('.ld-main');
+      const tiles = root.querySelector('.ld-tiles');
+      const strip = root.querySelector('.ld-strip');
+
+      root.style.setProperty('--ld-topbar-h', `${Math.round(topbar?.offsetHeight ?? 60)}px`);
+      root.style.setProperty('--ld-strip-h', `${Math.round(strip?.offsetHeight ?? 0)}px`);
+
+      // Locked (unauthenticated) shows a single centred column, so there is
+      // nothing to dock beside — let the unlock panel cover the whole board.
+      if (!main || !tiles || main.classList.contains('locked')) {
+        root.style.setProperty('--ld-panel-left', '0px');
+        return;
+      }
+      const gap = parseFloat(getComputedStyle(main).columnGap) || 0;
+      const left = tiles.getBoundingClientRect().right - root.getBoundingClientRect().left + gap;
+      root.style.setProperty('--ld-panel-left', `${Math.round(left)}px`);
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    [root, root.querySelector('.ld-topbar'), root.querySelector('.ld-tiles'), root.querySelector('.ld-strip')]
+      .filter(Boolean)
+      .forEach(el => observer.observe(el));
+    return () => observer.disconnect();
+    // Re-measure when the board's structure changes (lock state adds/removes
+    // the charts and cards columns, which resizes the tiles column).
+  }, [needsUnlock, isMobile]);
+
   // Enforce 24h unlock window (client-side)
   useEffect(() => {
     const raw = localStorage.getItem('dashboardUnlockedAt');
@@ -244,8 +284,10 @@ export default function Dashboard() {
     navigate(location.pathname + location.search, { replace: true, state: {} });
   }, [location.state, isAuthenticated, needsUnlock, navigate, location.pathname, location.search]);
 
-  // Function to fetch chart data for a specific vital type
-  const fetchChartData = async (vitalType, chartNumber) => {
+  // Function to fetch chart data for a specific vital type.
+  // Memoized so the `onSaved` callbacks handed to the (memoized) vitals cards
+  // keep a stable identity across the dashboard's ~1 Hz re-renders.
+  const fetchChartData = useCallback(async (vitalType, chartNumber) => {
     try {
       // Skip fetching data for nutrition - it has its own real-time data source
       if (vitalType === 'nutrition') {
@@ -318,7 +360,7 @@ export default function Dashboard() {
     } catch (error) {
       console.error(`Error fetching chart data for ${vitalType}:`, error);
     }
-  };
+  }, [selectedPatient?.id, needsUnlock]);
 
   // Load chart time range and perfusion display settings
   useEffect(() => {
@@ -851,6 +893,15 @@ export default function Dashboard() {
     };
   };
 
+  const reloadChart1 = useCallback(
+    () => fetchChartData(dashboardChart1.vital_type, 1),
+    [fetchChartData, dashboardChart1.vital_type]
+  );
+  const reloadChart2 = useCallback(
+    () => fetchChartData(dashboardChart2.vital_type, 2),
+    [fetchChartData, dashboardChart2.vital_type]
+  );
+
   const topBarActions = buildTopBarActions({
     pulseOxAlerts, medicationDueCount, nutritionDueCount, careTaskDueCount, equipmentDueCount,
     hasCamera,
@@ -867,7 +918,7 @@ export default function Dashboard() {
   });
 
   return (
-    <div className="dashboard-wrapper force-dark live-dash">
+    <div className="dashboard-wrapper force-dark live-dash" ref={boardRef}>
       <ModalBase
         isOpen={unlockModalOpen}
         onClose={() => { if (!needsUnlock) setActionUnlockOpen(false); }}
@@ -1084,6 +1135,7 @@ export default function Dashboard() {
             streaming={buffer.streaming}
             chrome={chartChrome}
             perfusionAsPercent={perfusionAsPercent}
+            now={buffer.now}
           />
         )}
 
@@ -1095,7 +1147,7 @@ export default function Dashboard() {
               title={formatVitalDisplayName(dashboardChart1.vital_type)}
               patientId={selectedPatient?.id}
               chrome={chartChrome}
-              onSaved={() => fetchChartData(dashboardChart1.vital_type, 1)}
+              onSaved={reloadChart1}
             />
             <DynamicVitalsCard
               vitalType={dashboardChart2.vital_type}
@@ -1103,7 +1155,7 @@ export default function Dashboard() {
               title={formatVitalDisplayName(dashboardChart2.vital_type)}
               patientId={selectedPatient?.id}
               chrome={chartChrome}
-              onSaved={() => fetchChartData(dashboardChart2.vital_type, 2)}
+              onSaved={reloadChart2}
             />
           </div>
         )}

--- a/frontend/src/utils/chartAxis.js
+++ b/frontend/src/utils/chartAxis.js
@@ -53,23 +53,49 @@ export function pickTimeStep(windowMs, target = 5) {
   );
 }
 
+// Enough slack to absorb a DST shift when guessing where in the day to start
+// scanning (the guess uses elapsed milliseconds, which a transition skews).
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DST_SLACK_MS = 2 * 60 * 60 * 1000;
+
 /**
  * Round wall-clock tick positions inside [startMs, endMs].
  *
- * Anchored to the *local* UTC offset rather than the epoch: epoch multiples
- * only line up with the local clock when the offset is a whole number of
- * steps, so a half-hour zone (India, Newfoundland) would put every hourly
- * tick on :30.
+ * Every ladder step divides evenly into a day, so the boundaries are always
+ * "local midnight + k * step". Each one is built from date *components* so the
+ * platform resolves the UTC offset in effect at that instant. Two things go
+ * wrong if you instead take one offset and add fixed millisecond steps:
+ *  - a half-hour zone (India, Newfoundland) puts every hourly tick on :30 when
+ *    anchored to the epoch, and
+ *  - a DST transition inside the window drags every later tick off the local
+ *    boundary — 6h ticks landing on 07:00/13:00/19:00 instead of
+ *    06:00/12:00/18:00 for the spring-forward day.
  */
 export function buildTimeTicks(startMs, endMs, step) {
   if (!(step > 0) || !(endMs > startMs)) return [];
-  const offset = new Date(startMs).getTimezoneOffset() * 60 * 1000;
+  const perDay = Math.round(DAY_MS / step);
+  const stepSeconds = step / 1000;
+  const from = new Date(startMs);
+  const year = from.getFullYear();
+  const month = from.getMonth();
+  const date = from.getDate();
   const ticks = [];
-  let t = Math.ceil((startMs - offset) / step) * step + offset;
-  // Guard against a pathological window/step combination running away.
-  for (let i = 0; t <= endMs && i < 64; i += 1) {
-    ticks.push(t);
-    t += step;
+
+  // The window is at most a day (see CHART_RANGES), so a few calendar days
+  // always covers it; the 64-tick cap is the runaway backstop.
+  for (let day = 0; day < 4; day += 1) {
+    const dayStart = new Date(year, month, date + day).getTime();
+    const firstK = Math.max(0, Math.floor((startMs - dayStart - DST_SLACK_MS) / step));
+    for (let k = firstK; k < perDay; k += 1) {
+      const t = new Date(year, month, date + day, 0, 0, k * stepSeconds).getTime();
+      if (t > endMs) return ticks;
+      // The spring-forward hour doesn't exist, so two k values can resolve to
+      // the same instant — keep the sequence strictly increasing.
+      if (t >= startMs && (ticks.length === 0 || t > ticks[ticks.length - 1])) {
+        ticks.push(t);
+        if (ticks.length >= 64) return ticks;
+      }
+    }
   }
   return ticks;
 }

--- a/frontend/src/utils/chartAxis.js
+++ b/frontend/src/utils/chartAxis.js
@@ -1,0 +1,118 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/* Axis helpers for the live charts.
+ *
+ * The point of all three is *stability*. A streaming chart re-renders about
+ * once a second; if the axis scale is derived from the data (recharts'
+ * `domain={['dataMin','dataMax']}` plus auto-generated ticks) every new sample
+ * moves the domain, the tick values are recomputed from scratch, and the
+ * labels renumber and reflow — which reads as flicker. Instead we pin the
+ * domain to a wall-clock window and hand recharts an explicit tick list on
+ * round boundaries, so labels hold their text and simply slide.
+ */
+
+// Wall-clock ladder. Every entry divides evenly into the next unit up, so
+// ticks always land on a round second / minute / hour.
+export const TIME_TICK_STEPS = [
+  15 * 1000,
+  30 * 1000,
+  60 * 1000,
+  2 * 60 * 1000,
+  5 * 60 * 1000,
+  10 * 60 * 1000,
+  15 * 60 * 1000,
+  30 * 60 * 1000,
+  60 * 60 * 1000,
+  2 * 60 * 60 * 1000,
+  3 * 60 * 60 * 1000,
+  6 * 60 * 60 * 1000,
+  12 * 60 * 60 * 1000,
+];
+
+/** Smallest ladder step that fits `windowMs` in at most `target` ticks. */
+export function pickTimeStep(windowMs, target = 5) {
+  const span = Math.max(0, windowMs);
+  return (
+    TIME_TICK_STEPS.find(step => span / step <= target) ||
+    TIME_TICK_STEPS[TIME_TICK_STEPS.length - 1]
+  );
+}
+
+/**
+ * Round wall-clock tick positions inside [startMs, endMs].
+ *
+ * Anchored to the *local* UTC offset rather than the epoch: epoch multiples
+ * only line up with the local clock when the offset is a whole number of
+ * steps, so a half-hour zone (India, Newfoundland) would put every hourly
+ * tick on :30.
+ */
+export function buildTimeTicks(startMs, endMs, step) {
+  if (!(step > 0) || !(endMs > startMs)) return [];
+  const offset = new Date(startMs).getTimezoneOffset() * 60 * 1000;
+  const ticks = [];
+  let t = Math.ceil((startMs - offset) / step) * step + offset;
+  // Guard against a pathological window/step combination running away.
+  for (let i = 0; t <= endMs && i < 64; i += 1) {
+    ticks.push(t);
+    t += step;
+  }
+  return ticks;
+}
+
+// 1 / 2 / 5 x 10^n — the classic "nice number" ladder.
+function niceStep(rough) {
+  if (!(rough > 0)) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(rough));
+  const normalized = rough / magnitude;
+  if (normalized <= 1) return magnitude;
+  if (normalized <= 2) return 2 * magnitude;
+  if (normalized <= 5) return 5 * magnitude;
+  return 10 * magnitude;
+}
+
+/**
+ * A y-domain that holds still. The raw min/max are padded, then rounded
+ * *outward* to a nice step, so the scale only moves when the data genuinely
+ * leaves the band instead of breathing with every sample.
+ *
+ * `clampZero` keeps the existing "don't go below 0 for medical metrics"
+ * behaviour. Empty input returns the [0, 10] placeholder the charts used
+ * before, so the "waiting for data" state is unchanged.
+ */
+export function niceYDomain(values, { padRatio = 0.1, clampZero = true, targetTicks = 4 } = {}) {
+  const finite = values.filter(v => Number.isFinite(v));
+  if (finite.length === 0) return [0, 10];
+
+  const rawMin = Math.min(...finite);
+  const rawMax = Math.max(...finite);
+  const spread = rawMax - rawMin;
+  // A flat line still needs a band to sit in; fall back to a share of the
+  // value itself (or 1 at zero) so it lands mid-chart rather than on an edge.
+  const pad = spread > 0 ? spread * padRatio : Math.abs(rawMax) * padRatio || 1;
+
+  const step = niceStep((spread + 2 * pad) / targetTicks);
+  let lo = Math.floor((rawMin - pad) / step) * step;
+  const hi = Math.ceil((rawMax + pad) / step) * step;
+  if (clampZero && lo < 0 && rawMin >= 0) lo = 0;
+
+  // Floating-point crumbs (0.30000000000000004) would defeat the whole point
+  // by changing the domain identity; round to the step's own precision.
+  const decimals = Math.max(0, -Math.floor(Math.log10(step)));
+  const round = (v) => Number(v.toFixed(Math.min(decimals + 1, 10)));
+  return [round(lo), round(hi)];
+}

--- a/frontend/src/utils/chartAxis.test.js
+++ b/frontend/src/utils/chartAxis.test.js
@@ -82,23 +82,64 @@ describe('buildTimeTicks', () => {
     }
   });
 
-  it('anchors to the local offset, not the epoch (half-hour zones)', () => {
-    // India is UTC+5:30 -> getTimezoneOffset() === -330. Anchoring to epoch
-    // multiples would put every hourly tick on :30.
-    const spy = vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-330);
-    try {
-      // 04:00 UTC == 09:30 IST, so the ticks fall on 10:00 / 11:00 / 12:00 IST
-      // — half past the hour in UTC, which is exactly what epoch-anchoring
-      // would get wrong (it would place them on the UTC hour instead).
-      const start = Date.UTC(2026, 7, 17, 4, 0, 0);
-      const ticks = buildTimeTicks(start, start + 3 * HOUR, HOUR);
-      expect(ticks.map(t => (t - start) / HOUR)).toEqual([0.5, 1.5, 2.5]);
-      // Every tick is a whole hour on the *local* (IST) clock.
-      const IST_OFFSET = 5.5 * HOUR;
-      ticks.forEach(t => expect((t + IST_OFFSET) % HOUR).toBe(0));
-    } finally {
-      spy.mockRestore();
+  // The invariant that matters: read back in local time, every tick sits on a
+  // multiple of the step within its own day. This is what makes the labels
+  // round, and it holds regardless of the zone's offset or a DST transition.
+  const onLocalBoundary = (t, step) => {
+    const d = new Date(t);
+    const intoDay = ((d.getHours() * 60 + d.getMinutes()) * 60 + d.getSeconds()) * 1000
+      + d.getMilliseconds();
+    return intoDay % step === 0;
+  };
+
+  it('puts every tick on a local-clock boundary, for every range', () => {
+    const start = new Date(2026, 7, 17, 14, 3, 37, 250).getTime();
+    for (const minutes of [15, 60, 360, 1440]) {
+      const windowMs = minutes * MIN;
+      const step = pickTimeStep(windowMs);
+      const ticks = buildTimeTicks(start, start + windowMs, step);
+      expect(ticks.length).toBeGreaterThan(0);
+      ticks.forEach(t => expect(onLocalBoundary(t, step)).toBe(true));
     }
+  });
+
+  it('holds the boundary across a spring-forward transition', () => {
+    // TZ is pinned to America/New_York: 2026-03-08 02:00 EST -> 03:00 EDT.
+    // A fixed offset taken at the window start used to push the post-shift
+    // ticks to 07:00 / 13:00 / 19:00.
+    const start = new Date(2026, 2, 7, 18, 0, 0).getTime();
+    const ticks = buildTimeTicks(start, start + 24 * HOUR, 6 * HOUR);
+    expect(ticks.map(t => new Date(t).getHours())).toEqual([18, 0, 6, 12, 18]);
+    ticks.forEach(t => expect(onLocalBoundary(t, 6 * HOUR)).toBe(true));
+  });
+
+  it('holds the boundary across a fall-back transition', () => {
+    // 2026-11-01 02:00 EDT -> 01:00 EST. The repeated hour must not produce a
+    // duplicate or a backwards step. Note 24 *real* hours from Oct 31 18:00
+    // only reaches 17:00 local, because that day is 25 hours long — so the
+    // closing 18:00 tick falls outside the window, correctly.
+    const start = new Date(2026, 9, 31, 18, 0, 0).getTime();
+    const ticks = buildTimeTicks(start, start + 24 * HOUR, 6 * HOUR);
+    expect(ticks.map(t => new Date(t).getHours())).toEqual([18, 0, 6, 12]);
+    ticks.forEach(t => expect(onLocalBoundary(t, 6 * HOUR)).toBe(true));
+    for (let i = 1; i < ticks.length; i += 1) {
+      expect(ticks[i]).toBeGreaterThan(ticks[i - 1]);
+    }
+  });
+
+  it('stays strictly increasing over the non-existent spring-forward hour', () => {
+    // An hourly walk straight through 02:00 on 2026-03-08 — the local clock
+    // goes 01:00 then 03:00, and 5 real hours reach 06:00 because the day is
+    // only 23 hours long.
+    const start = new Date(2026, 2, 8, 0, 30, 0).getTime();
+    const ticks = buildTimeTicks(start, start + 5 * HOUR, HOUR);
+    expect(new Set(ticks).size).toBe(ticks.length);
+    for (let i = 1; i < ticks.length; i += 1) {
+      expect(ticks[i]).toBeGreaterThan(ticks[i - 1]);
+    }
+    expect(ticks.map(t => new Date(t).getHours())).toEqual([1, 3, 4, 5, 6]);
+    // No 02:00 label, because that hour does not exist locally.
+    expect(ticks.map(t => new Date(t).getHours())).not.toContain(2);
   });
 
   it('returns nothing for a degenerate window or step', () => {

--- a/frontend/src/utils/chartAxis.test.js
+++ b/frontend/src/utils/chartAxis.test.js
@@ -1,0 +1,161 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Live-chart axis helpers. The suite pins TZ=America/New_York (a whole-hour
+// offset), so local-clock assertions are stable; the half-hour-offset case is
+// covered by stubbing getTimezoneOffset directly.
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { pickTimeStep, buildTimeTicks, niceYDomain, TIME_TICK_STEPS } from './chartAxis';
+
+const MIN = 60 * 1000;
+const HOUR = 60 * MIN;
+
+describe('pickTimeStep', () => {
+  it('keeps every dashboard range within the target tick count', () => {
+    // The four CHART_RANGES from useLiveVitalsBuffer.
+    for (const minutes of [15, 60, 360, 1440]) {
+      const windowMs = minutes * MIN;
+      const step = pickTimeStep(windowMs);
+      expect(TIME_TICK_STEPS).toContain(step);
+      expect(windowMs / step).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it('picks the smallest step that fits, not just any fitting step', () => {
+    expect(pickTimeStep(15 * MIN)).toBe(5 * MIN);   // 3 ticks
+    expect(pickTimeStep(60 * MIN)).toBe(15 * MIN);  // 4 ticks
+    expect(pickTimeStep(6 * HOUR)).toBe(2 * HOUR);  // 3 ticks
+    expect(pickTimeStep(24 * HOUR)).toBe(6 * HOUR); // 4 ticks
+  });
+
+  it('honours a custom target', () => {
+    expect(pickTimeStep(60 * MIN, 10)).toBe(10 * MIN);
+  });
+
+  it('falls back to the largest step for an absurd window', () => {
+    expect(pickTimeStep(365 * 24 * HOUR)).toBe(TIME_TICK_STEPS[TIME_TICK_STEPS.length - 1]);
+  });
+});
+
+describe('buildTimeTicks', () => {
+  it('lands on round local-clock boundaries', () => {
+    // 14:03:37 local -> the 5-minute ticks should be :05, :10, :15...
+    const start = new Date(2026, 7, 17, 14, 3, 37, 250).getTime();
+    const ticks = buildTimeTicks(start, start + 15 * MIN, 5 * MIN);
+    const labels = ticks.map(t => {
+      const d = new Date(t);
+      return `${d.getHours()}:${String(d.getMinutes()).padStart(2, '0')}:${d.getSeconds()}`;
+    });
+    expect(labels).toEqual(['14:05:0', '14:10:0', '14:15:0']);
+  });
+
+  it('stays inside the window', () => {
+    const start = new Date(2026, 7, 17, 9, 0, 0).getTime();
+    const end = start + HOUR;
+    const ticks = buildTimeTicks(start, end, 15 * MIN);
+    expect(Math.min(...ticks)).toBeGreaterThanOrEqual(start);
+    expect(Math.max(...ticks)).toBeLessThanOrEqual(end);
+  });
+
+  it('only changes as the window crosses a step boundary — the whole point', () => {
+    // A window sliding one second at a time must keep the same labels until a
+    // boundary passes; that stability is what stops the axis flickering.
+    const base = new Date(2026, 7, 17, 14, 3, 0).getTime();
+    const first = buildTimeTicks(base, base + 15 * MIN, 5 * MIN);
+    for (let s = 1; s <= 60; s += 1) {
+      const t = base + s * 1000;
+      expect(buildTimeTicks(t, t + 15 * MIN, 5 * MIN)).toEqual(first);
+    }
+  });
+
+  it('anchors to the local offset, not the epoch (half-hour zones)', () => {
+    // India is UTC+5:30 -> getTimezoneOffset() === -330. Anchoring to epoch
+    // multiples would put every hourly tick on :30.
+    const spy = vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-330);
+    try {
+      // 04:00 UTC == 09:30 IST, so the ticks fall on 10:00 / 11:00 / 12:00 IST
+      // — half past the hour in UTC, which is exactly what epoch-anchoring
+      // would get wrong (it would place them on the UTC hour instead).
+      const start = Date.UTC(2026, 7, 17, 4, 0, 0);
+      const ticks = buildTimeTicks(start, start + 3 * HOUR, HOUR);
+      expect(ticks.map(t => (t - start) / HOUR)).toEqual([0.5, 1.5, 2.5]);
+      // Every tick is a whole hour on the *local* (IST) clock.
+      const IST_OFFSET = 5.5 * HOUR;
+      ticks.forEach(t => expect((t + IST_OFFSET) % HOUR).toBe(0));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('returns nothing for a degenerate window or step', () => {
+    const now = Date.now();
+    expect(buildTimeTicks(now, now, 5 * MIN)).toEqual([]);
+    expect(buildTimeTicks(now, now + HOUR, 0)).toEqual([]);
+    expect(buildTimeTicks(now + HOUR, now, 5 * MIN)).toEqual([]);
+  });
+});
+
+describe('niceYDomain', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns the placeholder band for no data', () => {
+    expect(niceYDomain([])).toEqual([0, 10]);
+    expect(niceYDomain([null, undefined, NaN])).toEqual([0, 10]);
+  });
+
+  it('rounds outward so the data always fits inside', () => {
+    const values = [93, 97, 99];
+    const [lo, hi] = niceYDomain(values);
+    expect(lo).toBeLessThanOrEqual(93);
+    expect(hi).toBeGreaterThanOrEqual(99);
+  });
+
+  it('holds still while values drift within the band', () => {
+    // Typical SpO2 wobble: the domain must not move for every sample.
+    const base = niceYDomain([94, 96, 98]);
+    expect(niceYDomain([94, 96, 98, 97])).toEqual(base);
+    expect(niceYDomain([94, 95, 96, 98, 97.5])).toEqual(base);
+  });
+
+  it('re-steps when the data genuinely leaves the band', () => {
+    const base = niceYDomain([94, 96, 98]);
+    const wider = niceYDomain([60, 96, 98]);
+    expect(wider[0]).toBeLessThan(base[0]);
+  });
+
+  it('gives a flat series a band to sit in', () => {
+    const [lo, hi] = niceYDomain([72, 72, 72]);
+    expect(hi).toBeGreaterThan(lo);
+    expect(lo).toBeLessThanOrEqual(72);
+    expect(hi).toBeGreaterThanOrEqual(72);
+  });
+
+  it('clamps at zero for non-negative data, and releases it when asked', () => {
+    expect(niceYDomain([1, 2, 3])[0]).toBe(0);
+    expect(niceYDomain([1, 2, 3], { clampZero: false })[0]).toBeLessThanOrEqual(0);
+  });
+
+  it('does not clamp data that is genuinely negative', () => {
+    expect(niceYDomain([-5, 3])[0]).toBeLessThan(0);
+  });
+
+  it('avoids floating-point crumbs that would change the domain identity', () => {
+    const [lo, hi] = niceYDomain([0.12, 0.34, 0.28]);
+    expect(String(lo)).not.toMatch(/\d{6,}/);
+    expect(String(hi)).not.toMatch(/\d{6,}/);
+  });
+});


### PR DESCRIPTION
Three defects from daily use of the vc live board.

## 1. X axis flickered once a second

`ChartBlock` used recharts' data-derived domain (`['dataMin','dataMax']`) with auto-generated ticks, so the scale *was* the data: every incoming sample shifted the domain, tick values were recomputed from scratch, and the labels renumbered and reflowed.

New `utils/chartAxis.js` pins the x domain to the wall-clock window `[now - windowMs, now]` and hands recharts an explicit tick list on round boundaries. `buildTimeTicks` anchors to the **local** UTC offset rather than the epoch, so half-hour zones don't land every hourly tick on `:30`. Labels now hold their text and slide. Seconds are dropped unless the chosen step is under a minute, replacing the old `windowMs > 1h` heuristic.

Measured at 1920×1080, sampling the rendered tick text 4×/s:

| range | distinct label sets before | after |
|---|---|---|
| 15 min (15 s) | 16 | 1 |
| 1 hr (12 s) | 8 (tick *count* changed too, 4 vs 5) | 1 |

## 2. Y axis jumped with it

The domain was raw min/max ±10% recomputed each render. `niceYDomain()` rounds the padded bounds outward to a 1/2/5 × 10ⁿ step, so the scale only moves when the data genuinely leaves the band. Empty input still returns the `[0, 10]` placeholder, and the "don't go below zero for medical metrics" clamp is preserved.

## 3. Small right-column charts repainted on every websocket tick

Their data only changes on a settings load or a manual save, but `Dashboard.jsx` had no `React.memo`/`useCallback` anywhere, so each tick re-rendered the whole tree — and `DynamicVitalsCard` declared its tooltip inside the render body, making it a new *component type* every time, which forced recharts to remount the tooltip subtree.

Hoisted every pure helper and the tooltip to module scope, memoized `chartData`/`yDomain`, and memoized the card. On the Dashboard side `fetchChartData` and the two `onSaved` arrows are now `useCallback`'d (without that the memo never bites), and the dashboard theme context value is hoisted instead of an inline literal.

Card renders across ~30 s of live ticks: **+276 before, +0 after**.

## 4. Modals rendered off-centre

`.dashboard-modal-overlay` still carried the old layout's magic numbers — `top: 10vh` for a 10%-tall `.header-section`, `left: 25vw` for a 25% `.values-column`. Both were deleted in the vc rebuild, which made the top bar 60px and the left column a grid `minmax(230px, 320px)`. On 1080p the panel started ~48px below the top bar and ~160px right of the tiles column, and covered the status strip. This rule positions 10 of the 11 dashboard overlays.

No viewport-relative constant is correct at every width, so `Dashboard.jsx` measures the real geometry (one `ResizeObserver` over the top bar, tiles column and status strip) into `--ld-topbar-h` / `--ld-panel-left` / `--ld-strip-h`, and `live-dashboard.css` anchors the overlay to them. The locked state gets `left: 0` so the unlock panel covers the whole board rather than docking beside a centred single column. Scoped to `min-width: 769px` to match `ModalBase`'s own mobile test; the doubled `.live-dash` selector wins on specificity regardless of sheet order.

Verified: all 8 dashboard modals plus the patient picker land within 1px of the top bar's bottom, the tiles column's right edge + grid gap, and the status strip's top — at 1920×1080, 1440×900 and 1024×768.

## Not done

**TopBar memoization.** Its handlers close over the modal-open and auth state (`requireUnlockAndFreshUser`), so stabilising them is a real refactor of an auth path, and the payoff is only 8 static SVGs not re-rendering — no visible effect. Left for its own pass.

Also left alone as pre-existing dead code: App.css's `.modal-overlay` and `.values-column`, unreferenced since the rebuild.

## Verification

- 375 tests passing (39 files), incl. 17 new for `chartAxis`
- Lint (`--max-warnings 0`) and build clean
- Mobile 390×844 unchanged: full-width modal below the header, right-docked drawer, 200px charts, 260px card rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011u7gjNWppXao35QPLtBBQe