### PR TITLE
Menus dock into the board; Capture Vitals panel

### DIFF
--- a/backend/crud/vitals.py
+++ b/backend/crud/vitals.py
@@ -140,7 +140,8 @@ def save_capture_reading(db: Session, *, patient_id, vital_type, value, timestam
                          vital_group=None, unit=None, code=None, ucum_unit=None,
                          account_id=None, recorded_by=None, encounter_uid=None,
                          external_id=None, confirmed_against_warning=None,
-                         reference_low=None, reference_high=None, notes=None):
+                         reference_low=None, reference_high=None, notes=None,
+                         source='manual'):
     """Build one fully-stamped Vital row for the capture flow (no commit).
 
     Unlike save_vital, callers batch several rows into one transaction and
@@ -166,7 +167,7 @@ def save_capture_reading(db: Session, *, patient_id, vital_type, value, timestam
         unit=unit,
         code=code,
         ucum_unit=ucum_unit,
-        source='manual',
+        source=source,
         account_id=account_id,
         recorded_by=recorded_by,
         encounter_uid=encounter_uid,

--- a/backend/routes/vitals.py
+++ b/backend/routes/vitals.py
@@ -453,7 +453,12 @@ class CaptureReading(BaseModel):
     diastolic: Optional[float] = None
     unit: Optional[str] = None
     measured_at: Optional[datetime] = None
-    source: Literal['manual'] = 'manual'
+    # 'pulse_ox' is for readings the caregiver accepted from the connected
+    # oximeter rather than typing (the live dashboard's capture panel offers
+    # them as a snapshot). Recording those as 'manual' would misstate
+    # provenance in the record, and loinc_for() already keys the SpO2 code off
+    # this distinction: manual -> 2708-6, device -> 59408-5.
+    source: Literal['manual', 'pulse_ox'] = 'manual'
     confirmed_against_warning: bool = False
     note: Optional[str] = None
 
@@ -655,7 +660,7 @@ async def capture_vitals(
             if meta:
                 lk = meta['loinc_key']
                 loinc = loinc_for(lk.get(vital_group or field_key) if isinstance(lk, dict) else lk,
-                                  'manual')
+                                  r.source)
             else:
                 loinc = None
             return save_capture_reading(
@@ -667,7 +672,7 @@ async def capture_vitals(
                 confirmed_against_warning=True if band == 'concerning' else None,
                 reference_low=entry.get('expected_min'),
                 reference_high=entry.get('expected_max'),
-                notes=r.note)
+                notes=r.note, source=r.source)
 
         if r.vital_key == 'blood_pressure':
             map_value = round(r.diastolic + (r.systolic - r.diastolic) / 3)
@@ -767,6 +772,7 @@ def get_patient_vitals(
             grouped[key]['vital_type'] = v.vital_type
             grouped[key]['notes'] = v.notes
             grouped[key]['patient_id'] = v.patient_id
+            grouped[key]['source'] = v.source or 'manual'
             grouped[key]['values'][v.vital_group] = v.value
         else:
             single_vitals.append({
@@ -776,7 +782,9 @@ def get_patient_vitals(
                 'value': v.value,
                 'notes': v.notes,
                 'patient_id': v.patient_id,
-                'source': 'manual'
+                # The stored provenance, not an assumption: capture can record
+                # readings accepted from the connected oximeter ('pulse_ox').
+                'source': v.source or 'manual'
             })
     
     # Convert grouped vitals to list format
@@ -790,7 +798,7 @@ def get_patient_vitals(
                 'map': data['values'].get('map'),
                 'notes': data['notes'],
                 'patient_id': data['patient_id'],
-                'source': 'manual'
+                'source': data.get('source', 'manual')
             })
         elif data['vital_type'] == 'temperature':
             single_vitals.append({
@@ -799,7 +807,7 @@ def get_patient_vitals(
                 'value': data['values'].get('body') or data['values'].get('core'),
                 'notes': data['notes'],
                 'patient_id': data['patient_id'],
-                'source': 'manual'
+                'source': data.get('source', 'manual')
             })
     
     # Sort by timestamp descending

--- a/backend/tests/test_vitals_capture.py
+++ b/backend/tests/test_vitals_capture.py
@@ -75,6 +75,53 @@ def test_capture_ok_values_stamped(admin_client, admin_user, account, patient,
     assert events[0][1]["vital_data"] == {"spo2": 97}
 
 
+def test_capture_pulse_ox_source_is_recorded_and_changes_the_spo2_code(
+        admin_client, patient, db_session):
+    """A reading accepted from the connected oximeter is not a manual entry.
+
+    The live dashboard's capture panel offers the current SpO2/HR as a
+    snapshot; recording those as 'manual' would misstate provenance, and LOINC
+    distinguishes the two (2708-6 generic arterial vs 59408-5 pulse oximetry).
+    """
+    resp = _capture(admin_client, patient.id, [
+        {"vital_key": "spo2", "value": 97, "source": "pulse_ox"},
+        {"vital_key": "heart_rate", "value": 72, "source": "pulse_ox"},
+        {"vital_key": "temperature", "value": 98.6},
+    ])
+    assert resp.status_code == 200, resp.text
+
+    rows = {r.vital_type: r for r in _rows(db_session, patient.id)}
+    assert rows["spo2"].source == "pulse_ox"
+    assert rows["spo2"].code == "59408-5"  # device SpO2 -> pulse oximetry
+    assert rows["heart_rate"].source == "pulse_ox"
+    # An unmarked reading in the same batch stays manual.
+    assert rows["temperature"].source == "manual"
+
+
+def test_patient_vitals_endpoint_reports_the_stored_source(admin_client, patient):
+    """GET /patient/{id} used to hardcode source='manual' in its response.
+
+    With capture able to record device-accepted readings that is no longer a
+    safe assumption — the endpoint has to report what is stored.
+    """
+    _capture(admin_client, patient.id, [
+        {"vital_key": "spo2", "value": 97, "source": "pulse_ox"},
+        {"vital_key": "weight", "value": 150},
+    ])
+    resp = admin_client.get(f"/api/vitals/patient/{patient.id}?limit=20")
+    assert resp.status_code == 200, resp.text
+    by_type = {row["vital_type"]: row for row in resp.json()}
+    assert by_type["spo2"]["source"] == "pulse_ox"
+    assert by_type["weight"]["source"] == "manual"
+
+
+def test_capture_rejects_an_unknown_source(admin_client, patient):
+    resp = _capture(admin_client, patient.id, [
+        {"vital_key": "spo2", "value": 97, "source": "withings"},
+    ])
+    assert resp.status_code == 422
+
+
 def test_capture_blood_pressure_expands_and_computes_map(admin_client, patient,
                                                          db_session, events):
     resp = _capture(admin_client, patient.id, [

--- a/frontend/src/components/Icons.jsx
+++ b/frontend/src/components/Icons.jsx
@@ -1062,3 +1062,33 @@ export const BrandMarkIcon = ({ size = 32 }) => (
     <polyline points="6 14.5 9 14.5 10.5 11 12.5 17 14 14.5 18 14.5" />
   </svg>
 );
+
+/* Panel dock controls. The live dashboard opens its menus as a narrow panel
+   over the cards column and expands them across the charts; these two mark
+   that toggle. */
+export const ExpandPanelIcon = ({ size = 18 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="15 3 21 3 21 9" />
+    <polyline points="9 21 3 21 3 15" />
+    <line x1="21" y1="3" x2="14" y2="10" />
+    <line x1="3" y1="21" x2="10" y2="14" />
+  </svg>
+);
+
+export const CollapsePanelIcon = ({ size = 18 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="4 14 10 14 10 20" />
+    <polyline points="20 10 14 10 14 4" />
+    <line x1="14" y1="10" x2="21" y2="3" />
+    <line x1="3" y1="21" x2="10" y2="14" />
+  </svg>
+);
+
+export const VitalsCaptureIcon = ({ size = 26 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 12h4l2-5 3 10 2.5-6 1.5 3h5" />
+  </svg>
+);

--- a/frontend/src/components/ModalBase.jsx
+++ b/frontend/src/components/ModalBase.jsx
@@ -17,26 +17,39 @@
  */
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
+import { useModalDock } from "../contexts/ModalDockContext";
+import { ExpandPanelIcon, CollapsePanelIcon } from "./Icons";
 
 /**
- * Reusable modal component that can display various content
+ * Reusable modal component that can display various content.
+ *
+ * Three shapes:
+ *  - mobile (viewport <= 768px): full-screen sheet with a "Back" affordance
+ *  - docked (desktop, inside a ModalDockProvider): a panel beside the host's
+ *    content, narrow by default and expandable — see ModalDockContext
+ *  - plain desktop: the original slab
+ *
+ * `dock={false}` opts an individual modal out of docking even inside a
+ * provider (the unlock gate wants the whole board, not a side panel).
  */
-const ModalBase = ({ isOpen, onClose, title, children }) => {
+const ModalBase = ({ isOpen, onClose, title, children, dock }) => {
   const [isMobile, setIsMobile] = useState(false);
+  const { docked: dockAvailable, expanded, toggleExpand } = useModalDock();
+  const docked = dock !== false && dockAvailable && !isMobile;
 
   useEffect(() => {
     const checkMobile = () => {
       setIsMobile(window.innerWidth <= 768);
     };
-    
+
     checkMobile();
     window.addEventListener('resize', checkMobile);
-    
+
     // Prevent body scroll when modal is open on mobile
     if (isOpen && isMobile) {
       document.body.style.overflow = 'hidden';
     }
-    
+
     return () => {
       window.removeEventListener('resize', checkMobile);
       document.body.style.overflow = 'auto';
@@ -51,21 +64,41 @@ const ModalBase = ({ isOpen, onClose, title, children }) => {
     }
   };
 
+  // A docked panel occupies a slice of the board, so `.mobile` is deliberately
+  // NOT reused for it: that class's 100vw/100vh container fixes live inside
+  // App.css's max-width:768px query and would not apply here.
+  const variant = isMobile ? 'mobile' : (docked ? `docked${expanded ? ' expanded' : ''}` : '');
+  // The narrow stop reflows content that assumes a wide slab (see
+  // dashboard/dock-panel.css); expanding drops back to the normal layout.
+  const narrow = docked && !expanded ? ' ld-dock-narrow' : '';
+
   return (
-    <div className={`dashboard-modal-overlay ${isMobile ? 'mobile' : ''}`} onClick={!isMobile ? handleClose : undefined}>
-      <div className={`modal-container ${isMobile ? 'mobile' : ''}`} onClick={e => e.stopPropagation()}>
-        <div className={`modal-header ${isMobile ? 'mobile' : ''}`}>
+    <div className={`dashboard-modal-overlay ${variant}`} onClick={!isMobile && !docked ? handleClose : undefined}>
+      <div className={`modal-container ${variant}${narrow}`} onClick={e => e.stopPropagation()}>
+        <div className={`modal-header ${variant}`}>
           {isMobile && (
             <button className="modal-back-button" onClick={handleClose}>
               ← Back
             </button>
           )}
           <h2 className="modal-title">{title}</h2>
+          {docked && toggleExpand && (
+            <button
+              type="button"
+              className="modal-expand"
+              onClick={toggleExpand}
+              aria-label={expanded ? 'Collapse panel' : 'Expand panel over the charts'}
+              aria-pressed={expanded}
+              title={expanded ? 'Collapse panel' : 'Expand panel'}
+            >
+              {expanded ? <CollapsePanelIcon /> : <ExpandPanelIcon />}
+            </button>
+          )}
           {!isMobile && (
             <button className="modal-close" onClick={handleClose}>×</button>
           )}
         </div>
-        <div className={`modal-body ${isMobile ? 'mobile' : ''}`}>
+        <div className={`modal-body ${variant}`}>
           {children}
         </div>
       </div>
@@ -77,7 +110,8 @@ ModalBase.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  dock: PropTypes.bool
 };
 
 export default ModalBase;

--- a/frontend/src/components/dashboard/CaptureVitalsModal.jsx
+++ b/frontend/src/components/dashboard/CaptureVitalsModal.jsx
@@ -1,0 +1,80 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Third shell for CaptureVitalsPanel, after the phone surface at /capture and
+// the admin embed at /care/vitals. This one docks into the live dashboard, so
+// it is the only shell that can offer the connected snapshot: the board
+// already holds the oximeter's current SpO2 and heart rate.
+//
+// The host contract is the same as the others (see AdminV2VitalsCapture):
+// an outer `.vitals-capture <modifier>` element plus patient + connection.
+import { useEffect, useState } from 'react';
+import ModalBase from '../ModalBase';
+import CaptureVitalsPanel from '../../pages/capture/CaptureVitalsPanel';
+import useConnectionStatus from '../../hooks/useConnectionStatus';
+import ConnectionChip from '../ConnectionChip';
+import { useModalDock } from '../../contexts/ModalDockContext';
+
+export default function CaptureVitalsModal({ patient, sensorValues, streaming, onClose, onSaved }) {
+  const connection = useConnectionStatus();
+  const { docked, expanded } = useModalDock();
+
+  // The value-entry sheet portals to <body>, so it can't inherit the panel's
+  // bounds. Flag them on <body> and let capture.css align the sheet (and the
+  // toast) to the panel band instead of the middle of the screen.
+  useEffect(() => {
+    if (!docked) return undefined;
+    const cls = document.body.classList;
+    cls.add('ld-capture-docked');
+    cls.toggle('ld-capture-wide', expanded);
+    return () => cls.remove('ld-capture-docked', 'ld-capture-wide');
+  }, [docked, expanded]);
+
+  // Freeze the oximeter values at open. A snapshot that kept ticking would
+  // mean the number the caregiver accepted is not the number they read.
+  const [snapshot, setSnapshot] = useState(null);
+  useEffect(() => {
+    setSnapshot({
+      values: { spo2: sensorValues?.spo2 ?? null, bpm: sensorValues?.bpm ?? null },
+      streaming,
+      at: new Date().toISOString(),
+    });
+    // Deliberately open-only: see above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const title = (
+    <span className="ld-capture-title">
+      <span>Capture Vitals</span>
+      <ConnectionChip connection={connection} />
+    </span>
+  );
+
+  return (
+    <ModalBase isOpen onClose={onClose} title={title}>
+      <div className="vitals-capture vc-docked">
+        <CaptureVitalsPanel
+          patient={patient}
+          connection={connection}
+          layout="rows"
+          snapshot={snapshot}
+          onSaved={onSaved}
+        />
+      </div>
+    </ModalBase>
+  );
+}

--- a/frontend/src/components/dashboard/CaptureVitalsModal.test.jsx
+++ b/frontend/src/components/dashboard/CaptureVitalsModal.test.jsx
@@ -1,0 +1,211 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The live dashboard's docked capture panel: the connected snapshot (accepting
+// an oximeter reading rather than typing it, and recording that provenance),
+// the set-level note, and the dock's expand control.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }));
+vi.mock('../../config', () => ({
+  default: { apiUrl: '' },
+  apiFetch: apiFetchMock,
+}));
+
+import CaptureVitalsModal from './CaptureVitalsModal';
+import { ModalDockProvider } from '../../contexts/ModalDockContext';
+import { draftKey } from '../../pages/capture/useCaptureDraft';
+
+const PATIENT = { id: 5, first_name: 'Eli', last_name: 'Carty' };
+
+const jsonResponse = (body, status = 200) => ({
+  ok: status < 400, status, json: async () => body,
+});
+
+const RANGES = [
+  { vital_key: 'spo2', field_key: '', expected_min: 92, expected_max: 100,
+    implausible_min: 30, implausible_max: 100, required: false, source: 'default' },
+  { vital_key: 'heart_rate', field_key: '', expected_min: 40, expected_max: 180,
+    implausible_min: 10, implausible_max: 350, required: false, source: 'default' },
+];
+
+let captureBodies;
+
+beforeEach(() => {
+  localStorage.clear();
+  captureBodies = [];
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url, options = {}) => {
+    if (url.includes('/api/vitals/capture')) {
+      captureBodies.push(JSON.parse(options.body));
+      return jsonResponse({ status: 'success', saved: [], skipped_duplicates: 0 });
+    }
+    if (url.includes('/api/vitals/ranges')) return jsonResponse({ patient_id: 5, ranges: RANGES });
+    if (url.includes('/api/vitals/custom-definitions')) return jsonResponse([]);
+    if (url.includes('/api/status/health')) return jsonResponse({ status: 'ok' });
+    return jsonResponse({}, 404);
+  });
+});
+
+const renderPanel = async ({
+  sensorValues = { spo2: 97, bpm: 72 },
+  streaming = true,
+  dock = { docked: true, expanded: false, toggleExpand: vi.fn() },
+  onClose = vi.fn(),
+  onSaved = vi.fn(),
+} = {}) => {
+  const utils = render(
+    <ModalDockProvider value={dock}>
+      <CaptureVitalsModal
+        patient={PATIENT}
+        sensorValues={sensorValues}
+        streaming={streaming}
+        onClose={onClose}
+        onSaved={onSaved}
+      />
+    </ModalDockProvider>
+  );
+  await act(async () => { await Promise.resolve(); });
+  return { ...utils, dock, onClose, onSaved };
+};
+
+describe('CaptureVitalsModal', () => {
+  it('splits the vitals into a connected snapshot and manual readings', async () => {
+    await renderPanel();
+
+    expect(screen.getByText(/connected snapshot/i)).toBeInTheDocument();
+    expect(screen.getByText(/manual readings/i)).toBeInTheDocument();
+    expect(screen.getByText(/from the pulse ox at encounter time/i)).toBeInTheDocument();
+
+    // Only the two the oximeter can answer for get a "use live" affordance.
+    expect(screen.getByLabelText(/Record Oxygen 97% from the pulse ox/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Record Heart Rate 72bpm from the pulse ox/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Record Weight .* from the pulse ox/i)).not.toBeInTheDocument();
+  });
+
+  it('records an accepted reading with pulse_ox provenance, not manual', async () => {
+    await renderPanel();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(/Record Oxygen 97% from the pulse ox/i));
+    });
+    expect(screen.getByText(/1 of 6 recorded/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Pulse ox · /)).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /save vitals/i }));
+    });
+    await waitFor(() => expect(captureBodies).toHaveLength(1));
+
+    expect(captureBodies[0].readings).toEqual([
+      expect.objectContaining({ vital_key: 'spo2', value: 97, source: 'pulse_ox' }),
+    ]);
+  });
+
+  it('freezes the snapshot at open so the accepted number is the one on screen', async () => {
+    const { rerender } = await renderPanel({ sensorValues: { spo2: 97, bpm: 72 } });
+
+    // The board keeps ticking underneath.
+    rerender(
+      <ModalDockProvider value={{ docked: true, expanded: false, toggleExpand: vi.fn() }}>
+        <CaptureVitalsModal
+          patient={PATIENT}
+          sensorValues={{ spo2: 88, bpm: 130 }}
+          streaming
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      </ModalDockProvider>
+    );
+    await act(async () => { await Promise.resolve(); });
+
+    expect(screen.getByLabelText(/Record Oxygen 97% from the pulse ox/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Record Oxygen 88%/i)).not.toBeInTheDocument();
+  });
+
+  it('says so when the probe is not streaming rather than implying the values are current', async () => {
+    await renderPanel({ streaming: false });
+    expect(screen.getByText(/not streaming — these may be stale/i)).toBeInTheDocument();
+  });
+
+  it('falls back to hand entry when the oximeter has nothing to offer', async () => {
+    await renderPanel({ sensorValues: { spo2: null, bpm: null } });
+    expect(screen.getByText(/pulse ox offline — enter these by hand/i)).toBeInTheDocument();
+    expect(screen.queryByText(/use live/i)).not.toBeInTheDocument();
+  });
+
+  it('carries a set-level note onto every reading', async () => {
+    await renderPanel();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(/Record Oxygen 97% from the pulse ox/i));
+      fireEvent.click(screen.getByLabelText(/Record Heart Rate 72bpm from the pulse ox/i));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add note/i }));
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/note for this set/i),
+        { target: { value: 'Seated, room air.' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /save vitals/i }));
+    });
+    await waitFor(() => expect(captureBodies).toHaveLength(1));
+
+    expect(captureBodies[0].readings).toHaveLength(2);
+    for (const r of captureBodies[0].readings) {
+      expect(r.note).toBe('Seated, room air.');
+    }
+  });
+
+  it('clear draft empties the encounter and the stored draft', async () => {
+    await renderPanel();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(/Record Oxygen 97% from the pulse ox/i));
+    });
+    expect(localStorage.getItem(draftKey(5))).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /clear draft/i }));
+    });
+    expect(screen.getByText(/0 of 6 recorded/i)).toBeInTheDocument();
+    expect(localStorage.getItem(draftKey(5))).toBeNull();
+  });
+
+  it('offers the expand control while docked and calls back to the host', async () => {
+    const toggleExpand = vi.fn();
+    await renderPanel({ dock: { docked: true, expanded: false, toggleExpand } });
+
+    const expand = screen.getByRole('button', { name: /expand panel over the charts/i });
+    fireEvent.click(expand);
+    expect(toggleExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows collapse instead once expanded', async () => {
+    await renderPanel({ dock: { docked: true, expanded: true, toggleExpand: vi.fn() } });
+    expect(screen.getByRole('button', { name: /collapse panel/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /expand panel/i })).not.toBeInTheDocument();
+  });
+
+  it('has no expand control when the host is not docking (mobile)', async () => {
+    await renderPanel({ dock: { docked: false, expanded: false, toggleExpand: null } });
+    expect(screen.queryByRole('button', { name: /expand panel/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/CaptureVitalsModal.test.jsx
+++ b/frontend/src/components/dashboard/CaptureVitalsModal.test.jsx
@@ -117,6 +117,29 @@ describe('CaptureVitalsModal', () => {
     ]);
   });
 
+  it('stamps an accepted reading with the snapshot time, not the click time', async () => {
+    // The value is frozen at open, so the timestamp has to be too — otherwise a
+    // panel left sitting open attributes an older oximeter reading to "now".
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      vi.setSystemTime(new Date('2026-08-17T21:00:00.000Z'));
+      await renderPanel();
+
+      vi.setSystemTime(new Date('2026-08-17T21:10:00.000Z')); // ten minutes pass
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText(/Record Oxygen 97% from the pulse ox/i));
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /save vitals/i }));
+      });
+      await waitFor(() => expect(captureBodies).toHaveLength(1));
+
+      expect(captureBodies[0].readings[0].measured_at).toBe('2026-08-17T21:00:00.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('freezes the snapshot at open so the accepted number is the one on screen', async () => {
     const { rerender } = await renderPanel({ sensorValues: { spo2: 97, bpm: 72 } });
 

--- a/frontend/src/components/dashboard/dock-panel.css
+++ b/frontend/src/components/dashboard/dock-panel.css
@@ -1,0 +1,57 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Narrow stop of a docked dashboard panel (`.ld-dock-narrow`, set by ModalBase
+ * when docked and not expanded).
+ *
+ * The sections inside these panels were written for a slab several hundred
+ * pixels wider, and their own responsive rules are keyed to *viewport* media
+ * queries — which don't fire for a 380px panel on a 1920px screen. Rather than
+ * rewrite eight modals here, this sheet reflows the specific structures that
+ * would otherwise clip or crush; each is rebuilt properly when its section
+ * gets its own vc pass. Expanding the panel drops the class and restores the
+ * original layout, so nothing below is load-bearing for the wide view.
+ *
+ * Container queries are deliberately NOT used: `container-type` also makes the
+ * element a containing block for `position: fixed` descendants, and the alert
+ * detail sheet inside AlertsModal relies on fixed-to-viewport positioning.
+ */
+
+/* Titles are a flex row of tabs + counts with no wrap — let them stack rather
+   than overflow the header. Scoped to the title node, not "any flex row". */
+.ld-dock-narrow .modal-header > .modal-title { min-width: 0; }
+.ld-dock-narrow .modal-title > div,
+.ld-dock-narrow .modal-title > span { flex-wrap: wrap; }
+
+/* History's table sits in a container that clips (`overflow: hidden`) rather
+   than scrolls, so a 4-column table just loses its right-hand columns. */
+.ld-dock-narrow .admin-v2-table-container { overflow-x: auto; }
+.ld-dock-narrow .admin-v2-table { min-width: 420px; }
+.ld-dock-narrow .admin-v2-table th,
+.ld-dock-narrow .admin-v2-table td { padding: 0.5rem; }
+
+/* Give the content back the space the wide slab's padding spends. */
+.ld-dock-narrow .modal-body { padding: 0.75rem; }
+
+/* NOTE — deliberately not patched here: Settings' two hard `1fr 1fr` field
+   grids and the Alerts history row grid (a viewport-keyed Tailwind `sm:`
+   class, which stays "on" inside a narrow panel on a wide screen). Both need
+   a real fix in their own markup, and blanket inline-style attribute
+   selectors to reach them would fire on unrelated rows. They are cramped but
+   usable at the narrow stop, and the expand control is one click away —
+   they get sorted when those sections are rebuilt. */

--- a/frontend/src/components/dashboard/live-dashboard.css
+++ b/frontend/src/components/dashboard/live-dashboard.css
@@ -384,27 +384,100 @@
 .ld-tone-alert { color: #f0563c; }
 
 /* ---- Docked modal panels (desktop) ----
- * The dashboard modals (ModalBase → .dashboard-modal-overlay) deliberately
- * leave the vitals column and status strip uncovered so the board stays
- * readable while a panel is open. App.css's base rule still carries the OLD
- * layout's magic numbers (top: 10vh for a 10%-tall header, left: 25vw for a
- * 25% values column); both are gone, so anchor to the real geometry instead —
- * Dashboard.jsx measures it into these variables. The doubled `.live-dash`
- * selector wins on specificity regardless of sheet order (App.css is injected
- * after this one — same trick as the mobile rules below).
+ * A menu doesn't cover the board, it takes a seat in it. Two stops:
+ *   narrow   — exactly the cards column's footprint (the default on open)
+ *   expanded — also takes the charts column
+ * The vitals tiles, top bar and status strip stay visible in both.
+ *
+ * App.css's base rule still carries the OLD layout's magic numbers (top: 10vh
+ * for a 10%-tall header, left: 25vw for a 25% values column); both are gone,
+ * so anchor to the real geometry instead — Dashboard.jsx measures it into
+ * these variables. The doubled `.live-dash` selector wins on specificity
+ * regardless of sheet order (App.css is injected after this one — same trick
+ * as the mobile rules below).
  * Breakpoint matches ModalBase's own `window.innerWidth <= 768` test, which
  * switches the overlay to its full-screen `.mobile` variant. */
 @media (min-width: 769px) {
-  .live-dash .dashboard-modal-overlay {
-    top: var(--ld-topbar-h, 60px);
+  .live-dash .dashboard-modal-overlay.docked {
+    top: var(--ld-panel-top, 60px);
     left: var(--ld-panel-left, 0px);
-    right: 0;
-    bottom: var(--ld-strip-h, 0px);
+    right: var(--ld-panel-right, 0px);
+    bottom: var(--ld-panel-bottom, 0px);
     width: auto;
     height: auto;
-    border-left: 1px solid var(--dash-border);
+    /* The panel *is* the surface — no scrim, the board stays legible. */
+    background: none;
+    backdrop-filter: none;
+    transition: left 160ms ease;
+  }
+  .live-dash .dashboard-modal-overlay.docked.expanded {
+    left: var(--ld-panel-left-wide, 0px);
+  }
+
+  /* Undocked panels (the auth gates, `dock={false}`) still cover the board
+     below the top bar — an unlock prompt isn't something to work beside. */
+  .live-dash .dashboard-modal-overlay:not(.docked):not(.mobile) {
+    top: var(--ld-panel-top, 60px);
+    left: 0;
+    right: 0;
+    bottom: var(--ld-panel-bottom, 0px);
+    width: auto;
+    height: auto;
+  }
+
+  /* Docked panels wear the same chrome as the cards they stand in for. */
+  .live-dash .modal-container.docked {
+    border: 1px solid var(--dash-border);
+    border-radius: 12px;
+    background: var(--dash-surface);
+  }
+  .live-dash .modal-header.docked {
+    border-bottom: 1px solid var(--dash-border);
+    background: none;
+    padding: 0.7rem 0.5rem 0.7rem 1rem;
+    gap: 0.5rem;
+  }
+  .live-dash .modal-header.docked .modal-title {
+    font-size: 12.5px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--dash-text-muted);
+  }
+  .live-dash .modal-body.docked {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    padding: 0.85rem 1rem;
   }
 }
+
+/* Expand / collapse control in a docked panel header.
+ * box-sizing + padding are explicit because index.css styles every bare
+ * <button> outside `.tw` (0.6em/1.2em padding on a content-box), and the icon
+ * needs its own dimensions or it collapses to zero width as a flex item. */
+.modal-expand {
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  margin-left: auto;
+  border: 1px solid var(--dash-border);
+  border-radius: 8px;
+  background: none;
+  color: var(--dash-text-muted);
+  cursor: pointer;
+}
+.modal-expand svg { flex: 0 0 auto; width: 16px; height: 16px; }
+.modal-expand:hover {
+  border-color: var(--dash-border-strong);
+  color: var(--dash-text);
+}
+.modal-header.docked .modal-close { margin-left: 0; }
 
 /* ---- Mobile ---- */
 @media (max-width: 768px) {

--- a/frontend/src/components/dashboard/topBarActions.jsx
+++ b/frontend/src/components/dashboard/topBarActions.jsx
@@ -25,6 +25,7 @@ import {
   CareTasksIcon,
   MessagesIcon,
   CameraIcon,
+  VitalsCaptureIcon,
 } from '../Icons';
 
 export function buildTopBarActions({
@@ -32,6 +33,9 @@ export function buildTopBarActions({
   hasCamera, modalOpen, handlers,
 }) {
   return [
+    // Capture leads: recording a vital set is the one action a caregiver takes
+    // at the bedside mid-shift, and it is allowed in monitoring mode.
+    { key: 'capture', label: 'Capture Vitals', icon: <VitalsCaptureIcon />, onClick: handlers.capture, active: modalOpen.capture, badge: 0 },
     { key: 'alerts', label: 'Alerts', icon: <MinimalistPulseOxIcon />, onClick: handlers.alerts, active: modalOpen.alerts, badge: pulseOxAlerts },
     { key: 'medications', label: 'Medications', icon: <MedicationIcon />, onClick: handlers.medications, active: modalOpen.medications, badge: medicationDueCount },
     { key: 'nutrition', label: 'Nutrition', icon: <NutritionIcon />, onClick: handlers.nutrition, active: modalOpen.nutrition, badge: nutritionDueCount },

--- a/frontend/src/contexts/ModalDockContext.jsx
+++ b/frontend/src/contexts/ModalDockContext.jsx
@@ -1,0 +1,43 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { createContext, useContext } from 'react';
+
+/* Docked-panel mode for ModalBase.
+ *
+ * On the live dashboard a menu opens as a panel over the cards column and can
+ * be expanded across the charts, instead of as a slab covering the board. That
+ * is a property of the *host*, not of any individual modal, and there are ten
+ * ModalBase call sites — so it travels by context rather than by threading a
+ * prop through AlertsModal, MedicationModal, HistoryModal and the rest.
+ *
+ * Outside a provider the default is inert, so every other ModalBase consumer
+ * (the PIN challenge, quick-add, the alert detail sheet) is untouched.
+ */
+const INERT = { docked: false, expanded: false, toggleExpand: null };
+
+const ModalDockContext = createContext(INERT);
+
+export function ModalDockProvider({ value, children }) {
+  return <ModalDockContext.Provider value={value}>{children}</ModalDockContext.Provider>;
+}
+
+export function useModalDock() {
+  return useContext(ModalDockContext);
+}
+
+export { INERT as INERT_DOCK };

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from "react";
 import DynamicVitalsCard from "../components/DynamicVitalsCard";
 import ModalBase from "../components/ModalBase";
 import SettingsForm from "../components/SettingsForm";
@@ -28,9 +28,12 @@ import {
   NutritionIcon,
   CareTasksIcon,
   MessagesIcon,
-  CameraIcon
+  CameraIcon,
+  VitalsCaptureIcon
 } from "../components/Icons";
 import TopBar from "../components/dashboard/TopBar";
+import CaptureVitalsModal from "../components/dashboard/CaptureVitalsModal";
+import { ModalDockProvider } from "../contexts/ModalDockContext";
 import { buildTopBarActions } from "../components/dashboard/topBarActions";
 import StatTile from "../components/dashboard/StatTile";
 import LiveCharts from "../components/dashboard/LiveCharts";
@@ -38,6 +41,7 @@ import StatusStrip from "../components/dashboard/StatusStrip";
 import useLiveVitalsBuffer from "../hooks/useLiveVitalsBuffer";
 import config from '../config';
 import "../components/dashboard/live-dashboard.css";
+import "../components/dashboard/dock-panel.css";
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Alert } from '@/components/ui/alert';
@@ -151,7 +155,11 @@ export default function Dashboard() {
   const [isCareTaskModalOpen, setIsCareTaskModalOpen] = useState(false);
   const [isMessagesModalOpen, setIsMessagesModalOpen] = useState(false);
   const [isCameraModalOpen, setIsCameraModalOpen] = useState(false);
+  const [isCaptureModalOpen, setIsCaptureModalOpen] = useState(false);
   const [hasCamera, setHasCamera] = useState(false);
+  // Docked panels open on the narrow stop (over the cards column) and expand
+  // over the charts on request; every open starts narrow again.
+  const [panelExpanded, setPanelExpanded] = useState(false);
   const [isAlarmActive, setIsAlarmActive] = useState(false);
   const [isAlarmBlinking, setIsAlarmBlinking] = useState(false);
   const alarmBlinkInterval = useRef(null);
@@ -175,42 +183,67 @@ export default function Dashboard() {
     return () => root.style.setProperty('--auth-banner-height', '0px');
   }, [isMobile, authModalActive]);
 
-  // The dashboard modals dock against the live board rather than covering it,
-  // so the vitals stay readable while a panel is open. Publish the board's real
-  // geometry as CSS variables (see .live-dash .dashboard-modal-overlay in
-  // live-dashboard.css) — the left column is a grid `minmax(230px, 320px)`, so
-  // there is no viewport-relative constant that stays correct at every width.
+  // Menus open as a panel docked into the board, not a slab over it, so the
+  // vitals stay readable. Two stops: narrow sits exactly on the cards column,
+  // expanded also takes the charts. Both are measured rather than written as
+  // vw constants — the columns are a grid (`minmax(230px, 320px)` /
+  // `minmax(300px, 400px)`), so no viewport fraction is right at every width.
+  // Consumed by .live-dash .dashboard-modal-overlay in live-dashboard.css.
+  //
+  // Written to <html>, not to the board element: the capture panel's entry
+  // sheet portals to <body>, outside the board, and still has to line up with
+  // the panel. The board fills the viewport, so its offsets are the viewport's.
   const boardRef = useRef(null);
   useLayoutEffect(() => {
     const root = boardRef.current;
     if (!root) return undefined;
+    const target = document.documentElement;
 
     const measure = () => {
       const topbar = root.querySelector('.ld-topbar');
       const main = root.querySelector('.ld-main');
-      const tiles = root.querySelector('.ld-tiles');
+      const charts = root.querySelector('.ld-charts');
+      const cards = root.querySelector('.ld-cards');
       const strip = root.querySelector('.ld-strip');
+      const set = (name, px) => target.style.setProperty(name, `${Math.round(px)}px`);
+      const board = root.getBoundingClientRect();
 
-      root.style.setProperty('--ld-topbar-h', `${Math.round(topbar?.offsetHeight ?? 60)}px`);
-      root.style.setProperty('--ld-strip-h', `${Math.round(strip?.offsetHeight ?? 0)}px`);
-
-      // Locked (unauthenticated) shows a single centred column, so there is
-      // nothing to dock beside — let the unlock panel cover the whole board.
-      if (!main || !tiles || main.classList.contains('locked')) {
-        root.style.setProperty('--ld-panel-left', '0px');
+      // Fallback: locked (single centred column) and any state without the
+      // charts/cards columns has nothing to dock beside, so the panel takes
+      // the whole board below the top bar.
+      if (!main || !charts || !cards) {
+        set('--ld-panel-top', topbar?.offsetHeight ?? 60);
+        set('--ld-panel-bottom', strip?.offsetHeight ?? 0);
+        set('--ld-panel-left', 0);
+        set('--ld-panel-left-wide', 0);
+        set('--ld-panel-right', 0);
         return;
       }
-      const gap = parseFloat(getComputedStyle(main).columnGap) || 0;
-      const left = tiles.getBoundingClientRect().right - root.getBoundingClientRect().left + gap;
-      root.style.setProperty('--ld-panel-left', `${Math.round(left)}px`);
+
+      const chartsBox = charts.getBoundingClientRect();
+      const cardsBox = cards.getBoundingClientRect();
+      // Anchor to the grid's content box so the panel sits inside the board's
+      // padding like the cards it replaces, rather than bleeding to the edge.
+      set('--ld-panel-top', chartsBox.top - board.top);
+      set('--ld-panel-bottom', board.bottom - chartsBox.bottom);
+      set('--ld-panel-right', board.right - cardsBox.right);
+      set('--ld-panel-left', cardsBox.left - board.left);
+      set('--ld-panel-left-wide', chartsBox.left - board.left);
     };
 
     measure();
     const observer = new ResizeObserver(measure);
-    [root, root.querySelector('.ld-topbar'), root.querySelector('.ld-tiles'), root.querySelector('.ld-strip')]
+    ['.ld-topbar', '.ld-tiles', '.ld-charts', '.ld-cards', '.ld-strip']
+      .map(sel => root.querySelector(sel))
+      .concat(root)
       .filter(Boolean)
       .forEach(el => observer.observe(el));
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      ['--ld-panel-top', '--ld-panel-bottom', '--ld-panel-left',
+        '--ld-panel-left-wide', '--ld-panel-right']
+        .forEach(name => target.style.removeProperty(name));
+    };
     // Re-measure when the board's structure changes (lock state adds/removes
     // the charts and cards columns, which resizes the tiles column).
   }, [needsUnlock, isMobile]);
@@ -708,7 +741,10 @@ export default function Dashboard() {
     setIsCareTaskModalOpen(false);
     setIsMessagesModalOpen(false);
     setIsCameraModalOpen(false);
+    setIsCaptureModalOpen(false);
     setIsMobileMenuOpen(false);
+    // Each panel opens at the narrow stop; expanding is a per-visit choice.
+    setPanelExpanded(false);
   };
 
   // Open a specific top-nav modal after user selection redirect
@@ -839,6 +875,13 @@ export default function Dashboard() {
     setIsNutritionModalOpen(true);
   };
 
+  const handleCaptureClick = async () => {
+    if (isCaptureModalOpen) { setIsCaptureModalOpen(false); return; }
+    if (!(await requireUnlockAndFreshUser())) return;
+    closeAllModals();
+    setIsCaptureModalOpen(true);
+  };
+
   // Add this function to handle alert acknowledgment
   const handleAlertAcknowledged = () => {
     fetch(`${config.apiUrl}/api/monitoring/alerts/count`, { credentials: 'include' })
@@ -908,21 +951,32 @@ export default function Dashboard() {
     modalOpen: {
       alerts: isPulseOxModalOpen, medications: isMedicationModalOpen, nutrition: isNutritionModalOpen,
       careTasks: isCareTaskModalOpen, equipment: isVentModalOpen, history: isHistoryModalOpen,
-      camera: isCameraModalOpen, messages: isMessagesModalOpen,
+      camera: isCameraModalOpen, messages: isMessagesModalOpen, capture: isCaptureModalOpen,
     },
     handlers: {
       alerts: handlePulseOxClick, medications: handleMedicationClick, nutrition: handleNutritionClick,
       careTasks: handleCareTaskClick, equipment: handleVentClick, history: handleHistoryClick,
-      camera: handleCameraClick, messages: handleMessagesClick,
+      camera: handleCameraClick, messages: handleMessagesClick, capture: handleCaptureClick,
     },
   });
 
+  // Panels dock into the board on desktop; mobile keeps the full-screen sheet.
+  const modalDock = useMemo(() => ({
+    docked: !isMobile,
+    expanded: panelExpanded,
+    toggleExpand: () => setPanelExpanded(v => !v),
+  }), [isMobile, panelExpanded]);
+
   return (
+    <ModalDockProvider value={modalDock}>
     <div className="dashboard-wrapper force-dark live-dash" ref={boardRef}>
+      {/* Auth gates take the whole board rather than docking beside it — an
+          unlock prompt is not something to work alongside. */}
       <ModalBase
         isOpen={unlockModalOpen}
         onClose={() => { if (!needsUnlock) setActionUnlockOpen(false); }}
         title="Unlock"
+        dock={false}
       >
         <form onSubmit={handleUnlockSubmit} className="tw">
           <div className="flex flex-col gap-3">
@@ -953,6 +1007,7 @@ export default function Dashboard() {
         isOpen={!unlockModalOpen && showPatientModal}
         onClose={() => { if (selectedPatient) setShowPatientModal(false); }}
         title="Select Patient"
+        dock={false}
       >
         {loadingPatients ? (
           <div>Loading patients…</div>
@@ -1013,6 +1068,13 @@ export default function Dashboard() {
       {isMobile && isMobileMenuOpen && (
         <div className="mobile-menu-overlay" onClick={() => setIsMobileMenuOpen(false)}>
           <div className="mobile-menu" onClick={(e) => e.stopPropagation()}>
+            {/* Mirrors buildTopBarActions' order — this list is hand-written
+                because the drawer shows labels, not icon buttons. */}
+            <div className="mobile-menu-item" onClick={() => { handleCaptureClick(); setIsMobileMenuOpen(false); }}>
+              <VitalsCaptureIcon size={24} />
+              <span>Capture Vitals</span>
+            </div>
+
             <div className="mobile-menu-item" onClick={() => { handlePulseOxClick(); setIsMobileMenuOpen(false); }}>
               <MinimalistPulseOxIcon />
               <span>Alerts</span>
@@ -1225,6 +1287,19 @@ export default function Dashboard() {
       {isCareTaskModalOpen && (
         <CareTaskModal onClose={() => setIsCareTaskModalOpen(false)} />
       )}
+
+      {/* Capture Vitals — the live SpO2/HR are offered as a connected
+          snapshot, so they are read straight off the board's sensor state. */}
+      {isCaptureModalOpen && selectedPatient?.id && (
+        <CaptureVitalsModal
+          patient={selectedPatient}
+          sensorValues={sensorValues}
+          streaming={buffer.streaming.status === 'streaming'}
+          onClose={() => setIsCaptureModalOpen(false)}
+          onSaved={() => { reloadChart1(); reloadChart2(); }}
+        />
+      )}
     </div>
+    </ModalDockProvider>
   );
 }

--- a/frontend/src/pages/capture/CaptureVitalsPanel.jsx
+++ b/frontend/src/pages/capture/CaptureVitalsPanel.jsx
@@ -41,9 +41,33 @@ function encounterLabel(startedAt) {
   return `${d.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' })} · ${d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`;
 }
 
-export default function CaptureVitalsPanel({ patient, connection, embedded = false }) {
+// <input type="datetime-local"> wants local wall-clock with no zone, so the
+// ISO string has to be shifted out of UTC before slicing.
+function toLocalInput(iso) {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+}
+
+/* Vitals the connected oximeter can supply, in the order the panel shows them.
+ * Keyed to BUILTIN_CONFIGS; `read` pulls the value off the board's live
+ * sensor state. */
+const SNAPSHOT_VITALS = [
+  { key: 'spo2', read: (s) => s.spo2 },
+  { key: 'heart_rate', read: (s) => s.bpm },
+];
+
+export default function CaptureVitalsPanel({
+  patient,
+  connection,
+  embedded = false,
+  layout = 'grid',
+  snapshot = null,
+  onSaved,
+}) {
   const patientId = patient.id;
   const { connected, markSuccess } = connection;
+  const rows = layout === 'rows';
 
   const [customDefs, setCustomDefs] = useState([]);
   const [ranges, setRanges] = useState([]);
@@ -54,6 +78,13 @@ export default function CaptureVitalsPanel({ patient, connection, embedded = fal
   const [justSaved, setJustSaved] = useState([]);
   const [saving, setSaving] = useState(false);
   const toastTimer = useRef(null);
+  // Row layout extras (mirrors the bedside panel design): a set-level time
+  // override for readings taken a few minutes ago, and a note carried onto
+  // every reading in the encounter.
+  const [timeOverride, setTimeOverride] = useState(null);
+  const [editingTime, setEditingTime] = useState(false);
+  const [note, setNote] = useState('');
+  const [editingNote, setEditingNote] = useState(false);
 
   const configs = useMemo(() => buildConfigs(customDefs), [customDefs]);
 
@@ -106,6 +137,26 @@ export default function CaptureVitalsPanel({ patient, connection, embedded = fal
     setOpenVital(null);
   };
 
+  // Accept a live oximeter value into the encounter. Recorded with
+  // source 'pulse_ox' — the record must not claim someone typed it, and the
+  // backend keys the SpO2 LOINC code off exactly this distinction.
+  const acceptSnapshot = (vitalKey, value, unit) => {
+    setEncounter((prev) => {
+      const next = {
+        ...prev,
+        readings: {
+          ...prev.readings,
+          [vitalKey]: {
+            vitalKey, value, unit, source: 'pulse_ox',
+            measuredAt: new Date().toISOString(),
+          },
+        },
+      };
+      saveDraft(patientId, next);
+      return next;
+    });
+  };
+
   const removeReading = (vitalKey) => {
     setEncounter((prev) => {
       const readings = { ...prev.readings };
@@ -130,9 +181,12 @@ export default function CaptureVitalsPanel({ patient, connection, embedded = fal
           ? { systolic: r.systolic, diastolic: r.diastolic }
           : { value: r.value }),
         unit: r.unit,
-        measured_at: r.measuredAt,
-        source: 'manual',
+        // A set-level time override wins: the caregiver is stating when the
+        // readings were actually taken, not when they typed them in.
+        measured_at: timeOverride || r.measuredAt,
+        source: r.source === 'pulse_ox' ? 'pulse_ox' : 'manual',
         confirmed_against_warning: Boolean(r.confirmedAgainstWarning),
+        ...(note.trim() ? { note: note.trim() } : {}),
       }));
     try {
       const resp = await apiFetch(`${config.apiUrl}/api/vitals/capture`, {
@@ -151,9 +205,13 @@ export default function CaptureVitalsPanel({ patient, connection, embedded = fal
         clearDraft(patientId);
         markSuccess();
         setEncounter(newEncounter());
+        setTimeOverride(null);
+        setNote('');
+        setEditingNote(false);
         setJustSaved(savedKeys);
         setTimeout(() => setJustSaved([]), 4000);
         showToast(`Vitals saved · ${savedKeys.length} reading${savedKeys.length === 1 ? '' : 's'}`);
+        if (onSaved) onSaved(savedKeys);
       } else if (resp.status === 409 || resp.status === 422) {
         // Server ranges disagreed with ours (stale client). Reopen the first
         // offending vital so the caregiver sees the server's range.
@@ -180,6 +238,18 @@ export default function CaptureVitalsPanel({ patient, connection, embedded = fal
     }
   };
 
+  // Throw away the in-progress encounter (distinct from the resume banner's
+  // Discard, which drops a draft from a *previous* sitting).
+  const clearEncounter = () => {
+    clearDraft(patientId);
+    setEncounter(newEncounter());
+    setTimeOverride(null);
+    setEditingTime(false);
+    setNote('');
+    setEditingNote(false);
+    setOpenVital(null);
+  };
+
   const resumeDraft = () => {
     setEncounter(resumable);
     setResumable(null);
@@ -199,6 +269,25 @@ export default function CaptureVitalsPanel({ patient, connection, embedded = fal
   const counter = `${readingCount} of ${configs.length} recorded` +
     (requiredKeys.length > 0 && allRequiredDone ? ' · All required complete' : '');
   const remaining = configs.length - readingCount;
+
+  // Row layout splits the list the way the bedside does: what the connected
+  // oximeter can answer for, and what a person has to measure.
+  const snapshotKeys = snapshot ? SNAPSHOT_VITALS.map((s) => s.key) : [];
+  const snapshotConfigs = snapshot
+    ? SNAPSHOT_VITALS
+        .map((s) => ({ config: configs.find((c) => c.key === s.key), live: s.read(snapshot.values || {}) }))
+        .filter((s) => s.config)
+    : [];
+  const manualConfigs = configs.filter((c) => !snapshotKeys.includes(c.key));
+  // Say which of the three situations we're in rather than only "offline":
+  // a stalled probe still shows its last values, and accepting one of those
+  // silently would be the wrong kind of quiet.
+  const hasLive = snapshotConfigs.some((s) => s.live != null);
+  const snapshotCaption = !hasLive
+    ? 'Pulse ox offline — enter these by hand'
+    : snapshot.streaming
+      ? 'From the pulse ox at encounter time'
+      : 'Pulse ox not streaming — these may be stale';
 
   return (
     <>
@@ -227,22 +316,122 @@ export default function CaptureVitalsPanel({ patient, connection, embedded = fal
       )}
 
       <div className="vc-encounter vc-label">
-        <span>Encounter</span>
-        <span>{encounterLabel(encounter.startedAt)}</span>
+        <span>{rows && !timeOverride ? 'Now' : 'Encounter'}</span>
+        <span>{encounterLabel(timeOverride || encounter.startedAt)}</span>
+        {rows && (
+          <button
+            type="button"
+            className="vc-linklike vc-encounter-edit"
+            onClick={() => setEditingTime((v) => !v)}
+            aria-expanded={editingTime}
+          >
+            {editingTime ? 'Done' : 'Edit time'}
+          </button>
+        )}
         {embedded && <ConnectionChip connection={connection} />}
       </div>
 
-      <div className="vc-grid">
-        {configs.map((c) => (
-          <VitalTile
-            key={c.key}
-            config={c}
-            reading={encounter.readings[c.key]}
-            justSaved={justSaved.includes(c.key)}
-            onOpen={() => setOpenVital(c.key)}
+      {rows && editingTime && (
+        <div className="vc-encounter-time">
+          <label className="vc-caption" htmlFor="vc-measured-at">
+            When were these taken?
+          </label>
+          <input
+            id="vc-measured-at"
+            type="datetime-local"
+            className="vc-text-input"
+            value={toLocalInput(timeOverride || encounter.startedAt)}
+            max={toLocalInput(new Date().toISOString())}
+            onChange={(e) => setTimeOverride(
+              e.target.value ? new Date(e.target.value).toISOString() : null)}
           />
-        ))}
-      </div>
+          {timeOverride && (
+            <button type="button" className="vc-linklike" onClick={() => setTimeOverride(null)}>
+              Reset to now
+            </button>
+          )}
+        </div>
+      )}
+
+      {rows ? (
+        <>
+          {snapshotConfigs.length > 0 && (
+            <>
+              <div className="vc-section vc-label">
+                <span>Connected snapshot</span>
+                <span className="vc-caption">{snapshotCaption}</span>
+              </div>
+              <div className="vc-rows">
+                {snapshotConfigs.map(({ config: c, live }) => (
+                  <VitalTile
+                    key={c.key}
+                    config={c}
+                    reading={encounter.readings[c.key]}
+                    justSaved={justSaved.includes(c.key)}
+                    onOpen={() => setOpenVital(c.key)}
+                    row
+                    liveValue={live}
+                    onAcceptLive={live == null
+                      ? null
+                      : () => acceptSnapshot(c.key, live, c.unit)}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+          <div className="vc-section vc-label">
+            <span>{snapshotConfigs.length > 0 ? 'Manual readings' : 'Readings'}</span>
+          </div>
+          <div className="vc-rows">
+            {manualConfigs.map((c) => (
+              <VitalTile
+                key={c.key}
+                config={c}
+                reading={encounter.readings[c.key]}
+                justSaved={justSaved.includes(c.key)}
+                onOpen={() => setOpenVital(c.key)}
+                row
+              />
+            ))}
+          </div>
+        </>
+      ) : (
+        <div className="vc-grid">
+          {configs.map((c) => (
+            <VitalTile
+              key={c.key}
+              config={c}
+              reading={encounter.readings[c.key]}
+              justSaved={justSaved.includes(c.key)}
+              onOpen={() => setOpenVital(c.key)}
+            />
+          ))}
+        </div>
+      )}
+
+      {rows && (
+        <div className="vc-note">
+          {editingNote || note ? (
+            <>
+              <label className="vc-caption" htmlFor="vc-note">Note for this set</label>
+              <textarea
+                id="vc-note"
+                className="vc-text-input"
+                rows={2}
+                value={note}
+                maxLength={500}
+                placeholder="Context that applies to all readings — position, activity, device…"
+                onChange={(e) => setNote(e.target.value)}
+              />
+            </>
+          ) : (
+            <button type="button" className="vc-note-add" onClick={() => setEditingNote(true)}>
+              <span>Add note</span>
+              <span aria-hidden="true">›</span>
+            </button>
+          )}
+        </div>
+      )}
 
       <div className="vc-footer">
         <div className="vc-progress" aria-live="polite">{counter}</div>
@@ -266,6 +455,16 @@ export default function CaptureVitalsPanel({ patient, connection, embedded = fal
         >
           {saving ? 'Saving…' : 'Save vitals'}
         </button>
+        {rows && (
+          <button
+            type="button"
+            className="vc-btn secondary vc-clear"
+            disabled={readingCount === 0 && !note && !timeOverride}
+            onClick={clearEncounter}
+          >
+            Clear draft
+          </button>
+        )}
       </div>
 
       {openConfig && (

--- a/frontend/src/pages/capture/CaptureVitalsPanel.jsx
+++ b/frontend/src/pages/capture/CaptureVitalsPanel.jsx
@@ -140,16 +140,18 @@ export default function CaptureVitalsPanel({
   // Accept a live oximeter value into the encounter. Recorded with
   // source 'pulse_ox' — the record must not claim someone typed it, and the
   // backend keys the SpO2 LOINC code off exactly this distinction.
+  //
+  // Stamped with the time the snapshot was *taken*, not the time it was
+  // accepted: the value was frozen when the panel opened, so if the panel has
+  // been sitting open the click time would attribute an older reading to now.
   const acceptSnapshot = (vitalKey, value, unit) => {
+    const measuredAt = snapshot?.at || new Date().toISOString();
     setEncounter((prev) => {
       const next = {
         ...prev,
         readings: {
           ...prev.readings,
-          [vitalKey]: {
-            vitalKey, value, unit, source: 'pulse_ox',
-            measuredAt: new Date().toISOString(),
-          },
+          [vitalKey]: { vitalKey, value, unit, source: 'pulse_ox', measuredAt },
         },
       };
       saveDraft(patientId, next);

--- a/frontend/src/pages/capture/capture.css
+++ b/frontend/src/pages/capture/capture.css
@@ -648,3 +648,198 @@
   .vc-toast { animation: vc-fade-in 1ms linear; }
   .vc-caret { animation: none; }
 }
+
+/* ---- Docked in the live dashboard --------------------------------------
+ * Third shell (components/dashboard/CaptureVitalsModal). The panel stands in
+ * the board's cards column, so it is narrower than the phone surface and the
+ * admin embed: the two-up tile grid becomes a list, and the vitals split into
+ * what the connected oximeter answers for and what a person measures.
+ * The panel body already supplies the card chrome, so no border here. */
+.vitals-capture.vc-docked {
+  min-height: 0;
+  max-width: none;
+  background: none;
+  gap: 0;
+}
+.vitals-capture.vc-docked .vc-encounter,
+.vitals-capture.vc-docked .vc-resume { margin-left: 0; margin-right: 0; }
+.vitals-capture.vc-docked .vc-rows { padding: 0; }
+.vitals-capture.vc-docked .vc-footer { padding: 0.75rem 0 0; }
+
+/* Section headings inside the docked panel */
+.vc-section {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0.9rem 0 0.45rem;
+}
+.vc-section:first-child { margin-top: 0.25rem; }
+.vc-section .vc-caption { text-transform: none; letter-spacing: 0.02em; }
+
+/* Row layout: label + value on one line, provenance under it. */
+.vc-rows { display: flex; flex-direction: column; gap: 0.4rem; }
+.vc-tile-wrap {
+  display: flex;
+  align-items: stretch;
+  gap: 0.4rem;
+  min-width: 0;
+}
+.vc-tile-wrap > .vc-tile { flex: 1; min-width: 0; }
+.vc-tile.row {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  row-gap: 0.15rem;
+  column-gap: 0.6rem;
+  padding: 0.55rem 0.7rem;
+}
+.vc-tile.row .vc-tile-head {
+  grid-column: 1;
+  grid-row: 1;
+  justify-content: flex-start;
+  gap: 0.4rem;
+}
+.vc-tile.row .vc-tile-head .vc-label { font-size: 11px; }
+.vc-tile.row .vc-tile-value {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  font-size: 26px;
+  justify-self: end;
+  white-space: nowrap;
+}
+.vc-tile.row .vc-tile-value.bp { font-size: 22px; }
+.vc-tile.row .vc-tile-value.empty { font-size: 18px; }
+.vc-tile.row .vc-tile-provenance { grid-column: 1; grid-row: 2; font-size: 9.5px; }
+
+/* "Use live" — accept the oximeter's current reading instead of typing it.
+   Sits beside the row so the recorded state stays a single tap away. */
+.vc-tile-accept {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.1rem;
+  min-width: 82px;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--vc-data-live);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--vc-data-live) 14%, transparent);
+  color: var(--vc-text-primary);
+  cursor: pointer;
+}
+.vc-tile-accept:hover {
+  background: color-mix(in srgb, var(--vc-data-live) 24%, transparent);
+  border-color: var(--vc-data-live);
+}
+.vc-tile-accept-value {
+  font-family: var(--vc-font-mono);
+  font-size: 19px;
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.vc-tile-accept-value .vc-unit { font-size: 10px; margin-left: 2px; }
+.vc-tile-accept-hint {
+  font-family: var(--vc-font-mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-data-live);
+}
+
+/* The docked panel's title carries the connection chip. */
+.ld-capture-title { display: flex; align-items: center; gap: 0.6rem; min-width: 0; }
+
+/* The entry sheet and toast portal to <body>, so they can't inherit the docked
+   panel's bounds — the live dashboard publishes them on <html> (see
+   Dashboard.jsx) and flags the mode on <body>. Without this the sheet slides
+   up from the middle of a 1920px screen while the panel sits on the right. */
+body.ld-capture-docked .vc-sheet,
+body.ld-capture-docked .vc-sheet-overlay {
+  left: var(--ld-panel-left, 0px);
+  right: var(--ld-panel-right, 0px);
+  max-width: none;
+  margin: 0;
+}
+body.ld-capture-docked.ld-capture-wide .vc-sheet,
+body.ld-capture-docked.ld-capture-wide .vc-sheet-overlay {
+  left: var(--ld-panel-left-wide, 0px);
+}
+body.ld-capture-docked .vc-sheet {
+  bottom: var(--ld-panel-bottom, 0px);
+  border-radius: 12px 12px 0 0;
+}
+body.ld-capture-docked .vc-sheet-overlay {
+  top: var(--ld-panel-top, 0px);
+  bottom: var(--ld-panel-bottom, 0px);
+}
+body.ld-capture-docked .vc-toast {
+  left: var(--ld-panel-left, 0px);
+  right: var(--ld-panel-right, 0px);
+  transform: none;
+  justify-content: center;
+  margin: 0 auto;
+  width: max-content;
+  max-width: none;
+}
+body.ld-capture-docked.ld-capture-wide .vc-toast { left: var(--ld-panel-left-wide, 0px); }
+
+/* Set-level time override and note (row layout only) */
+.vc-encounter-edit { margin-left: auto; }
+.vitals-capture.vc-docked .vc-encounter .vc-chip { margin-left: 0.5rem; }
+.vc-encounter-time {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 0.5rem 0 0;
+}
+.vc-note { margin-top: 0.9rem; display: flex; flex-direction: column; gap: 0.35rem; }
+.vc-note-add {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.vc-note-add:hover { border-color: var(--vc-line-strong); color: var(--vc-text-primary); }
+.vc-text-input {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 40px;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  background: var(--vc-bg-base);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  letter-spacing: 0.03em;
+  resize: vertical;
+}
+.vc-text-input:focus {
+  outline: none;
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 1px var(--vc-data-live);
+}
+
+/* The save actions sit at the bottom of a short panel rather than floating
+   under the last row; `min-height: 100%` gives `margin-top: auto` something to
+   push against, and taller content simply scrolls the panel body instead. */
+.vitals-capture.vc-docked { display: flex; flex-direction: column; min-height: 100%; }
+.vitals-capture.vc-docked .vc-footer { margin-top: auto; padding-bottom: 0; }
+.vitals-capture.vc-docked .vc-clear { width: 100%; min-height: 42px; }

--- a/frontend/src/pages/capture/components/VitalTile.jsx
+++ b/frontend/src/pages/capture/components/VitalTile.jsx
@@ -18,21 +18,30 @@
 // One vital card. Recorded state is carried by BOTH color and shape:
 // solid check = recorded, dotted ring = not recorded. Provenance shows on
 // every recorded tile (SOURCE • time), per the spec's consistency rule.
+//
+// `row` switches to the list layout used by the live dashboard's docked panel
+// (a side panel is too narrow for the two-up card grid). `liveValue` /
+// `onAcceptLive` add the connected-oximeter affordance: a reading the
+// caregiver accepts rather than types, recorded as source 'pulse_ox'.
 import { CheckCircleIcon } from '../../../components/Icons';
+
+const SOURCE_LABEL = { pulse_ox: 'Pulse ox', manual: 'Manual' };
 
 function provenanceLabel(reading) {
   const t = new Date(reading.measuredAt)
     .toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-  return `Manual · ${t}`;
+  return `${SOURCE_LABEL[reading.source] || 'Manual'} · ${t}`;
 }
 
-export default function VitalTile({ config, reading, justSaved, onOpen }) {
+export default function VitalTile({ config, reading, justSaved, onOpen, row = false, liveValue = null, onAcceptLive = null }) {
   const recorded = Boolean(reading);
   const isBP = config.key === 'blood_pressure';
-  return (
+  const offerLive = !recorded && liveValue != null && onAcceptLive;
+
+  const tile = (
     <button
       type="button"
-      className={`vc-tile ${justSaved ? 'just-saved' : ''}`}
+      className={`vc-tile ${row ? 'row' : ''} ${justSaved ? 'just-saved' : ''}`}
       onClick={onOpen}
       aria-label={recorded
         ? `${config.label}, recorded. Edit reading.`
@@ -56,5 +65,28 @@ export default function VitalTile({ config, reading, justSaved, onOpen }) {
         {recorded ? provenanceLabel(reading) : 'Not recorded'}
       </span>
     </button>
+  );
+
+  // Grid mode returns the bare tile so the phone and admin-embedded surfaces
+  // keep their existing grid-child structure untouched.
+  if (!row) return tile;
+
+  return (
+    <div className="vc-tile-wrap">
+      {tile}
+      {offerLive && (
+        <button
+          type="button"
+          className="vc-tile-accept"
+          onClick={onAcceptLive}
+          aria-label={`Record ${config.label} ${liveValue}${config.unit} from the pulse ox`}
+        >
+          <span className="vc-tile-accept-value">
+            {liveValue}<span className="vc-unit">{config.unit}</span>
+          </span>
+          <span className="vc-tile-accept-hint">Use live</span>
+        </button>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
**Stacked on #113** — merge that first; GitHub will retarget this to `dev/main` automatically.

## The flow

Menus no longer cover the board, they take a seat in it. A tap docks the panel onto the cards column's **exact footprint** and renders it in the narrow layout; the expand control widens it across the charts. Vitals tiles, top bar and status strip stay visible in both. Every open starts narrow — expanding is a per-visit choice.

Docking travels by **context, not by prop**. `ModalBase` has ten call sites and the behaviour belongs to the *host*, so `ModalDockContext` carries it and none of AlertsModal / MedicationModal / HistoryModal / the rest changed. Outside a provider the default is inert, so the PIN challenge, quick-add and alert-detail sheet are untouched. `dock={false}` opts out per modal — the unlock gate and patient picker still take the whole board, since an auth prompt isn't something to work beside.

The docked variant deliberately does **not** reuse `.mobile`: that class's container fixes (`100vw/100vh` → `100%`) live inside App.css's `max-width: 768px` query, so applying it at desktop width would size the panel to the viewport.

Geometry is measured, not assumed — the same ResizeObserver from #113 now publishes `--ld-panel-top/-bottom/-left/-left-wide/-right`, written to `<html>` rather than the board element because the capture panel's entry sheet portals to `<body>` and still has to line up.

## Capture Vitals

`CaptureVitalsPanel` is already the shared capture experience behind `/capture` (phone) and `/care/vitals` (admin embed), so this adds a **third shell, not a third implementation** — draft persistence, range warnings, custom vitals and the save endpoint all come along. New to the panel, additively (existing shells pass none of it and behave identically):

| prop | |
|---|---|
| `layout="rows"` | list layout for a ~400px column |
| `snapshot` | the board's live SpO2/HR, frozen at open |
| `onSaved` | so the dashboard's mini-charts refresh |

Plus, following the mockup: a set-level **time override**, a **note** carried onto every reading in the set (the API already had per-reading `note`), and **Clear draft** — distinct from the resume banner's Discard, which drops a *previous* sitting.

### The connected snapshot needed backend work to be honest

`CaptureReading` accepted `source: Literal['manual']` only, and `save_capture_reading` hardcoded `'manual'` — so a reading accepted from the oximeter could only be stored as if someone had typed it. Widened to `Literal['manual', 'pulse_ox']` and threaded through. `terminology.loinc_for()` already keyed the SpO2 code off exactly this distinction, so device readings now correctly get **59408-5** (pulse oximetry) rather than 2708-6 (generic arterial). Verified end to end — the row lands with `source=pulse_ox`, `code=59408-5`.

That turned up a related bug: `GET /api/vitals/patient/{id}` hardcoded `'source': 'manual'` in its response. Harmless when manual was the only capture source, a misreport now. It reports the stored value.

The snapshot caption distinguishes three states rather than just "offline" — streaming, stalled-with-stale-values, and nothing to offer. Accepting a stale reading silently would be the wrong kind of quiet.

Capture is reachable from the top-bar action row and the mobile drawer (a separate hand-written list). **The top bar is otherwise untouched** — the streaming chip and badge treatment from the mockups are for a later pass, per your call.

## Narrow-stop reflow

`dock-panel.css` fixes what the narrow stop would otherwise break, most of it because those sections' responsive rules are *viewport* media queries that don't fire for a 380px panel on a 1920px screen. The real one: History's 4-column table sat in an `overflow: hidden` container and simply lost its right-hand columns.

Container queries were avoided on purpose — `container-type` also makes the element a containing block for `position: fixed` descendants, and the alert-detail sheet depends on fixed-to-viewport positioning.

Left alone: Settings' two hard `1fr 1fr` field grids and the Alerts history row grid. Cramped but usable, and reaching them would need blanket inline-style attribute selectors that fire on unrelated rows. They get fixed when those sections are rebuilt.

## Verification

- 1920×1080: narrow lands within 1px of the cards column; expanded within 1px of charts-left → cards-right; collapse returns; entry sheet tracks the panel band instead of the screen centre
- Mobile 390×844 unchanged — full-screen sheet, no expand control
- 385 frontend tests (40 files, 10 new), 585 backend tests (3 new), lint and build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011u7gjNWppXao35QPLtBBQe