### PR TITLE
Medications: one schedule, two dock sizes

### DIFF
--- a/backend/crud/medications.py
+++ b/backend/crud/medications.py
@@ -1079,8 +1079,10 @@ def get_medication_history(db: Session, limit=25, medication_name=None, start_da
             query = query.filter(MedicationLog.patient_id == patient_id)
         
         # Filter to one medication by id (exact; see the docstring on why this
-        # is not the same as filtering by name)
-        if medication_id:
+        # is not the same as filtering by name). Explicit None check rather
+        # than truthiness — the parameter is Optional[int], and "not provided"
+        # is the only case that should skip the filter.
+        if medication_id is not None:
             query = query.filter(MedicationLog.medication_id == medication_id)
 
         # Filter by medication name (partial match, case insensitive)

--- a/backend/crud/medications.py
+++ b/backend/crud/medications.py
@@ -251,7 +251,8 @@ def delete_medication(db: Session, med_id):
         return False
 
 
-def administer_medication(db: Session, med_id, dose_amount, schedule_id=None, scheduled_time=None, notes=None, patient_id=None, administered_at=None):
+def administer_medication(db: Session, med_id, dose_amount, schedule_id=None, scheduled_time=None,
+                          notes=None, patient_id=None, administered_at=None, administered_by=None):
     try:
         med = db.query(Medication).filter(Medication.id == med_id).first()
         if not med or med.quantity is None or dose_amount is None:
@@ -342,6 +343,10 @@ def administer_medication(db: Session, med_id, dose_amount, schedule_id=None, sc
             scheduled_time=scheduled_time,
             administered_early=administered_early,
             administered_late=administered_late,
+            # Who gave the dose. The column has existed since the initial
+            # migration but nothing ever wrote it, so `completed_by` came back
+            # None for every medication while care tasks recorded it properly.
+            administered_by=administered_by,
             notes=notes,
             created_at=now
         )
@@ -1046,7 +1051,7 @@ def get_medication_schedule_counts(db: Session, patient_id=None, tz=None):
         return {'due': 0, 'overdue': 0}
 
 
-def get_medication_history(db: Session, limit=25, medication_name=None, start_date=None, end_date=None, status_filter=None, patient_id=None):
+def get_medication_history(db: Session, limit=25, medication_name=None, start_date=None, end_date=None, status_filter=None, patient_id=None, medication_id=None):
     """
     Get medication administration history with filtering options
     
@@ -1058,6 +1063,9 @@ def get_medication_history(db: Session, limit=25, medication_name=None, start_da
         end_date: Filter by end date (YYYY-MM-DD format)  
         status_filter: Filter by status ('late', 'early', 'skipped', 'on-time')
         patient_id: Filter by patient ID
+        medication_id: Filter to exactly one medication. Prefer this over
+            medication_name when the caller already knows the id — the name
+            filter is a substring match, so 'Pro' also returns Propranolol.
     
     Returns:
         List of medication administration records with related data
@@ -1070,6 +1078,11 @@ def get_medication_history(db: Session, limit=25, medication_name=None, start_da
         if patient_id:
             query = query.filter(MedicationLog.patient_id == patient_id)
         
+        # Filter to one medication by id (exact; see the docstring on why this
+        # is not the same as filtering by name)
+        if medication_id:
+            query = query.filter(MedicationLog.medication_id == medication_id)
+
         # Filter by medication name (partial match, case insensitive)
         if medication_name:
             query = query.filter(Medication.name.ilike(f'%{medication_name}%'))
@@ -1125,6 +1138,9 @@ def get_medication_history(db: Session, limit=25, medication_name=None, start_da
                 'scheduled_time': _utc_iso(log.scheduled_time),
                 'is_scheduled': log.is_scheduled,
                 'status': status,
+                # Now that administer paths write it, surface it — the dose
+                # detail pane shows who gave each dose.
+                'administered_by': log.administered_by,
                 'notes': log.notes,
                 'patient_id': log.patient_id,
                 'schedule_id': log.schedule_id,

--- a/backend/routes/medications.py
+++ b/backend/routes/medications.py
@@ -23,7 +23,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from typing import Optional, List
 from db import get_db
-from dependencies import require_read_access
+from dependencies import require_read_access, get_current_user
 from models.medications import (
     MedicationCreate,
     MedicationUpdate,
@@ -333,7 +333,9 @@ async def toggle_medication_active_endpoint(med_id: int, db: Session = Depends(g
 
 
 @router.post("/medications/{med_id}/administer")
-async def administer_medication_endpoint(med_id: int, data: MedicationAdminister, db: Session = Depends(get_db)):
+async def administer_medication_endpoint(med_id: int, data: MedicationAdminister,
+                                         db: Session = Depends(get_db),
+                                         current_user=Depends(get_current_user)):
     """Record a medication administration and deduct from quantity. Pass patient_id when administering a patient-specific medication without a global current patient."""
     # A dose can't be given in the future — reject an administered_at past now
     # (catches the date-left-on-today slip). Not overridable.
@@ -357,6 +359,7 @@ async def administer_medication_endpoint(med_id: int, data: MedicationAdminister
         result = administer_medication(
             db, med_id, data.dose_amount, data.schedule_id, data.scheduled_time, data.notes,
             patient_id=data.patient_id, administered_at=data.administered_at,
+            administered_by=getattr(current_user, 'id', None),
         )
     except InsufficientMedicationQuantityError as e:
         # Refuse — the caller must update on-hand quantity first.
@@ -493,6 +496,7 @@ async def get_medication_history_endpoint(
     end_date: Optional[str] = None,
     status_filter: Optional[str] = None,
     patient_id: Optional[int] = None,
+    medication_id: Optional[int] = None,
     db: Session = Depends(get_db),
     _: bool = Depends(require_read_access)
 ):
@@ -506,6 +510,9 @@ async def get_medication_history_endpoint(
     - end_date: Filter by end date (YYYY-MM-DD format)
     - status_filter: Filter by status ('late', 'early', 'skipped', 'on-time')
     - patient_id: Filter by patient ID
+    - medication_id: Filter to exactly one medication. Callers that already
+      hold the id (the dose panel does — every schedule row carries it) should
+      use this rather than medication_name, which is a substring match.
     """
     try:
         history = get_medication_history(
@@ -515,7 +522,8 @@ async def get_medication_history_endpoint(
             start_date=start_date,
             end_date=end_date,
             status_filter=status_filter,
-            patient_id=patient_id
+            patient_id=patient_id,
+            medication_id=medication_id
         )
         return {"history": history, "count": len(history)}
     except Exception as e:

--- a/backend/routes/schedule.py
+++ b/backend/routes/schedule.py
@@ -266,7 +266,8 @@ async def get_daily_schedule(
 @router.post("/complete/medication")
 async def complete_medication(
     data: CompleteItemRequest,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user)
 ):
     """Mark a scheduled medication as administered"""
     try:
@@ -342,6 +343,10 @@ async def complete_medication(
             scheduled_time=scheduled_dt,
             administered_early=early_flag,
             administered_late=late_flag,
+            # Care tasks have always recorded who performed them; medications
+            # left this column unwritten, so `completed_by` on the daily
+            # schedule was permanently None for doses.
+            administered_by=getattr(current_user, 'id', None),
             notes=data.notes,
             created_at=utc_now()
         )
@@ -487,7 +492,8 @@ async def complete_bulk(
     medications: List[CompleteItemRequest] = Body(default=[]),
     nutrition: List[CompleteItemRequest] = Body(default=[]),
     care_tasks: List[CompleteItemRequest] = Body(default=[]),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user)
 ):
     """Complete multiple schedule items at once (e.g., all items in an hour)"""
     # Pre-flight: refuse the whole bulk if any item is outside the administration
@@ -611,6 +617,7 @@ async def complete_bulk(
                             scheduled_time=scheduled_dt,
                             administered_early=early_flag,
                             administered_late=late_flag,
+                            administered_by=getattr(current_user, 'id', None),
                             notes=item.notes,
                             created_at=utc_now()
                         )

--- a/backend/tests/test_medications.py
+++ b/backend/tests/test_medications.py
@@ -55,6 +55,58 @@ def test_administer_deducts_quantity(admin_client, patient):
     assert resp.json().get("success") is True
 
 
+def test_administer_records_who_gave_the_dose(admin_client, admin_user, patient, db_session):
+    """`administered_by` is written.
+
+    The column has existed since the initial migration but nothing populated
+    it, so `completed_by` came back None for every medication on the daily
+    schedule while care tasks recorded it properly. The dose detail pane shows
+    this, so a blank would be a silent lie about who gave a dose.
+    """
+    from schemas.medication_log import MedicationLog
+
+    med_id = _make_med(admin_client, patient, quantity=10).json()["id"]
+    resp = admin_client.post(f"/api/medications/{med_id}/administer",
+                             json={"dose_amount": 2, "patient_id": patient.id})
+    assert resp.status_code == 200, resp.text
+
+    log = db_session.query(MedicationLog).filter(
+        MedicationLog.medication_id == med_id).one()
+    assert log.administered_by == admin_user.id
+
+
+def test_history_filters_by_medication_id_not_a_name_prefix(admin_client, patient):
+    """`medication_id` is exact where `medication_name` is a substring match.
+
+    Two medications sharing a prefix is ordinary (Pro-something), and the dose
+    detail pane must never show another drug's doses.
+    """
+    a_id = _make_med(admin_client, patient, name="Propranolol", quantity=10).json()["id"]
+    _make_med(admin_client, patient, name="Propranolol ER", quantity=10)
+
+    for med, dose in ((a_id, 1), (a_id, 2)):
+        admin_client.post(f"/api/medications/{med}/administer",
+                          json={"dose_amount": dose, "patient_id": patient.id})
+    b_id = _make_med(admin_client, patient, name="Propafenone", quantity=10).json()["id"]
+    admin_client.post(f"/api/medications/{b_id}/administer",
+                      json={"dose_amount": 1, "patient_id": patient.id})
+
+    by_name = admin_client.get(
+        f"/api/medications/history?patient_id={patient.id}&medication_name=Prop")
+    assert by_name.status_code == 200
+    assert {r["medication_name"] for r in by_name.json()["history"]} == {
+        "Propranolol", "Propafenone"}
+
+    by_id = admin_client.get(
+        f"/api/medications/history?patient_id={patient.id}&medication_id={a_id}")
+    assert by_id.status_code == 200
+    rows = by_id.json()["history"]
+    assert len(rows) == 2
+    assert {r["medication_id"] for r in rows} == {a_id}
+    # The pane renders this, so it has to come back on the record.
+    assert all("administered_by" in r for r in rows)
+
+
 def test_administer_blocked_when_insufficient_quantity(admin_client, patient):
     """Dose larger than on-hand quantity is hard-blocked with 409."""
     med_id = _make_med(admin_client, patient, quantity=1).json()["id"]

--- a/frontend/src/components/Icons.jsx
+++ b/frontend/src/components/Icons.jsx
@@ -1092,3 +1092,15 @@ export const VitalsCaptureIcon = ({ size = 26 }) => (
     <path d="M3 12h4l2-5 3 10 2.5-6 1.5 3h5" />
   </svg>
 );
+
+/* A scored tablet — the round kind you swallow. Distinct from TabletIcon, which
+   is a tablet *computer*. The score line is horizontal on purpose: a diagonal
+   line inside a circle is the universal "prohibited" sign, which is not what
+   you want next to a medication. */
+export const TabletPillIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="8" />
+    <line x1="6" y1="12" x2="18" y2="12" />
+  </svg>
+);

--- a/frontend/src/components/MedicationModal.jsx
+++ b/frontend/src/components/MedicationModal.jsx
@@ -19,7 +19,10 @@ import React, { useState, useEffect, useMemo } from 'react';
 import ModalBase from './ModalBase';
 import config from '../config';
 import { useAdminPatient } from '../contexts/AdminPatientContext';
-import ScheduleList from './schedule/ScheduleList';
+import { useAuth } from '../contexts/AuthContext';
+import DoseScheduleView from './schedule/DoseScheduleView';
+import DoseDetailPane from './schedule/DoseDetailPane';
+import { useModalDock } from '../contexts/ModalDockContext';
 import { computeScheduleStatus } from './schedule/scheduleStatus';
 import { checkAdministrationWindow, formatDurationMinutes, getCurrentLocalDateTime } from '../utils/timezone';
 import MedicationDoseModal from '../pages/admin-v2/components/MedicationDoseModal';
@@ -47,6 +50,14 @@ const OFF_WINDOW_ERRORS = ['early_administration', 'late_administration', 'off_w
 const MedicationModal = ({ onClose }) => {
   const { selectedPatient } = useAdminPatient();
   const [tab, setTab] = useState('scheduled');
+  // Which dose the detail pane is showing. Kept here rather than in the view so
+  // it survives the refetch after recording.
+  const [selectedId, setSelectedId] = useState(null);
+  const { user } = useAuth();
+  const { docked, expanded } = useModalDock();
+  // The panel is ~380px at the narrow stop on a 1920px screen, so the compact
+  // controls have to key off the dock, not the viewport.
+  const compact = docked && !expanded;
   const [scheduled, setScheduled] = useState([]);          // raw `medications` rows from /api/schedule/daily
   const [activeMedications, setActiveMedications] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -133,6 +144,16 @@ const MedicationModal = ({ onClose }) => {
     });
   }, [scheduled]);
 
+  // A dose's normalized id embeds log_id, which appears the moment the dose is
+  // recorded — so selecting by id would drop the selection on the refetch that
+  // follows. Key on the schedule slot instead, which is stable.
+  const doseKey = (raw) => `${raw?.schedule_id ?? 'prn'}-${raw?.scheduled_time}`;
+  const selectedItem = useMemo(
+    () => scheduledItems.find(i => doseKey(i._raw) === selectedId) || null,
+    [scheduledItems, selectedId]
+  );
+  const recordingAs = user?.full_name || user?.username || null;
+
   const formatTimestamp = (iso) => {
     if (!iso) return null;
     try {
@@ -145,7 +166,7 @@ const MedicationModal = ({ onClose }) => {
   };
 
   // ===== Completion / skip (unified endpoints) =====
-  const submitMed = async (med, { override = false, skip = false } = {}) => {
+  const submitMed = async (med, { override = false, skip = false, note } = {}) => {
     if (!selectedPatient) return;
     try {
       const res = await fetch(`${config.apiUrl}/api/schedule/complete/medication`, {
@@ -158,14 +179,14 @@ const MedicationModal = ({ onClose }) => {
           patient_id: selectedPatient.id,
           dose_amount: skip ? 0 : (med.dose_amount ?? null),
           completed_at: null,
-          notes: skip ? 'Dose skipped via live dashboard' : 'Administered via live dashboard',
+          notes: note || (skip ? 'Dose skipped via live dashboard' : 'Administered via live dashboard'),
           early_override: override,
         }),
       });
       if (res.ok) { fetchSchedule(); fetchActiveMedications(); return; }
       const err = await res.json().catch(() => ({}));
       if (res.status === 409 && err.error === 'insufficient_quantity') {
-        setQtyGate({ open: true, info: err, retry: () => submitMed(med, { override, skip }) });
+        setQtyGate({ open: true, info: err, retry: () => submitMed(med, { override, skip, note }) });
         return;
       }
       if (res.status === 409 && OFF_WINDOW_ERRORS.includes(err.error) && !override && !skip) {
@@ -180,7 +201,7 @@ const MedicationModal = ({ onClose }) => {
               ? `${formatDurationMinutes(Math.abs(check.minutesOffset))} ago`
               : `${formatDurationMinutes(check.minutesOffset)} from now`
           }.`,
-          onConfirm: () => submitMed(med, { override: true }),
+          onConfirm: () => submitMed(med, { override: true, note }),
         });
         return;
       }
@@ -284,7 +305,7 @@ const MedicationModal = ({ onClose }) => {
   return (
     <>
       <ModalBase isOpen={true} onClose={onClose} title={
-        isMobile ? (
+        (compact || isMobile) ? (
           <div className="tw flex w-full gap-2">
             <Select value={tab} onValueChange={setTab}>
               <SelectTrigger className="flex-1"><SelectValue /></SelectTrigger>
@@ -324,14 +345,24 @@ const MedicationModal = ({ onClose }) => {
 
           <div style={{ flex: 1, overflow: 'auto' }}>
             {tab === 'scheduled' && (
-              <ScheduleList
+              <DoseScheduleView
                 items={scheduledItems}
                 loading={loading}
-                title="Scheduled Medications"
                 emptyText="No scheduled medications for today"
-                onMarkComplete={(item) => submitMed(item._raw)}
-                onSkip={(item) => submitMed(item._raw, { skip: true })}
-                onMarkAll={(items) => submitBulk(items.map(i => i._raw))}
+                selectedId={selectedItem?.id || null}
+                onSelect={(item) => setSelectedId(doseKey(item._raw))}
+                onRecord={(item, opts) => submitMed(item._raw, opts)}
+                onSkip={(item, opts) => submitMed(item._raw, { ...opts, skip: true })}
+                onRecordAll={(items) => submitBulk(items.map(i => i._raw))}
+                detail={(
+                  <DoseDetailPane
+                    item={selectedItem}
+                    patientId={selectedPatient?.id}
+                    recordingAs={recordingAs}
+                    onRecord={(item, opts) => submitMed(item._raw, opts)}
+                    onSkip={(item, opts) => submitMed(item._raw, { ...opts, skip: true })}
+                  />
+                )}
               />
             )}
             {tab === 'active' && (

--- a/frontend/src/components/MedicationModal.jsx
+++ b/frontend/src/components/MedicationModal.jsx
@@ -22,8 +22,11 @@ import { useAdminPatient } from '../contexts/AdminPatientContext';
 import { useAuth } from '../contexts/AuthContext';
 import DoseScheduleView from './schedule/DoseScheduleView';
 import DoseDetailPane from './schedule/DoseDetailPane';
-import { useModalDock } from '../contexts/ModalDockContext';
+import MedicationViewSwitcher from './medication-panel/MedicationViewSwitcher';
+import PrnPicker from './medication-panel/PrnPicker';
+import './medication-panel/medication-panel.css';
 import { computeScheduleStatus } from './schedule/scheduleStatus';
+import { rollupSchedule } from './schedule/scheduleRollup';
 import { checkAdministrationWindow, formatDurationMinutes, getCurrentLocalDateTime } from '../utils/timezone';
 import MedicationDoseModal from '../pages/admin-v2/components/MedicationDoseModal';
 import UpdateQuantityModal from '../pages/admin-v2/components/UpdateQuantityModal';
@@ -54,14 +57,9 @@ const MedicationModal = ({ onClose }) => {
   // it survives the refetch after recording.
   const [selectedId, setSelectedId] = useState(null);
   const { user } = useAuth();
-  const { docked, expanded } = useModalDock();
-  // The panel is ~380px at the narrow stop on a 1920px screen, so the compact
-  // controls have to key off the dock, not the viewport.
-  const compact = docked && !expanded;
   const [scheduled, setScheduled] = useState([]);          // raw `medications` rows from /api/schedule/daily
   const [activeMedications, setActiveMedications] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [isMobile, setIsMobile] = useState(typeof window !== 'undefined' && window.innerWidth <= 768);
 
   // Off-window confirm (shared shape for single + bulk completion).
   const [windowConfirm, setWindowConfirm] = useState({ open: false, title: '', heading: '', detail: '', onConfirm: null });
@@ -70,12 +68,6 @@ const MedicationModal = ({ onClose }) => {
   // PRN: pick an as-needed med, then the shared dose modal collects dose/time.
   const [prnPickerOpen, setPrnPickerOpen] = useState(false);
   const [prnMed, setPrnMed] = useState(null);
-
-  useEffect(() => {
-    const onResize = () => setIsMobile(window.innerWidth <= 768);
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, []);
 
   useEffect(() => {
     if (!selectedPatient) return;
@@ -153,6 +145,30 @@ const MedicationModal = ({ onClose }) => {
     [scheduledItems, selectedId]
   );
   const recordingAs = user?.full_name || user?.username || null;
+
+  // The menu shows what each view is holding, so you can choose without
+  // opening both: how much is outstanding, and how many profiles there are.
+  const viewOptions = useMemo(() => {
+    const { counts } = rollupSchedule(scheduledItems);
+    const outstanding = counts.missed + counts.due;
+    return [
+      {
+        value: 'scheduled',
+        label: 'Scheduled',
+        sublabel: "Today's administration tasks",
+        note: counts.missed > 0
+          ? `${counts.missed} missed`
+          : (outstanding > 0 ? `${outstanding} due` : 'All done'),
+        tone: counts.missed > 0 || outstanding > 0 ? 'due' : 'given',
+      },
+      {
+        value: 'active',
+        label: 'Active medications',
+        sublabel: 'All current medication profiles',
+        count: activeMedications.length,
+      },
+    ];
+  }, [scheduledItems, activeMedications.length]);
 
   const formatTimestamp = (iso) => {
     if (!iso) return null;
@@ -305,43 +321,30 @@ const MedicationModal = ({ onClose }) => {
   return (
     <>
       <ModalBase isOpen={true} onClose={onClose} title={
-        (compact || isMobile) ? (
-          <div className="tw flex w-full gap-2">
-            <Select value={tab} onValueChange={setTab}>
-              <SelectTrigger className="flex-1"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="scheduled">Scheduled</SelectItem>
-                <SelectItem value="active">Active ({activeMedications.length})</SelectItem>
-              </SelectContent>
-            </Select>
-            <Button
-              onClick={openPrnPicker}
-              disabled={!selectedPatient || prnMedications.length === 0}
-              className="shrink-0 bg-[#6f42c1] text-white hover:bg-[#6f42c1]/90"
-            >PRN</Button>
-          </div>
-        ) : (
-          <div className="tw flex w-full items-center gap-2">
-            <Button size="sm" variant={tab === 'scheduled' ? 'default' : 'secondary'} onClick={() => setTab('scheduled')}>Scheduled</Button>
-            <Button size="sm" variant={tab === 'active' ? 'default' : 'secondary'} onClick={() => setTab('active')}>Active ({activeMedications.length})</Button>
-            <Button
-              size="sm"
-              onClick={openPrnPicker}
-              disabled={!selectedPatient || prnMedications.length === 0}
-              className="bg-[#6f42c1] text-white hover:bg-[#6f42c1]/90"
-            >PRN</Button>
-          </div>
-        )
+        <span className="mp-modal-title">
+          <span>Medications</span>
+          <span className="mp-modal-title-sub">
+            {selectedPatient
+              ? `${selectedPatient.first_name} ${selectedPatient.last_name} \u00b7 ${tab === 'active' ? 'Active' : 'Schedule'}`
+              : 'No patient selected'}
+          </span>
+        </span>
       }>
         <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-          {/* Patient banner */}
-          <div className="tw" style={{ marginBottom: 16 }}>
-            <Alert variant={selectedPatient ? 'default' : 'warning'}>
-              {selectedPatient
-                ? <>Viewing medications for: {selectedPatient.first_name} {selectedPatient.last_name}</>
-                : 'No patient selected'}
-            </Alert>
-          </div>
+          {!selectedPatient && (
+            <div className="tw" style={{ marginBottom: 16 }}>
+              <Alert variant="warning">No patient selected</Alert>
+            </div>
+          )}
+
+          <MedicationViewSwitcher
+            views={viewOptions}
+            value={tab}
+            onChange={setTab}
+            prnCount={prnMedications.length}
+            prnDisabled={!selectedPatient || prnMedications.length === 0}
+            onPrn={openPrnPicker}
+          />
 
           <div style={{ flex: 1, overflow: 'auto' }}>
             {tab === 'scheduled' && (
@@ -398,36 +401,16 @@ const MedicationModal = ({ onClose }) => {
         </DialogContent>
       </Dialog>
 
-      {/* PRN pick: choose an as-needed med */}
-      <Dialog open={prnPickerOpen} onOpenChange={(o) => { if (!o) setPrnPickerOpen(false); }}>
-        <DialogContent className="sm:max-w-[480px]" aria-describedby={undefined}>
-          <DialogHeader>
-            <DialogTitle>Give a PRN (as-needed) medication</DialogTitle>
-          </DialogHeader>
-          <div className="flex flex-col gap-2">
-            {prnMedications.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No as-needed medications for this patient.</p>
-            ) : prnMedications.map(med => (
-              <Button
-                key={med.id}
-                type="button"
-                variant="secondary"
-                onClick={() => pickPrnMed(med)}
-                className="h-auto w-full justify-between whitespace-normal px-4 py-3 text-left"
-              >
-                <span className="flex min-w-0 flex-col">
-                  <strong>{med.name}</strong>
-                  <span className="text-xs font-normal text-muted-foreground">
-                    {med.concentration ? `${med.concentration} • ` : ''}
-                    {med.quantity ?? '—'} {med.quantity_unit || ''} on hand
-                  </span>
-                </span>
-                <Badge className="ml-2 shrink-0">Give</Badge>
-              </Button>
-            ))}
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* PRN step 1: choose an as-needed med (step 2 is MedicationDoseModal) */}
+      <PrnPicker
+        open={prnPickerOpen}
+        onOpenChange={(o) => { if (!o) setPrnPickerOpen(false); }}
+        patientName={selectedPatient
+          ? `${selectedPatient.first_name} ${selectedPatient.last_name}`.trim()
+          : null}
+        medications={prnMedications}
+        onSelect={pickPrnMed}
+      />
 
       {/* Shared dose modal for the chosen PRN med */}
       <MedicationDoseModal

--- a/frontend/src/components/MedicationModal.jsx
+++ b/frontend/src/components/MedicationModal.jsx
@@ -350,7 +350,7 @@ const MedicationModal = ({ onClose }) => {
                 loading={loading}
                 emptyText="No scheduled medications for today"
                 selectedId={selectedItem?.id || null}
-                onSelect={(item) => setSelectedId(doseKey(item._raw))}
+                onSelect={(item) => setSelectedId(item ? doseKey(item._raw) : null)}
                 onRecord={(item, opts) => submitMed(item._raw, opts)}
                 onSkip={(item, opts) => submitMed(item._raw, { ...opts, skip: true })}
                 onRecordAll={(items) => submitBulk(items.map(i => i._raw))}

--- a/frontend/src/components/ModalBase.jsx
+++ b/frontend/src/components/ModalBase.jsx
@@ -30,12 +30,16 @@ import { ExpandPanelIcon, CollapsePanelIcon } from "./Icons";
  *  - plain desktop: the original slab
  *
  * `dock={false}` opts an individual modal out of docking even inside a
- * provider (the unlock gate wants the whole board, not a side panel).
+ * provider (the unlock gate wants the whole board, not a side panel), and
+ * `dock={true}` opts one *in* from outside a provider.
  */
 const ModalBase = ({ isOpen, onClose, title, children, dock }) => {
   const [isMobile, setIsMobile] = useState(false);
   const { docked: dockAvailable, expanded, toggleExpand } = useModalDock();
-  const docked = dock !== false && dockAvailable && !isMobile;
+  // `dock` is normally advisory (opt out with false). `true` forces the docked
+  // treatment for a modal that renders *above* the dock provider in the React
+  // tree but is portalled into the board — the PIN challenge does exactly that.
+  const docked = (dock === true || dockAvailable) && dock !== false && !isMobile;
 
   useEffect(() => {
     const checkMobile = () => {

--- a/frontend/src/components/ModalBase.test.jsx
+++ b/frontend/src/components/ModalBase.test.jsx
@@ -1,0 +1,69 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// How ModalBase decides to dock. `dock` is normally advisory, but a modal that
+// renders above the dock provider in the React tree and portals into the board
+// has to be able to opt in — the PIN challenge does exactly that.
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import ModalBase from './ModalBase';
+import { ModalDockProvider } from '../contexts/ModalDockContext';
+
+const open = (props = {}, dockValue = null) => {
+  const ui = <ModalBase isOpen onClose={vi.fn()} title="T" {...props}><p>body</p></ModalBase>;
+  return render(dockValue ? <ModalDockProvider value={dockValue}>{ui}</ModalDockProvider> : ui);
+};
+
+const overlay = (c) => c.querySelector('.dashboard-modal-overlay');
+
+describe('ModalBase docking', () => {
+  it('does not dock outside a provider', () => {
+    const { container } = open();
+    expect(overlay(container).classList.contains('docked')).toBe(false);
+  });
+
+  it('docks inside a provider that offers it', () => {
+    const { container } = open({}, { docked: true, expanded: false, toggleExpand: vi.fn() });
+    expect(overlay(container).classList.contains('docked')).toBe(true);
+  });
+
+  it('dock={false} opts out even inside a provider', () => {
+    // The unlock gate uses this — it wants the board, not a side panel.
+    const { container } = open({ dock: false }, { docked: true, expanded: false, toggleExpand: vi.fn() });
+    expect(overlay(container).classList.contains('docked')).toBe(false);
+  });
+
+  it('dock={true} opts in from outside a provider', () => {
+    const { container } = open({ dock: true });
+    expect(overlay(container).classList.contains('docked')).toBe(true);
+  });
+
+  it('carries the narrow class until expanded', () => {
+    const { container: narrow } = open({ dock: true });
+    expect(narrow.querySelector('.modal-container').classList.contains('ld-dock-narrow')).toBe(true);
+
+    const { container: wide } = open({}, { docked: true, expanded: true, toggleExpand: vi.fn() });
+    expect(wide.querySelector('.modal-container').classList.contains('ld-dock-narrow')).toBe(false);
+  });
+
+  it('offers no expand control when the host provides no way to expand', () => {
+    // A forced dock with no provider has no toggleExpand — an auth prompt has
+    // nothing to expand into anyway.
+    const { queryByRole } = open({ dock: true });
+    expect(queryByRole('button', { name: /expand panel/i })).toBeNull();
+  });
+});

--- a/frontend/src/components/auth/PinChallengeModal.jsx
+++ b/frontend/src/components/auth/PinChallengeModal.jsx
@@ -19,6 +19,7 @@ import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ModalBase from '../ModalBase';
 import { useAuth } from '../../contexts/AuthContext';
+import './pin-challenge.css';
 
 /**
  * Global PIN re-auth challenge. Two steps:
@@ -29,8 +30,14 @@ import { useAuth } from '../../contexts/AuthContext';
  * AuthContext is updated with the new user and downstream actions log under
  * that user_id.
  *
- * Portaled to document.body so transform/perspective ancestors (e.g. the
- * flipping DynamicVitalsCard) can't trap its position: fixed overlay.
+ * Portaled rather than rendered in place, so transform/perspective ancestors
+ * (e.g. the flipping DynamicVitalsCard) can't trap its position: fixed overlay.
+ *
+ * When the live dashboard is mounted it portals into the board's own slot
+ * instead of <body>. Two things follow from that: it inherits the board's dark
+ * `--dash-*` tokens (on <body> it fell back to a stale navy), and it picks up
+ * the measured panel geometry, so it docks into the cards column. This prompt
+ * gates *actions*, never the reading of vitals — it must not cover the board.
  */
 export default function PinChallengeModal({ open, onSuccess, onCancel }) {
   const { getAccountUsers, selectUser } = useAuth();
@@ -102,55 +109,37 @@ export default function PinChallengeModal({ open, onSuccess, onCancel }) {
 
   if (!open) return null;
 
+  const boardSlot = typeof document !== 'undefined'
+    ? document.getElementById('ld-auth-slot')
+    : null;
+
   return createPortal(
-    <ModalBase isOpen={true} onClose={onCancel} title="Verify Caregiver">
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 16, color: '#e6edf3' }}>
-        {error && (
-          <div role="alert" style={{
-            padding: '10px 12px', borderRadius: 6,
-            background: 'rgba(220,53,69,0.15)',
-            border: '1px solid rgba(220,53,69,0.5)',
-            color: '#f8d7da', fontSize: 13,
-          }}>{error}</div>
-        )}
+    <ModalBase isOpen={true} onClose={onCancel} title="Verify Caregiver" dock={!!boardSlot}>
+      <div className="pc-body">
+        {error && <div role="alert" className="pc-error">{error}</div>}
 
         {!selected ? (
           <>
-            <p style={{ margin: 0, color: '#a0aec0', fontSize: 13 }}>
+            <p className="pc-intro">
               Confirm who is at the device. Saves and actions will be logged under
               this user until the next 5-minute idle window.
             </p>
             {loadingUsers ? (
-              <div style={{ textAlign: 'center', padding: 24, color: '#a0aec0' }}>Loading…</div>
+              <div className="pc-loading">Loading…</div>
             ) : users.length === 0 ? (
-              <div style={{ textAlign: 'center', padding: 24, color: '#a0aec0' }}>
-                No active users available.
-              </div>
+              <div className="pc-loading">No active users available.</div>
             ) : (
-              <div style={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
-                gap: 10,
-              }}>
+              <div className="pc-users">
                 {users.map((u) => (
                   <button
                     key={u.id}
                     type="button"
+                    className="pc-user"
                     onClick={() => handlePickUser(u)}
-                    style={{
-                      padding: '14px 16px', borderRadius: 10,
-                      border: '1px solid rgba(255,255,255,0.15)',
-                      background: '#161b22', color: '#e6edf3',
-                      cursor: 'pointer', textAlign: 'left',
-                      display: 'flex', flexDirection: 'column', gap: 4,
-                      fontSize: 14, fontWeight: 600,
-                    }}
                   >
-                    <span>{u.full_name || u.username}</span>
+                    <span className="pc-user-name">{u.full_name || u.username}</span>
                     {u.requires_full_password && (
-                      <span style={{ color: '#f0883e', fontSize: 11, fontWeight: 500 }}>
-                        Password required
-                      </span>
+                      <span className="pc-user-note">Password</span>
                     )}
                   </button>
                 ))}
@@ -158,42 +147,32 @@ export default function PinChallengeModal({ open, onSuccess, onCancel }) {
             )}
           </>
         ) : (
-          <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            <div style={{
-              padding: '8px 12px', borderRadius: 8,
-              background: 'rgba(88,166,255,0.08)',
-              border: '1px solid rgba(88,166,255,0.3)',
-              color: '#58a6ff', fontSize: 13, fontWeight: 600,
-            }}>
-              {selected.full_name || selected.username}
+          <form onSubmit={handleSubmit} className="pc-form">
+            <div className="pc-chosen">
+              <span className="pc-chosen-label">Signing in as</span>
+              <span className="pc-chosen-name">{selected.full_name || selected.username}</span>
             </div>
 
             {requirePassword ? (
               <div>
-                <label style={{ display: 'block', marginBottom: 6, fontSize: 12, fontWeight: 600 }}>
-                  Password
-                </label>
+                <label className="pc-label" htmlFor="pc-password">Password</label>
                 <input
+                  id="pc-password"
                   type="password"
+                  className="pc-input"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   autoFocus
                   required
-                  style={{
-                    width: '100%', padding: 12, fontSize: 16,
-                    background: '#0d1117', color: '#fff',
-                    border: '1px solid rgba(255,255,255,0.15)',
-                    borderRadius: 6, boxSizing: 'border-box',
-                  }}
                 />
               </div>
             ) : (
               <div>
-                <label style={{ display: 'block', marginBottom: 6, fontSize: 12, fontWeight: 600 }}>
-                  PIN
-                </label>
+                <label className="pc-label" htmlFor="pc-pin">PIN</label>
                 <input
+                  id="pc-pin"
                   type="password"
+                  className="pc-input pin"
                   inputMode="numeric"
                   value={pin}
                   onChange={(e) => setPin(e.target.value)}
@@ -201,52 +180,22 @@ export default function PinChallengeModal({ open, onSuccess, onCancel }) {
                   pattern="\d*"
                   autoFocus
                   required
-                  style={{
-                    width: '100%', padding: 12, fontSize: 18,
-                    background: '#0d1117', color: '#fff',
-                    border: '1px solid rgba(255,255,255,0.15)',
-                    borderRadius: 6, boxSizing: 'border-box',
-                    textAlign: 'center', letterSpacing: '0.5em',
-                  }}
                 />
               </div>
             )}
 
-            <div style={{
-              display: 'flex', justifyContent: 'space-between',
-              gap: 8, alignItems: 'center',
-            }}>
+            <div className="pc-actions">
               <button
                 type="button"
+                className="pc-btn ghost"
                 onClick={() => { setSelected(null); setError(null); }}
-                style={{
-                  padding: '8px 12px', borderRadius: 6,
-                  border: '1px solid rgba(255,255,255,0.15)',
-                  background: 'transparent', color: '#c9d1d9',
-                  cursor: 'pointer', fontSize: 13,
-                }}
               >← Change user</button>
-              <div style={{ display: 'flex', gap: 8 }}>
-                <button
-                  type="button"
-                  onClick={onCancel}
-                  style={{
-                    padding: '9px 16px', borderRadius: 6,
-                    border: '1px solid rgba(255,255,255,0.15)',
-                    background: 'transparent', color: '#e6edf3',
-                    cursor: 'pointer', fontSize: 14,
-                  }}
-                >Cancel</button>
+              <div className="pc-actions-right">
+                <button type="button" className="pc-btn ghost" onClick={onCancel}>Cancel</button>
                 <button
                   type="submit"
+                  className="pc-btn primary"
                   disabled={submitting || (requirePassword ? !password : !pin)}
-                  style={{
-                    padding: '9px 18px', borderRadius: 6, border: 'none',
-                    background: '#238636', color: '#fff',
-                    cursor: submitting ? 'default' : 'pointer',
-                    fontSize: 14, fontWeight: 600,
-                    opacity: submitting ? 0.6 : 1,
-                  }}
                 >{submitting ? 'Verifying…' : 'Verify'}</button>
               </div>
             </div>
@@ -254,6 +203,6 @@ export default function PinChallengeModal({ open, onSuccess, onCancel }) {
         )}
       </div>
     </ModalBase>,
-    document.body
+    boardSlot || document.body
   );
 }

--- a/frontend/src/components/auth/pin-challenge.css
+++ b/frontend/src/components/auth/pin-challenge.css
@@ -1,0 +1,189 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Caregiver verification. Sized for the narrow dock stop, because that is
+ * where it lives on the live dashboard: this prompt gates *actions*, never the
+ * reading of vitals, so it takes the cards column and leaves the board intact.
+ *
+ * Rendered outside the `.tw` island, so box-sizing and the bare <button> paint
+ * are asserted here. `:where()` keeps that reset at element specificity so the
+ * component classes below outrank it. */
+@import '../../styles/vc-tokens.css';
+
+.pc-body, .pc-body * { box-sizing: border-box; }
+:where(.pc-body) button {
+  font-family: var(--vc-font-mono);
+  padding: 0;
+  border: 1px solid transparent;
+  background: none;
+  color: inherit;
+}
+
+.pc-body { display: flex; flex-direction: column; gap: 0.9rem; }
+
+.pc-intro {
+  margin: 0;
+  font-family: var(--vc-font-sans);
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--vc-text-secondary);
+}
+
+.pc-error {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-size: 12.5px;
+}
+
+.pc-loading {
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--vc-text-tertiary);
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/* One user per row: at the narrow stop a grid of cards would give each name a
+   sliver, and the name is the whole point of the choice. */
+.pc-users { display: flex; flex-direction: column; gap: 0.5rem; }
+.pc-user {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-primary);
+  cursor: pointer;
+  text-align: left;
+}
+.pc-user:hover { border-color: var(--vc-data-live); background: var(--vc-bg-raised); }
+.pc-user-name {
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Amber: needing a password is a step, not a fault. */
+.pc-user-note {
+  flex-shrink: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-state-due);
+}
+
+.pc-form { display: flex; flex-direction: column; gap: 0.75rem; }
+.pc-chosen {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--vc-data-live) 45%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--vc-data-live) 10%, transparent);
+}
+.pc-chosen-label {
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.pc-chosen-name {
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--vc-text-primary);
+}
+
+.pc-label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.pc-input {
+  width: 100%;
+  min-height: 46px;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  background: var(--vc-bg-base);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 16px;
+}
+.pc-input:focus {
+  outline: none;
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 1px var(--vc-data-live);
+}
+.pc-input.pin { text-align: center; font-size: 20px; letter-spacing: 0.5em; }
+
+.pc-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.pc-actions-right { display: flex; gap: 0.5rem; margin-left: auto; }
+.pc-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 0.9rem;
+  border-radius: 8px;
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.pc-btn.ghost { border: 1px solid var(--vc-line-strong); color: var(--vc-text-secondary); }
+.pc-btn.ghost:hover { color: var(--vc-text-primary); border-color: var(--vc-text-tertiary); }
+.pc-btn.primary {
+  border: 1px solid var(--vc-data-live);
+  background: color-mix(in srgb, var(--vc-data-live) 18%, transparent);
+  color: var(--vc-text-primary);
+}
+.pc-btn.primary:hover:not(:disabled) { background: color-mix(in srgb, var(--vc-data-live) 30%, transparent); }
+.pc-btn.primary:disabled { opacity: 0.45; cursor: default; }

--- a/frontend/src/components/dashboard/live-dashboard.css
+++ b/frontend/src/components/dashboard/live-dashboard.css
@@ -414,11 +414,12 @@
     left: var(--ld-panel-left-wide, 0px);
   }
 
-  /* Undocked panels (the auth gates, `dock={false}`) still cover the board
-     below the top bar — an unlock prompt isn't something to work beside. */
+  /* Undocked panels (`dock={false}`) take the rest of the board, but still
+     start after the vitals column: the pulse ox keeps streaming while the
+     board is locked, so an unlock prompt must not cover live readings. */
   .live-dash .dashboard-modal-overlay:not(.docked):not(.mobile) {
     top: var(--ld-panel-top, 60px);
-    left: 0;
+    left: var(--ld-panel-left, 0px);
     right: 0;
     bottom: var(--ld-panel-bottom, 0px);
     width: auto;

--- a/frontend/src/components/medication-panel/MedicationViewSwitcher.jsx
+++ b/frontend/src/components/medication-panel/MedicationViewSwitcher.jsx
@@ -1,0 +1,109 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The medication panel's view row: which list you are looking at, plus the PRN
+// entry point. It sits in the body rather than in the modal title because it
+// carries two lines and a count — the title bar is one tight line at the narrow
+// dock stop.
+//
+// Built on Radix Select so focus, keyboard and outside-click come free, then
+// skinned from the vc tokens; the menu portals to <body>, so the vc class rides
+// along on SelectContent rather than being inherited.
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { ChevronDownIcon, CheckIcon, CalendarIcon, ClipboardListIcon } from '../Icons';
+import './medication-panel.css';
+
+const VIEW_ICON = {
+  scheduled: CalendarIcon,
+  active: ClipboardListIcon,
+};
+
+/**
+ * @param views  [{ value, label, sublabel, count?, note?, tone? }]
+ *               `note` is the right-hand status line (e.g. "23 missed");
+ *               `tone` colours it ('due' | 'given' | null).
+ */
+export default function MedicationViewSwitcher({
+  views,
+  value,
+  onChange,
+  prnCount = 0,
+  prnDisabled = false,
+  onPrn,
+}) {
+  const current = views.find((v) => v.value === value) || views[0];
+
+  return (
+    <div className="mp-viewrow">
+      <span className="mp-viewrow-label">View</span>
+      <div className="mp-viewrow-controls">
+        <SelectPrimitive.Root value={value} onValueChange={onChange}>
+          <SelectPrimitive.Trigger className="mp-view-trigger" aria-label="Choose a medication view">
+            <span className="mp-view-trigger-text">
+              <span className="mp-view-title">{current?.label}</span>
+              {current?.sublabel && <span className="mp-view-sub">{current.sublabel}</span>}
+            </span>
+            <SelectPrimitive.Icon asChild>
+              <span className="mp-view-caret" aria-hidden="true"><ChevronDownIcon size={16} /></span>
+            </SelectPrimitive.Icon>
+          </SelectPrimitive.Trigger>
+
+          <SelectPrimitive.Portal>
+            <SelectPrimitive.Content position="popper" sideOffset={6} className="mp-view-menu">
+              <SelectPrimitive.Viewport>
+                {views.map((view) => {
+                  const Icon = VIEW_ICON[view.value];
+                  return (
+                    <SelectPrimitive.Item key={view.value} value={view.value} className="mp-view-item">
+                      {Icon && <span className="mp-view-item-icon" aria-hidden="true"><Icon size={22} /></span>}
+                      <span className="mp-view-item-text">
+                        <SelectPrimitive.ItemText>{view.label}</SelectPrimitive.ItemText>
+                        {view.sublabel && <span className="mp-view-sub">{view.sublabel}</span>}
+                      </span>
+                      <span className="mp-view-item-meta">
+                        <SelectPrimitive.ItemIndicator asChild>
+                          <span className="mp-view-check" aria-hidden="true"><CheckIcon size={16} /></span>
+                        </SelectPrimitive.ItemIndicator>
+                        {view.note && (
+                          <span className={`mp-view-note ${view.tone || ''}`}>{view.note}</span>
+                        )}
+                        {view.count != null && !view.note && (
+                          <span className="mp-view-count">{view.count}</span>
+                        )}
+                      </span>
+                    </SelectPrimitive.Item>
+                  );
+                })}
+              </SelectPrimitive.Viewport>
+            </SelectPrimitive.Content>
+          </SelectPrimitive.Portal>
+        </SelectPrimitive.Root>
+
+        <button
+          type="button"
+          className="mp-prn-btn"
+          onClick={onPrn}
+          disabled={prnDisabled}
+          title={prnDisabled ? 'No as-needed medications for this patient' : 'Give an as-needed medication'}
+        >
+          <span className="mp-prn-label">PRN</span>
+          <span className="mp-prn-count">{prnCount}</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/medication-panel/PrnPicker.jsx
+++ b/frontend/src/components/medication-panel/PrnPicker.jsx
@@ -23,7 +23,7 @@
 // tokens. The content portals to <body>, so the vc class rides on the content
 // element rather than being inherited from the panel.
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { XIcon, DropletIcon, PillIcon, TabletIcon } from '../Icons';
+import { XIcon, DropletIcon, PillIcon, TabletPillIcon } from '../Icons';
 import { isLowStock } from './lowStock';
 import './medication-panel.css';
 
@@ -33,7 +33,7 @@ function formIcon(med) {
   const unit = (med.quantity_unit || '').toLowerCase();
   if (unit.includes('ml') || unit.includes('unit') || unit.includes('spray')) return DropletIcon;
   if (unit.includes('capsule')) return PillIcon;
-  return TabletIcon;
+  return TabletPillIcon;
 }
 
 const onHandLabel = (med) => {

--- a/frontend/src/components/medication-panel/PrnPicker.jsx
+++ b/frontend/src/components/medication-panel/PrnPicker.jsx
@@ -1,0 +1,104 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Step one of giving an as-needed dose: pick the medication. Step two (dose,
+// time, notes) is the existing MedicationDoseModal, so this only has to hand
+// back a choice.
+//
+// Built on Radix Dialog for focus trapping and escape handling, skinned from vc
+// tokens. The content portals to <body>, so the vc class rides on the content
+// element rather than being inherited from the panel.
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon, DropletIcon, PillIcon, TabletIcon } from '../Icons';
+import { isLowStock } from './lowStock';
+import './medication-panel.css';
+
+// A rough read of the form from the unit, only to give each row a recognisable
+// silhouette — it is never the only thing distinguishing two medications.
+function formIcon(med) {
+  const unit = (med.quantity_unit || '').toLowerCase();
+  if (unit.includes('ml') || unit.includes('unit') || unit.includes('spray')) return DropletIcon;
+  if (unit.includes('capsule')) return PillIcon;
+  return TabletIcon;
+}
+
+const onHandLabel = (med) => {
+  const qty = med.quantity ?? 0;
+  const unit = med.quantity_unit || '';
+  return `${qty}${unit ? ` ${unit}` : ''} on hand`;
+};
+
+export default function PrnPicker({ open, onOpenChange, patientName, medications = [], onSelect }) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="mp-sheet-overlay" />
+        <DialogPrimitive.Content className="mp-sheet" aria-describedby={undefined}>
+          <div className="mp-sheet-grip" aria-hidden="true" />
+
+          <div className="mp-sheet-head">
+            <div className="mp-sheet-headings">
+              <span className="mp-sheet-eyebrow">PRN medication</span>
+              <DialogPrimitive.Title className="mp-sheet-title">Select medication</DialogPrimitive.Title>
+              <span className="mp-sheet-sub">
+                {patientName ? `${patientName} · ` : ''}{medications.length} available
+              </span>
+            </div>
+            <DialogPrimitive.Close className="mp-sheet-close" aria-label="Close">
+              <XIcon size={18} />
+            </DialogPrimitive.Close>
+          </div>
+
+          <div className="mp-sheet-body">
+            {medications.length === 0 ? (
+              <p className="mp-sheet-empty">No as-needed medications for this patient.</p>
+            ) : medications.map((med) => {
+              const Icon = formIcon(med);
+              const low = isLowStock(med);
+              return (
+                <button
+                  key={med.id}
+                  type="button"
+                  className="mp-prn-row"
+                  onClick={() => onSelect(med)}
+                >
+                  <span className="mp-prn-icon" aria-hidden="true"><Icon size={22} /></span>
+                  <span className="mp-prn-text">
+                    <span className="mp-prn-name">{med.name}</span>
+                    {med.concentration && <span className="mp-prn-conc">{med.concentration}</span>}
+                    <span className={`mp-prn-stock${low ? ' low' : ''}`}>
+                      {onHandLabel(med)}
+                      {low && <span className="mp-prn-lowtag"> · low</span>}
+                    </span>
+                  </span>
+                  <span className="mp-prn-select">Select ›</span>
+                </button>
+              );
+            })}
+          </div>
+
+          {medications.length > 0 && (
+            <div className="mp-sheet-foot">
+              <span>Select a medication to set dose, reason + time</span>
+              <span className="mp-sheet-step">Step 1 of 2</span>
+            </div>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/frontend/src/components/medication-panel/PrnPicker.test.jsx
+++ b/frontend/src/components/medication-panel/PrnPicker.test.jsx
@@ -1,0 +1,74 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Step one of the PRN flow.
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import PrnPicker from './PrnPicker';
+
+const MEDS = [
+  { id: 1, name: 'Albuterol', concentration: '0.083%', quantity: 19, quantity_unit: 'units' },
+  {
+    id: 2, name: 'Ondansetron', concentration: '4mg/5ml', quantity: 2, quantity_unit: 'ml',
+    low_stock_threshold: 5, low_stock_threshold_type: 'quantity',
+  },
+];
+
+const open = (props = {}) => render(
+  <PrnPicker open onOpenChange={vi.fn()} patientName="Elijah Carty"
+             medications={MEDS} onSelect={vi.fn()} {...props} />
+);
+
+describe('PrnPicker', () => {
+  it('names the step and what is on offer', () => {
+    open();
+    expect(screen.getByText('Select medication')).toBeInTheDocument();
+    expect(screen.getByText(/Elijah Carty · 2 available/)).toBeInTheDocument();
+    expect(screen.getByText(/step 1 of 2/i)).toBeInTheDocument();
+  });
+
+  it('shows concentration and what is on hand', () => {
+    open();
+    const row = screen.getByText('Albuterol').closest('button');
+    expect(within(row).getByText('0.083%')).toBeInTheDocument();
+    expect(within(row).getByText(/19 units on hand/)).toBeInTheDocument();
+  });
+
+  it('marks a medication that is running low', () => {
+    open();
+    // Radix portals the sheet to <body>, outside RTL's container.
+    const low = document.querySelectorAll('.mp-prn-stock.low');
+    expect(low).toHaveLength(1);
+    expect(low[0].textContent).toMatch(/2 ml on hand/);
+    // Amber, per the panel's colour rule — red is for clinical concern.
+    const untouched = screen.getByText('Albuterol').closest('button');
+    expect(untouched.querySelector('.mp-prn-stock.low')).toBeNull();
+  });
+
+  it('hands the chosen medication back for step two', () => {
+    const onSelect = vi.fn();
+    open({ onSelect });
+    fireEvent.click(screen.getByText('Ondansetron').closest('button'));
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: 'Ondansetron' }));
+  });
+
+  it('says so when there is nothing to give, and drops the step footer', () => {
+    open({ medications: [] });
+    expect(screen.getByText(/no as-needed medications/i)).toBeInTheDocument();
+    expect(screen.queryByText(/step 1 of 2/i)).toBeNull();
+  });
+});

--- a/frontend/src/components/medication-panel/lowStock.js
+++ b/frontend/src/components/medication-panel/lowStock.js
@@ -1,0 +1,43 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Is this medication running low on hand?
+ *
+ * Low stock is a real per-medication setting, not a guess: `low_stock_threshold`
+ * is NULL when the medication opts out of alerting entirely, and
+ * `low_stock_threshold_type` says how to read it — 'quantity' is the raw
+ * on-hand amount, 'days' is days of supply projected from the medication's
+ * schedules.
+ *
+ * Only 'quantity' can be judged from a medication record alone. 'days' needs a
+ * schedule projection the client does not have, and a PRN medication has no
+ * schedule to project from, so it is reported as not-low rather than guessed
+ * at — a wrong amber on a controlled medication is worse than no amber.
+ */
+export function isLowStock(med) {
+  if (!med || med.low_stock_threshold == null) return false;
+  if ((med.low_stock_threshold_type || 'quantity') !== 'quantity') return false;
+  // An unknown quantity is not a zero quantity: `Number(null)` is 0, which
+  // would read as "none left" and flag a medication nobody has counted.
+  if (med.quantity == null) return false;
+  const qty = Number(med.quantity);
+  const threshold = Number(med.low_stock_threshold);
+  if (!Number.isFinite(qty) || !Number.isFinite(threshold)) return false;
+  return qty <= threshold;
+}

--- a/frontend/src/components/medication-panel/lowStock.test.js
+++ b/frontend/src/components/medication-panel/lowStock.test.js
@@ -1,0 +1,59 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The amber "on hand" signal in the PRN picker. It has to be conservative: a
+// wrong amber on a controlled medication is worse than no amber.
+import { describe, it, expect } from 'vitest';
+import { isLowStock } from './lowStock';
+
+const med = (over = {}) => ({
+  quantity: 10, quantity_unit: 'tablets',
+  low_stock_threshold: null, low_stock_threshold_type: 'quantity', ...over,
+});
+
+describe('isLowStock', () => {
+  it('is off when the medication opts out of alerting', () => {
+    // NULL threshold is the opt-out, not "zero".
+    expect(isLowStock(med({ quantity: 0, low_stock_threshold: null }))).toBe(false);
+  });
+
+  it('fires at or below the threshold', () => {
+    expect(isLowStock(med({ quantity: 3, low_stock_threshold: 5 }))).toBe(true);
+    expect(isLowStock(med({ quantity: 5, low_stock_threshold: 5 }))).toBe(true);
+    expect(isLowStock(med({ quantity: 6, low_stock_threshold: 5 }))).toBe(false);
+  });
+
+  it('will not guess at a days-of-supply threshold', () => {
+    // 'days' projects over the medication's schedules, which the client does
+    // not have — and a PRN medication has none to project from.
+    expect(isLowStock(med({
+      quantity: 1, low_stock_threshold: 30, low_stock_threshold_type: 'days',
+    }))).toBe(false);
+  });
+
+  it('treats a missing type as quantity, which is the column default', () => {
+    expect(isLowStock(med({
+      quantity: 1, low_stock_threshold: 5, low_stock_threshold_type: undefined,
+    }))).toBe(true);
+  });
+
+  it('stays quiet on unusable numbers rather than showing a false alarm', () => {
+    expect(isLowStock(med({ quantity: null, low_stock_threshold: 5 }))).toBe(false);
+    expect(isLowStock(med({ quantity: 'many', low_stock_threshold: 5 }))).toBe(false);
+    expect(isLowStock(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/components/medication-panel/medication-panel.css
+++ b/frontend/src/components/medication-panel/medication-panel.css
@@ -1,0 +1,398 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Medication panel chrome: the view row and the PRN picker.
+ *
+ * Both are Radix primitives skinned from vc tokens rather than shadcn defaults,
+ * because both portal to <body> — outside the dashboard's `--dash-*` subtree —
+ * and would otherwise arrive in the admin light-ish palette on the dark board.
+ * That is why every class here is `mp-` prefixed and self-contained.
+ *
+ * Rendered outside the `.tw` island, so box-sizing and the bare <button> paint
+ * are asserted (index.css gives every button outside .tw a padded, filled
+ * default). */
+@import '../../styles/vc-tokens.css';
+
+.mp-viewrow, .mp-viewrow *,
+.mp-view-menu, .mp-view-menu *,
+.mp-sheet, .mp-sheet * { box-sizing: border-box; }
+
+/* `:where()` keeps this at element specificity (0,0,1) so every component class
+   below outranks it. Written as `.mp-viewrow button` it would be (0,1,1) and
+   would beat `.mp-view-trigger` (0,1,0), stripping the borders it sets. */
+:where(.mp-viewrow, .mp-view-menu, .mp-sheet) button {
+  font-family: var(--vc-font-mono);
+  padding: 0;
+  border: 1px solid transparent;
+  background: none;
+  color: inherit;
+}
+
+/* ---------- view row ---------- */
+
+.mp-viewrow { display: flex; flex-direction: column; gap: 0.35rem; margin-bottom: 0.9rem; }
+.mp-viewrow-label {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.mp-viewrow-controls { display: flex; align-items: stretch; gap: 0.5rem; }
+
+.mp-view-trigger {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--vc-data-live);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--vc-data-live) 8%, transparent);
+  color: var(--vc-text-primary);
+  cursor: pointer;
+  text-align: left;
+}
+.mp-view-trigger:hover { background: color-mix(in srgb, var(--vc-data-live) 15%, transparent); }
+.mp-view-trigger-text { display: flex; flex-direction: column; gap: 0.1rem; min-width: 0; }
+.mp-view-title {
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+.mp-view-sub {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mp-view-caret { display: flex; flex-shrink: 0; color: var(--vc-data-live); }
+
+.mp-prn-btn {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0 0.85rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-primary);
+  cursor: pointer;
+}
+.mp-prn-btn:hover:not(:disabled) { border-color: var(--vc-data-live); }
+.mp-prn-btn:disabled { opacity: 0.45; cursor: default; }
+.mp-prn-label {
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+.mp-prn-count {
+  min-width: 22px;
+  padding: 0.1rem 0.35rem;
+  border-radius: 999px;
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  text-align: center;
+}
+
+/* ---------- view menu (portalled) ---------- */
+
+.mp-view-menu {
+  z-index: 1200;
+  min-width: var(--radix-select-trigger-width);
+  max-height: var(--radix-select-content-available-height);
+  overflow: hidden;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 12px;
+  background: var(--vc-bg-sheet);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+}
+.mp-view-item {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.7rem 0.85rem;
+  cursor: pointer;
+  outline: none;
+  color: var(--vc-text-primary);
+}
+.mp-view-item + .mp-view-item { border-top: 1px solid var(--vc-line-hairline); }
+.mp-view-item[data-highlighted] { background: color-mix(in srgb, var(--vc-data-live) 14%, transparent); }
+.mp-view-item-icon { display: flex; flex-shrink: 0; color: var(--vc-text-secondary); }
+.mp-view-item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+  flex: 1;
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.mp-view-item-text .mp-view-sub { font-weight: 400; text-transform: none; letter-spacing: 0.02em; }
+.mp-view-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  flex-direction: column;
+  align-items: flex-end;
+}
+.mp-view-check { display: flex; color: var(--vc-data-live); }
+.mp-view-note {
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  white-space: nowrap;
+}
+.mp-view-note.due { color: var(--vc-state-due); }
+.mp-view-note.given { color: var(--vc-state-complete); }
+.mp-view-count {
+  min-width: 30px;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  text-align: center;
+}
+
+/* ---------- PRN picker sheet (portalled) ---------- */
+
+.mp-sheet-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  background: rgba(0, 0, 0, 0.65);
+}
+.mp-sheet {
+  position: fixed;
+  z-index: 1201;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 520px;
+  max-height: min(84dvh, 720px);
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--vc-line-strong);
+  border-bottom: none;
+  border-radius: 16px 16px 0 0;
+  background: var(--vc-bg-sheet);
+  color: var(--vc-text-primary);
+  box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.55);
+}
+/* On a roomy screen it reads better as a centred panel than a bottom sheet. */
+@media (min-height: 700px) and (min-width: 640px) {
+  .mp-sheet {
+    top: 50%;
+    bottom: auto;
+    transform: translate(-50%, -50%);
+    border-bottom: 1px solid var(--vc-line-strong);
+    border-radius: 16px;
+  }
+  .mp-sheet-grip { display: none; }
+}
+.mp-sheet-grip {
+  width: 42px;
+  height: 4px;
+  margin: 0.55rem auto 0;
+  border-radius: 999px;
+  background: var(--vc-line-strong);
+}
+
+.mp-sheet-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.9rem 1rem 0.8rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.mp-sheet-headings { display: flex; flex-direction: column; gap: 0.15rem; min-width: 0; }
+.mp-sheet-eyebrow {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.mp-sheet-title {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+.mp-sheet-sub {
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.mp-sheet-close {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+.mp-sheet-close:hover { color: var(--vc-text-primary); border-color: var(--vc-line-strong); }
+
+.mp-sheet-body { flex: 1; min-height: 0; overflow-y: auto; }
+.mp-sheet-empty {
+  margin: 0;
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--vc-text-tertiary);
+  font-family: var(--vc-font-sans);
+  font-size: 13px;
+}
+
+.mp-prn-row {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  width: 100%;
+  padding: 0.85rem 1rem;
+  text-align: left;
+  cursor: pointer;
+  color: var(--vc-text-primary);
+}
+.mp-prn-row + .mp-prn-row { border-top: 1px solid var(--vc-line-hairline); }
+.mp-prn-row:hover { background: var(--vc-bg-surface); }
+.mp-prn-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  color: var(--vc-text-secondary);
+}
+.mp-prn-text { display: flex; flex-direction: column; gap: 0.12rem; min-width: 0; flex: 1; }
+.mp-prn-name {
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mp-prn-conc {
+  font-family: var(--vc-font-mono);
+  font-size: 11.5px;
+  color: var(--vc-text-secondary);
+}
+.mp-prn-stock {
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+/* Amber, not red: low stock is a supply signal, not a clinical alarm. */
+.mp-prn-stock.low { color: var(--vc-state-due); }
+.mp-prn-lowtag { font-weight: 700; }
+.mp-prn-select {
+  flex-shrink: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-data-live);
+}
+
+.mp-sheet-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  padding: 0.7rem 1rem calc(0.7rem + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid var(--vc-line-hairline);
+  border-left: 3px solid var(--vc-data-live);
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.mp-sheet-step { flex-shrink: 0; color: var(--vc-data-live); font-weight: 700; }
+
+/* Modal title: name on top, patient + which view under it. Styled here rather
+   than leaning on the dock's `.modal-header.docked` rule, which does not apply
+   on a phone — the title would fall back to the 1.5rem sans <h2>. */
+.mp-modal-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+.mp-modal-title-sub {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/src/components/schedule/DoseDetailPane.jsx
+++ b/frontend/src/components/schedule/DoseDetailPane.jsx
@@ -1,0 +1,241 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Dose details for the selected row, shown beside the schedule at the wide dock
+// stop. Rendered inline inside the same ModalBase rather than as a second
+// overlay — the same shape AlertDetailInline takes inside AlertsList.
+//
+// Recording and skipping are the host's handlers, unchanged: they already carry
+// the 409 paths for off-window administration and insufficient quantity, and
+// re-implementing those here would be a second place to get them wrong.
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import config from '../../config';
+import { bucketFor, recurrenceLabel } from './scheduleRollup';
+import { ChevronRightIcon } from '../Icons';
+
+const STATUS_TEXT = {
+  completed: 'Given',
+  skipped: 'Skipped',
+  missed: 'Missed',
+  pending: 'Upcoming',
+  upcoming: 'Upcoming',
+  due_on_time: 'Due',
+  due_warning: 'Due',
+  due_late: 'Due',
+};
+
+const HISTORY_STATUS = {
+  'on-time': 'On time',
+  early: 'Early',
+  late: 'Late',
+  skipped: 'Skipped',
+};
+
+const fmtDateTime = (iso) => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '—';
+  return d.toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+  });
+};
+
+const fmtTime = (iso) => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '—';
+  return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+};
+
+export default function DoseDetailPane({
+  item,
+  patientId,
+  recordingAs,
+  onRecord,
+  onSkip,
+  busy = false,
+}) {
+  const navigate = useNavigate();
+  const [note, setNote] = useState('');
+  const [history, setHistory] = useState(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [historyError, setHistoryError] = useState(false);
+
+  const medicationId = item?._raw?.medication_id ?? null;
+
+  // The note belongs to the dose in front of you, not to the pane.
+  useEffect(() => {
+    setNote('');
+    setHistoryOpen(false);
+  }, [item?.id]);
+
+  // Filter by medication_id, not name: the name filter is a substring match,
+  // so "Pro" would pull in every medication starting with it.
+  useEffect(() => {
+    if (!historyOpen || !medicationId || !patientId) return undefined;
+    let cancelled = false;
+    setHistoryError(false);
+    (async () => {
+      try {
+        const res = await fetch(
+          `${config.apiUrl}/api/medications/history?patient_id=${patientId}&medication_id=${medicationId}&limit=10`,
+          { credentials: 'include' }
+        );
+        if (cancelled) return;
+        if (!res.ok) { setHistoryError(true); return; }
+        const data = await res.json();
+        if (!cancelled) setHistory(data.history || []);
+      } catch {
+        if (!cancelled) setHistoryError(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [historyOpen, medicationId, patientId]);
+
+  const bucket = useMemo(() => (item ? bucketFor(item.status) : null), [item]);
+
+  if (!item) {
+    return (
+      <div className="ld-dose-detail empty">
+        <p>Select a medication to see its details and history.</p>
+      </div>
+    );
+  }
+
+  const done = item.is_completed;
+
+  return (
+    <div className="ld-dose-detail">
+      <div className="ld-dose-detail-head">
+        <h3 className="ld-dose-detail-name">{item.name}</h3>
+        {item.extra && <span className="ld-dose-detail-amount">{item.extra}</span>}
+      </div>
+
+      <dl className="ld-dose-detail-rows">
+        <div>
+          <dt>Scheduled</dt>
+          <dd>
+            {fmtTime(item.scheduled_time)}
+            {recurrenceLabel(item.description) ? ` · ${recurrenceLabel(item.description)}` : ''}
+            {item.is_yesterday ? ' · yesterday' : ''}
+          </dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd className={`ld-dose-detail-status ${bucket}`}>
+            {bucket !== 'given' && bucket !== 'skipped' && <span className="ld-dose-dot" aria-hidden="true" />}
+            {STATUS_TEXT[item.status] || item.status}
+          </dd>
+        </div>
+        {item._raw?.completed_at && (
+          <div>
+            <dt>Recorded</dt>
+            <dd>{fmtDateTime(item._raw.completed_at)}</dd>
+          </div>
+        )}
+      </dl>
+
+      {!done && (
+        <>
+          <label className="ld-dose-detail-label" htmlFor="ld-dose-note">
+            Add note (optional)
+          </label>
+          <textarea
+            id="ld-dose-note"
+            className="ld-dose-note"
+            rows={2}
+            maxLength={500}
+            value={note}
+            placeholder="Anything worth recording with this dose"
+            onChange={(e) => setNote(e.target.value)}
+          />
+
+          <button
+            type="button"
+            className="ld-dose-btn primary block"
+            disabled={busy}
+            onClick={() => onRecord && onRecord(item, { note: note.trim() || undefined })}
+          >
+            {busy ? 'Recording…' : 'Record dose'}
+          </button>
+        </>
+      )}
+
+      <div className="ld-dose-detail-actions">
+        <span className="ld-dose-detail-label">Other actions</span>
+        {!done && onSkip && (
+          <button
+            type="button"
+            className="ld-dose-action"
+            disabled={busy}
+            onClick={() => onSkip(item, { note: note.trim() || undefined })}
+          >
+            <span>
+              Skip dose
+              <em>Recorded as a zero dose with your note</em>
+            </span>
+            <ChevronRightIcon size={16} />
+          </button>
+        )}
+        <button
+          type="button"
+          className="ld-dose-action"
+          onClick={() => navigate('/care/medications/schedule')}
+        >
+          <span>Correct schedule</span>
+          <ChevronRightIcon size={16} />
+        </button>
+        <button
+          type="button"
+          className="ld-dose-action"
+          aria-expanded={historyOpen}
+          onClick={() => setHistoryOpen((v) => !v)}
+        >
+          <span>{historyOpen ? 'Hide history' : 'View history'}</span>
+          <ChevronRightIcon size={16} />
+        </button>
+      </div>
+
+      {historyOpen && (
+        <div className="ld-dose-history">
+          {historyError && <p className="ld-dose-history-empty">Could not load history.</p>}
+          {!historyError && history === null && <p className="ld-dose-history-empty">Loading…</p>}
+          {!historyError && history?.length === 0 && (
+            <p className="ld-dose-history-empty">No doses recorded yet.</p>
+          )}
+          {!historyError && history?.map((row) => (
+            <div key={row.id} className="ld-dose-history-row">
+              <span className="ld-dose-history-when">{fmtDateTime(row.administered_at)}</span>
+              <span className={`ld-dose-history-status ${row.status === 'skipped' ? 'skipped' : 'given'}`}>
+                {HISTORY_STATUS[row.status] || row.status}
+              </span>
+              <span className="ld-dose-history-dose">
+                {row.dose_amount}{row.dose_unit ? ` ${row.dose_unit}` : ''}
+              </span>
+              {row.notes && <span className="ld-dose-history-note">{row.notes}</span>}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {recordingAs && (
+        <p className="ld-dose-detail-footer">Recording as {recordingAs}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/schedule/DoseDetailPane.jsx
+++ b/frontend/src/components/schedule/DoseDetailPane.jsx
@@ -24,7 +24,7 @@
 // re-implementing those here would be a second place to get them wrong.
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import config from '../../config';
+import config, { apiFetch } from '../../config';
 import { bucketFor, recurrenceLabel } from './scheduleRollup';
 import { ChevronRightIcon } from '../Icons';
 
@@ -86,15 +86,18 @@ export default function DoseDetailPane({
 
   // Filter by medication_id, not name: the name filter is a substring match,
   // so "Pro" would pull in every medication starting with it.
+  //
+  // apiFetch, not fetch: inside a cross-origin iframe (the Home Assistant
+  // embed) SameSite blocks the session cookie, and the wrapper falls back to
+  // the bearer token.
   useEffect(() => {
     if (!historyOpen || !medicationId || !patientId) return undefined;
     let cancelled = false;
     setHistoryError(false);
     (async () => {
       try {
-        const res = await fetch(
-          `${config.apiUrl}/api/medications/history?patient_id=${patientId}&medication_id=${medicationId}&limit=10`,
-          { credentials: 'include' }
+        const res = await apiFetch(
+          `${config.apiUrl}/api/medications/history?patient_id=${patientId}&medication_id=${medicationId}&limit=10`
         );
         if (cancelled) return;
         if (!res.ok) { setHistoryError(true); return; }

--- a/frontend/src/components/schedule/DoseScheduleView.jsx
+++ b/frontend/src/components/schedule/DoseScheduleView.jsx
@@ -275,11 +275,13 @@ export default function DoseScheduleView({
                           onClick={() => onSelect && onSelect(item)}
                         >
                           <th scope="row">
-                            <button
-                              type="button"
-                              className="ld-dose-rowbtn"
-                              onClick={() => onSelect && onSelect(item)}
-                            >
+                            {/* The button exists to make the row reachable by
+                                keyboard — a <tr> is not focusable. Its click
+                                (including the one Enter/Space synthesises)
+                                bubbles to the row's handler, so it deliberately
+                                carries none of its own; a second handler here
+                                would select twice per click. */}
+                            <button type="button" className="ld-dose-rowbtn">
                               {item.name}
                             </button>
                           </th>

--- a/frontend/src/components/schedule/DoseScheduleView.jsx
+++ b/frontend/src/components/schedule/DoseScheduleView.jsx
@@ -1,0 +1,296 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The medication schedule at both dock stops. Same items, two readings:
+//
+//   narrow (the cards column, ~300-400px) — triage. What is overdue, at what
+//     time, and a way to record it without leaving the board.
+//   expanded (across the charts) — the day's four counts, a time-grouped table,
+//     and a detail pane for whichever dose is selected.
+//
+// Size comes from the dock (useModalDock), never from window.innerWidth: the
+// panel is ~380px wide on a 1920px screen, so a viewport test reports "desktop"
+// exactly where the narrow layout is wanted. That mismatch is why ScheduleList
+// reads wrong in the dock today.
+import { useMemo } from 'react';
+import { useModalDock } from '../../contexts/ModalDockContext';
+import {
+  BUCKETS, BUCKET_LABELS, bucketFor, groupByDaySlot, recurrenceLabel, rollupSchedule, slotLabel,
+} from './scheduleRollup';
+import './schedule-panel.css';
+
+const STATUS_TEXT = {
+  completed: 'Given',
+  skipped: 'Skipped',
+  missed: 'Missed',
+  pending: 'Upcoming',
+  upcoming: 'Upcoming',
+  due_on_time: 'Due',
+  due_warning: 'Due',
+  due_late: 'Due',
+};
+
+function StatusBadge({ status }) {
+  const bucket = bucketFor(status);
+  return (
+    <span className={`ld-dose-badge ${bucket}`}>
+      {bucket !== 'given' && bucket !== 'skipped' && <span className="ld-dose-dot" aria-hidden="true" />}
+      {STATUS_TEXT[status] || status}
+    </span>
+  );
+}
+
+/* "Daily · 08:00" — the schedule line. */
+function scheduleLine(item) {
+  const time = slotLabel(item.scheduled_time);
+  const recurrence = recurrenceLabel(item.description);
+  return recurrence ? `${recurrence} · ${time}` : time;
+}
+
+export default function DoseScheduleView({
+  items = [],
+  loading = false,
+  emptyText = 'No scheduled doses today',
+  selectedId = null,
+  onSelect,
+  onRecord,
+  onSkip,
+  onRecordAll,
+  detail = null,
+}) {
+  const { expanded, setExpanded } = useModalDock();
+  // The wide layout is opt-in: it appears only when the panel has actually been
+  // expanded. That covers the narrow dock stop *and* a phone, where the modal
+  // fills a 390px screen and is never expandable — keying off `docked` instead
+  // would hand the phone the table.
+  const narrow = !expanded;
+
+  const { counts, needsAttention, lead } = useMemo(() => rollupSchedule(items), [items]);
+  const days = useMemo(() => groupByDaySlot(items), [items]);
+
+  // Tapping a dose in the narrow panel opens it in the detail pane, which only
+  // exists at the wide stop — so reaching it means widening first.
+  const openDetail = (item) => {
+    if (onSelect) onSelect(item);
+    // No-op where there is nothing wider to reach (mobile).
+    if (narrow && setExpanded) setExpanded(true);
+  };
+
+  if (loading) {
+    return <div className="ld-dose-empty">Loading schedule…</div>;
+  }
+  if (items.length === 0) {
+    return <div className="ld-dose-empty">{emptyText}</div>;
+  }
+
+  if (narrow) {
+    return (
+      <div className="ld-dose-panel narrow">
+        {lead && (
+          <div className="ld-dose-lead">
+            <span className={`ld-dose-lead-count ${lead.bucket}`}>
+              {counts.missed > 0 ? `${counts.missed} missed` : `${counts.due} due`}
+              {' · '}
+              {slotLabel(lead.item.scheduled_time)}
+            </span>
+            {onRecordAll && needsAttention.length > 0 && (
+              <button
+                type="button"
+                className="ld-dose-linkbtn"
+                onClick={() => onRecordAll(needsAttention)}
+              >
+                Record all
+              </button>
+            )}
+          </div>
+        )}
+        <div className="ld-dose-subcount">
+          {needsAttention.length} of {items.length} need attention
+        </div>
+
+        {days.map((day) => (
+          <div key={day.day} className="ld-dose-day">
+            {days.length > 1 && <div className="ld-dose-day-head">{day.label}</div>}
+            {day.slots.map((slot) => {
+              const open = slot.items.filter((i) => !i.is_completed);
+              return (
+                <div key={slot.time || 'unscheduled'} className="ld-dose-slot">
+                  {/* Time bands, not one long run of cards: the times are what a
+                      caregiver scans by, and reading them off each card is
+                      slower than reading them off a header. */}
+                  <div className="ld-dose-slot-head">
+                    <span className="ld-dose-slot-time">{slot.time || 'Unscheduled'}</span>
+                    <span className="ld-dose-slot-count">{slot.items.length}</span>
+                    {onRecordAll && open.length > 0 && (
+                      <button
+                        type="button"
+                        className="ld-dose-linkbtn"
+                        onClick={() => onRecordAll(open)}
+                      >
+                        Record all
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="ld-dose-cards">
+                    {slot.items.map((item) => (
+                      <div
+                        key={item.id}
+                        className={`ld-dose-card ${bucketFor(item.status)}${item.id === selectedId ? ' selected' : ''}`}
+                      >
+                        <button
+                          type="button"
+                          className="ld-dose-card-body"
+                          onClick={() => openDetail(item)}
+                          aria-label={`${item.name}, ${STATUS_TEXT[item.status] || item.status}. Open details.`}
+                        >
+                          <span className="ld-dose-card-head">
+                            <span className="ld-dose-name">{item.name}</span>
+                            <StatusBadge status={item.status} />
+                          </span>
+                          {item.extra && <span className="ld-dose-amount">{item.extra}</span>}
+                          <span className="ld-dose-schedule">{recurrenceLabel(item.description)}</span>
+                        </button>
+                        {!item.is_completed && (
+                          <div className="ld-dose-card-actions">
+                            {onRecord && (
+                              <button
+                                type="button"
+                                className="ld-dose-btn primary"
+                                onClick={(e) => { e.stopPropagation(); onRecord(item); }}
+                              >
+                                Record dose
+                              </button>
+                            )}
+                            {onSkip && (
+                              <button
+                                type="button"
+                                className="ld-dose-btn ghost"
+                                onClick={(e) => { e.stopPropagation(); onSkip(item); }}
+                                aria-label={`Skip ${item.name}`}
+                                title="Skip dose"
+                              >
+                                Skip
+                              </button>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="ld-dose-panel wide">
+      <div className="ld-dose-main">
+        <div className="ld-dose-tiles">
+          {BUCKETS.map((bucket) => (
+            <div
+              key={bucket}
+              className={`ld-dose-tile ${bucket}${bucket === 'missed' && counts.missed > 0 ? ' alert' : ''}`}
+            >
+              <span className="ld-dose-tile-label">{BUCKET_LABELS[bucket]}</span>
+              <span className="ld-dose-tile-count">{counts[bucket]}</span>
+            </div>
+          ))}
+        </div>
+
+        {days.map((day) => (
+          <div key={day.day} className="ld-dose-day">
+            {days.length > 1 && <div className="ld-dose-day-head">{day.label}</div>}
+            {day.slots.map((slot) => {
+              const open = slot.items.filter((i) => !i.is_completed);
+              return (
+                <div key={slot.time || 'unscheduled'} className="ld-dose-slot">
+                  <div className="ld-dose-slot-head">
+                    <span className="ld-dose-slot-time">{slot.time || 'Unscheduled'}</span>
+                    <span className="ld-dose-slot-count">
+                      {slot.items.length} medication{slot.items.length === 1 ? '' : 's'}
+                    </span>
+                    {onRecordAll && open.length > 0 && (
+                      <button
+                        type="button"
+                        className="ld-dose-linkbtn"
+                        onClick={() => onRecordAll(open)}
+                      >
+                        Record all
+                      </button>
+                    )}
+                  </div>
+
+                  <table className="ld-dose-table">
+                    <thead>
+                      <tr>
+                        <th>Medication</th>
+                        <th>Dose</th>
+                        <th>Schedule</th>
+                        <th>Status</th>
+                        <th className="ld-dose-actions-col">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {slot.items.map((item) => (
+                        <tr
+                          key={item.id}
+                          className={item.id === selectedId ? 'selected' : ''}
+                          onClick={() => onSelect && onSelect(item)}
+                        >
+                          <th scope="row">
+                            <button
+                              type="button"
+                              className="ld-dose-rowbtn"
+                              onClick={() => onSelect && onSelect(item)}
+                            >
+                              {item.name}
+                            </button>
+                          </th>
+                          <td>{item.extra || '—'}</td>
+                          <td>{scheduleLine(item)}</td>
+                          <td><StatusBadge status={item.status} /></td>
+                          <td className="ld-dose-actions-col">
+                            {!item.is_completed && onRecord && (
+                              <button
+                                type="button"
+                                className="ld-dose-btn primary sm"
+                                onClick={(e) => { e.stopPropagation(); onRecord(item); }}
+                              >
+                                Record dose
+                              </button>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+
+      {detail && <div className="ld-dose-side">{detail}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/schedule/DoseScheduleView.jsx
+++ b/frontend/src/components/schedule/DoseScheduleView.jsx
@@ -28,6 +28,7 @@
 // reads wrong in the dock today.
 import { useMemo } from 'react';
 import { useModalDock } from '../../contexts/ModalDockContext';
+import { ChevronLeftIcon } from '../Icons';
 import {
   BUCKETS, BUCKET_LABELS, bucketFor, groupByDaySlot, recurrenceLabel, rollupSchedule, slotLabel,
 } from './scheduleRollup';
@@ -72,22 +73,23 @@ export default function DoseScheduleView({
   onRecordAll,
   detail = null,
 }) {
-  const { expanded, setExpanded } = useModalDock();
-  // The wide layout is opt-in: it appears only when the panel has actually been
-  // expanded. That covers the narrow dock stop *and* a phone, where the modal
-  // fills a 390px screen and is never expandable — keying off `docked` instead
-  // would hand the phone the table.
-  const narrow = !expanded;
+  const { docked, expanded, setExpanded } = useModalDock();
+  // Side-by-side needs room, which only the expanded dock stop has. A phone is
+  // never wide — it fills a 390px screen and has no expand control, so it must
+  // not be handed the table just because a dose got selected.
+  const wide = docked && expanded;
+  // With no room beside the list, the detail takes the panel and the list steps
+  // back — the same move AlertDetailInline makes inside AlertsList.
+  const stackedDetail = !docked && detail && selectedId;
 
   const { counts, needsAttention, lead } = useMemo(() => rollupSchedule(items), [items]);
   const days = useMemo(() => groupByDaySlot(items), [items]);
 
-  // Tapping a dose in the narrow panel opens it in the detail pane, which only
-  // exists at the wide stop — so reaching it means widening first.
+  // Tapping a dose opens its details. In the dock that means widening first,
+  // since the pane lives beside the list; on a phone the pane replaces it.
   const openDetail = (item) => {
     if (onSelect) onSelect(item);
-    // No-op where there is nothing wider to reach (mobile).
-    if (narrow && setExpanded) setExpanded(true);
+    if (docked && !expanded && setExpanded) setExpanded(true);
   };
 
   if (loading) {
@@ -97,7 +99,23 @@ export default function DoseScheduleView({
     return <div className="ld-dose-empty">{emptyText}</div>;
   }
 
-  if (narrow) {
+  if (stackedDetail) {
+    return (
+      <div className="ld-dose-panel stacked">
+        <button
+          type="button"
+          className="ld-dose-back"
+          onClick={() => onSelect && onSelect(null)}
+        >
+          <ChevronLeftIcon size={16} />
+          Back to schedule
+        </button>
+        {detail}
+      </div>
+    );
+  }
+
+  if (!wide) {
     return (
       <div className="ld-dose-panel narrow">
         {lead && (

--- a/frontend/src/components/schedule/DoseScheduleView.test.jsx
+++ b/frontend/src/components/schedule/DoseScheduleView.test.jsx
@@ -1,0 +1,242 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The two dock stops of the medication schedule. The point of these tests is
+// that the layout follows the *dock*, not the viewport — jsdom reports a 1024px
+// window throughout, so anything keyed to window.innerWidth would render the
+// wide layout in every case here.
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+import DoseScheduleView from './DoseScheduleView';
+import { ModalDockProvider } from '../../contexts/ModalDockContext';
+
+const at = (h, m = 0) => new Date(2026, 7, 17, h, m, 0).toISOString();
+
+const ITEMS = [
+  {
+    id: 'briviact', name: 'Briviact', extra: '10 mL', description: 'Daily',
+    status: 'missed', is_completed: false, scheduled_time: at(8),
+    _raw: { schedule_id: 1, medication_id: 11 },
+  },
+  {
+    id: 'propranolol', name: 'Propranolol', extra: '1 tablet', description: 'Daily',
+    status: 'missed', is_completed: false, scheduled_time: at(8),
+    _raw: { schedule_id: 2, medication_id: 12 },
+  },
+  {
+    id: 'senna', name: 'Senna', extra: '3 tablets', description: 'Daily',
+    status: 'completed', is_completed: true, scheduled_time: at(16),
+    _raw: { schedule_id: 3, medication_id: 13 },
+  },
+];
+
+const renderAt = (dock, props = {}) => {
+  const value = {
+    docked: true, expanded: false, toggleExpand: vi.fn(), setExpanded: vi.fn(), ...dock,
+  };
+  const utils = render(
+    <ModalDockProvider value={value}>
+      <DoseScheduleView items={ITEMS} {...props} />
+    </ModalDockProvider>
+  );
+  return { ...utils, dock: value };
+};
+
+describe('DoseScheduleView — narrow stop', () => {
+  it('leads with what is overdue and how many need attention', () => {
+    renderAt({ expanded: false });
+    expect(screen.getByText(/2 missed · 08:00/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 of 3 need attention/i)).toBeInTheDocument();
+  });
+
+  it('bands the cards by time so the slots are scannable', () => {
+    const { container } = renderAt({ expanded: false });
+    const times = [...container.querySelectorAll('.ld-dose-slot-time')].map(t => t.textContent);
+    expect(times).toEqual(['08:00', '16:00']);
+    // The time lives in the band header, so the card no longer repeats it.
+    const firstCard = container.querySelector('.ld-dose-card');
+    expect(within(firstCard).getByText('Daily')).toBeInTheDocument();
+    expect(within(firstCard).queryByText(/08:00/)).toBeNull();
+  });
+
+  it('separates yesterday from today rather than merging the same time slot', () => {
+    const withYesterday = [
+      { ...ITEMS[0], id: 'y-briviact', is_yesterday: true },
+      ITEMS[0],
+    ];
+    const { container } = render(
+      <ModalDockProvider value={{ docked: true, expanded: false, setExpanded: vi.fn() }}>
+        <DoseScheduleView items={withYesterday} />
+      </ModalDockProvider>
+    );
+    const dayHeads = [...container.querySelectorAll('.ld-dose-day-head')].map(d => d.textContent);
+    expect(dayHeads).toEqual(['Yesterday', 'Today']);
+    // Two 08:00 bands, one per day — not one band with a duplicate-looking pair.
+    expect(container.querySelectorAll('.ld-dose-slot-time')).toHaveLength(2);
+  });
+
+  it('renders cards, not the table, however wide the window claims to be', () => {
+    const { container } = renderAt({ expanded: false });
+    expect(container.querySelector('.ld-dose-panel.narrow')).toBeInTheDocument();
+    expect(container.querySelector('table')).toBeNull();
+    expect(container.querySelectorAll('.ld-dose-card')).toHaveLength(3);
+  });
+
+  it('gives a phone the cards too — it is narrow and cannot expand', () => {
+    // Not docked (mobile), so `docked` is false; the layout must still be the
+    // card list rather than the wide table.
+    const { container } = render(
+      <ModalDockProvider value={{ docked: false, expanded: false, toggleExpand: null, setExpanded: null }}>
+        <DoseScheduleView items={ITEMS} />
+      </ModalDockProvider>
+    );
+    expect(container.querySelector('.ld-dose-panel.narrow')).toBeInTheDocument();
+    expect(container.querySelector('table')).toBeNull();
+  });
+
+  it('does not try to expand when the host offers no way to', () => {
+    const onSelect = vi.fn();
+    render(
+      <ModalDockProvider value={{ docked: false, expanded: false, setExpanded: null }}>
+        <DoseScheduleView items={ITEMS} onSelect={onSelect} />
+      </ModalDockProvider>
+    );
+    // Selecting still works; it just has nowhere wider to go.
+    expect(() => fireEvent.click(
+      screen.getByRole('button', { name: /Briviact, Missed\. Open details\./i })
+    )).not.toThrow();
+    expect(onSelect).toHaveBeenCalled();
+  });
+
+  it('tapping a card expands the panel and selects that dose', () => {
+    const onSelect = vi.fn();
+    const { dock } = renderAt({ expanded: false }, { onSelect });
+
+    fireEvent.click(screen.getByRole('button', { name: /Briviact, Missed\. Open details\./i }));
+
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: 'Briviact' }));
+    expect(dock.setExpanded).toHaveBeenCalledWith(true);
+  });
+
+  it('recording from a card acts in place, without widening the panel', () => {
+    const onRecord = vi.fn();
+    const onSelect = vi.fn();
+    const { dock, container } = renderAt({ expanded: false }, { onRecord, onSelect });
+
+    const card = container.querySelector('.ld-dose-card');
+    fireEvent.click(within(card).getByRole('button', { name: /record dose/i }));
+
+    expect(onRecord).toHaveBeenCalledWith(expect.objectContaining({ name: 'Briviact' }));
+    expect(dock.setExpanded).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('offers no actions on a dose already given', () => {
+    const { container } = renderAt({ expanded: false }, { onRecord: vi.fn(), onSkip: vi.fn() });
+    const given = [...container.querySelectorAll('.ld-dose-card')].find(
+      c => within(c).queryByText('Senna')
+    );
+    expect(within(given).queryByRole('button', { name: /record dose/i })).toBeNull();
+    expect(within(given).queryByRole('button', { name: /skip/i })).toBeNull();
+  });
+
+  it('record all is offered per time band, and only what still needs doing', () => {
+    const onRecordAll = vi.fn();
+    renderAt({ expanded: false }, { onRecordAll });
+    // 16:00 holds only an already-given dose, so it offers nothing to record.
+    const buttons = screen.getAllByRole('button', { name: /record all/i });
+    expect(buttons).toHaveLength(2); // the lead line, plus the 08:00 band
+    fireEvent.click(buttons[1]);
+    expect(onRecordAll).toHaveBeenCalledWith([
+      expect.objectContaining({ name: 'Briviact' }),
+      expect.objectContaining({ name: 'Propranolol' }),
+    ]);
+  });
+});
+
+describe('DoseScheduleView — expanded stop', () => {
+  it('shows the four counts for the day', () => {
+    const { container } = renderAt({ expanded: true });
+    const tiles = [...container.querySelectorAll('.ld-dose-tile')].map(t => t.textContent);
+    expect(tiles).toEqual(['Given1', 'Due0', 'Missed2', 'Skipped0']);
+  });
+
+  it('groups the table by time slot', () => {
+    const { container } = renderAt({ expanded: true });
+    expect(container.querySelector('.ld-dose-panel.wide')).toBeInTheDocument();
+    const slots = [...container.querySelectorAll('.ld-dose-slot-time')].map(s => s.textContent);
+    expect(slots).toEqual(['08:00', '16:00']);
+    expect(screen.getByText('2 medications')).toBeInTheDocument();
+    expect(screen.getByText('1 medication')).toBeInTheDocument();
+  });
+
+  it('selecting a row does not resize the panel — the detail pane is already there', () => {
+    const onSelect = vi.fn();
+    const { dock } = renderAt({ expanded: true }, { onSelect });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Propranolol' }));
+
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: 'Propranolol' }));
+    expect(dock.setExpanded).not.toHaveBeenCalled();
+  });
+
+  it('marks the selected row', () => {
+    const { container } = renderAt({ expanded: true }, { selectedId: 'propranolol' });
+    const selected = container.querySelectorAll('tr.selected');
+    expect(selected).toHaveLength(1);
+    expect(within(selected[0]).getByText('Propranolol')).toBeInTheDocument();
+  });
+
+  it('renders the detail pane beside the list', () => {
+    renderAt({ expanded: true }, { detail: <p>Dose details go here</p> });
+    expect(screen.getByText('Dose details go here')).toBeInTheDocument();
+  });
+
+  it('record all in a slot passes only that slot, only what is open', () => {
+    const onRecordAll = vi.fn();
+    renderAt({ expanded: true }, { onRecordAll });
+    // The 16:00 slot holds one already-given dose, so it offers no Record all.
+    const buttons = screen.getAllByRole('button', { name: /record all/i });
+    expect(buttons).toHaveLength(1);
+    fireEvent.click(buttons[0]);
+    expect(onRecordAll).toHaveBeenCalledWith([
+      expect.objectContaining({ name: 'Briviact' }),
+      expect.objectContaining({ name: 'Propranolol' }),
+    ]);
+  });
+});
+
+describe('DoseScheduleView — empty and loading', () => {
+  it('says so when the day is empty', () => {
+    render(
+      <ModalDockProvider value={{ docked: true, expanded: false, setExpanded: vi.fn() }}>
+        <DoseScheduleView items={[]} emptyText="No scheduled medications for today" />
+      </ModalDockProvider>
+    );
+    expect(screen.getByText('No scheduled medications for today')).toBeInTheDocument();
+  });
+
+  it('shows a loading state rather than an empty day', () => {
+    render(
+      <ModalDockProvider value={{ docked: true, expanded: false, setExpanded: vi.fn() }}>
+        <DoseScheduleView items={[]} loading />
+      </ModalDockProvider>
+    );
+    expect(screen.getByText(/loading schedule/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/schedule/DoseScheduleView.test.jsx
+++ b/frontend/src/components/schedule/DoseScheduleView.test.jsx
@@ -97,32 +97,6 @@ describe('DoseScheduleView — narrow stop', () => {
     expect(container.querySelectorAll('.ld-dose-card')).toHaveLength(3);
   });
 
-  it('gives a phone the cards too — it is narrow and cannot expand', () => {
-    // Not docked (mobile), so `docked` is false; the layout must still be the
-    // card list rather than the wide table.
-    const { container } = render(
-      <ModalDockProvider value={{ docked: false, expanded: false, toggleExpand: null, setExpanded: null }}>
-        <DoseScheduleView items={ITEMS} />
-      </ModalDockProvider>
-    );
-    expect(container.querySelector('.ld-dose-panel.narrow')).toBeInTheDocument();
-    expect(container.querySelector('table')).toBeNull();
-  });
-
-  it('does not try to expand when the host offers no way to', () => {
-    const onSelect = vi.fn();
-    render(
-      <ModalDockProvider value={{ docked: false, expanded: false, setExpanded: null }}>
-        <DoseScheduleView items={ITEMS} onSelect={onSelect} />
-      </ModalDockProvider>
-    );
-    // Selecting still works; it just has nowhere wider to go.
-    expect(() => fireEvent.click(
-      screen.getByRole('button', { name: /Briviact, Missed\. Open details\./i })
-    )).not.toThrow();
-    expect(onSelect).toHaveBeenCalled();
-  });
-
   it('tapping a card expands the panel and selects that dose', () => {
     const onSelect = vi.fn();
     const { dock } = renderAt({ expanded: false }, { onSelect });
@@ -238,5 +212,60 @@ describe('DoseScheduleView — empty and loading', () => {
       </ModalDockProvider>
     );
     expect(screen.getByText(/loading schedule/i)).toBeInTheDocument();
+  });
+});
+
+// A phone is not docked: it fills the screen, has no expand control, and never
+// has room for a pane beside the list.
+describe('DoseScheduleView — phone', () => {
+  const onPhone = (props = {}) => {
+    const dock = { docked: false, expanded: false, toggleExpand: null, setExpanded: vi.fn() };
+    const utils = render(
+      <ModalDockProvider value={dock}>
+        <DoseScheduleView items={ITEMS} {...props} />
+      </ModalDockProvider>
+    );
+    return { ...utils, dock };
+  };
+
+  it('gets the cards, not the table', () => {
+    const { container } = onPhone();
+    expect(container.querySelector('.ld-dose-panel.narrow')).toBeInTheDocument();
+    expect(container.querySelector('table')).toBeNull();
+  });
+
+  it('never switches to the wide layout, even once a dose is selected', () => {
+    // The host still hands setExpanded down, so selecting must not be allowed
+    // to flip a 390px screen to the side-by-side table.
+    const { container, dock } = onPhone({ selectedId: 'briviact', detail: <p>Details</p> });
+    expect(container.querySelector('.ld-dose-panel.wide')).toBeNull();
+    expect(dock.setExpanded).not.toHaveBeenCalled();
+  });
+
+  it('shows the detail in place of the list, with a way back', () => {
+    const onSelect = vi.fn();
+    const { container } = onPhone({
+      selectedId: 'briviact', detail: <p>Dose details go here</p>, onSelect,
+    });
+
+    expect(screen.getByText('Dose details go here')).toBeInTheDocument();
+    expect(container.querySelectorAll('.ld-dose-card')).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: /back to schedule/i }));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('tapping a dose selects it without asking for a width it cannot get', () => {
+    const onSelect = vi.fn();
+    const { dock } = onPhone({ onSelect });
+    fireEvent.click(screen.getByRole('button', { name: /Briviact, Missed\. Open details\./i }));
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: 'Briviact' }));
+    expect(dock.setExpanded).not.toHaveBeenCalled();
+  });
+
+  it('stays on the list while nothing is selected', () => {
+    const { container } = onPhone({ detail: <p>Dose details go here</p> });
+    expect(screen.queryByText('Dose details go here')).toBeNull();
+    expect(container.querySelectorAll('.ld-dose-card')).toHaveLength(3);
   });
 });

--- a/frontend/src/components/schedule/DoseScheduleView.test.jsx
+++ b/frontend/src/components/schedule/DoseScheduleView.test.jsx
@@ -169,6 +169,21 @@ describe('DoseScheduleView — expanded stop', () => {
     expect(dock.setExpanded).not.toHaveBeenCalled();
   });
 
+  it('selects once per click, not once per nested handler', () => {
+    // The name is a <button> so the row is keyboard-reachable, and the row
+    // itself is clickable. Only one of them may handle the click, or every
+    // selection fires twice and the host refetches twice.
+    const onSelect = vi.fn();
+    renderAt({ expanded: true }, { onSelect });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Propranolol' }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+
+    onSelect.mockClear();
+    fireEvent.click(screen.getByText('1 tablet'));   // a plain cell in the row
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
   it('marks the selected row', () => {
     const { container } = renderAt({ expanded: true }, { selectedId: 'propranolol' });
     const selected = container.querySelectorAll('tr.selected');

--- a/frontend/src/components/schedule/schedule-panel.css
+++ b/frontend/src/components/schedule/schedule-panel.css
@@ -425,6 +425,9 @@
   align-items: baseline;
   justify-content: space-between;
   gap: 0.6rem;
+  /* At phone width the value ("8:00 AM · Daily · yesterday") is longer than the
+     row, so let it drop under the label rather than run off the edge. */
+  flex-wrap: wrap;
 }
 .ld-dose-detail-rows dt {
   font-family: var(--vc-font-mono);
@@ -436,6 +439,7 @@
 }
 .ld-dose-detail-rows dd {
   margin: 0;
+  min-width: 0;
   font-family: var(--vc-font-mono);
   font-size: 12px;
   color: var(--vc-text-primary);
@@ -590,3 +594,27 @@
   margin-bottom: 0.7rem;
 }
 .ld-dose-yesterday { font-style: normal; color: var(--vc-state-due); }
+
+/* Stacked detail — a phone has no room beside the list, so the detail takes the
+   panel and this steps back to it. */
+.ld-dose-panel.stacked { display: flex; flex-direction: column; gap: 0.7rem; }
+.ld-dose-back {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: 40px;
+  padding: 0 0.7rem 0 0.4rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.ld-dose-back:hover { color: var(--vc-text-primary); border-color: var(--vc-line-strong); }
+.ld-dose-panel.stacked .ld-dose-detail { border: none; padding: 0; background: none; }

--- a/frontend/src/components/schedule/schedule-panel.css
+++ b/frontend/src/components/schedule/schedule-panel.css
@@ -1,0 +1,592 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Dose panel — the medication schedule at both dock stops.
+ *
+ * Colour roles follow the rule set in pages/admin-v2/vc-content.css: schedule
+ * adherence is NEVER red. Due / missed are amber (--vc-state-due), green means
+ * given, cyan is the primary action, and red stays reserved for clinical
+ * concern and destructive actions.
+ *
+ * This surface renders outside the `.tw` island, so box-sizing and the bare
+ * <button> paint have to be asserted here (index.css styles every button
+ * outside .tw with a padded, filled default). */
+@import '../../styles/vc-tokens.css';
+
+.ld-dose-panel,
+.ld-dose-panel *,
+.ld-dose-detail,
+.ld-dose-detail * { box-sizing: border-box; }
+
+.ld-dose-panel button,
+.ld-dose-detail button {
+  font-family: var(--vc-font-mono);
+  padding: 0;
+  border: 1px solid transparent;
+  background: none;
+  color: inherit;
+}
+
+.ld-dose-empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--vc-text-tertiary);
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ---------- shared bits ---------- */
+
+.ld-dose-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-shrink: 0;
+  padding: 0.15rem 0.45rem;
+  border: 1px solid;
+  border-radius: 999px;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.ld-dose-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+.ld-dose-badge.missed,
+.ld-dose-badge.due {
+  color: var(--vc-state-due);
+  border-color: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
+  background: color-mix(in srgb, var(--vc-state-due) 12%, transparent);
+}
+.ld-dose-badge.given {
+  color: var(--vc-state-complete);
+  border-color: color-mix(in srgb, var(--vc-state-complete) 45%, transparent);
+  background: color-mix(in srgb, var(--vc-state-complete) 10%, transparent);
+}
+.ld-dose-badge.skipped {
+  color: var(--vc-text-tertiary);
+  border-color: var(--vc-line-hairline);
+  background: var(--vc-bg-surface);
+}
+
+.ld-dose-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0 0.85rem;
+  border-radius: 8px;
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.ld-dose-btn.primary {
+  border: 1px solid var(--vc-data-live);
+  background: color-mix(in srgb, var(--vc-data-live) 16%, transparent);
+  color: var(--vc-text-primary);
+}
+.ld-dose-btn.primary:hover {
+  background: color-mix(in srgb, var(--vc-data-live) 28%, transparent);
+}
+.ld-dose-btn.primary:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.ld-dose-btn.ghost {
+  border: 1px solid var(--vc-line-strong);
+  color: var(--vc-text-secondary);
+}
+.ld-dose-btn.ghost:hover { color: var(--vc-text-primary); border-color: var(--vc-text-tertiary); }
+.ld-dose-btn.sm { min-height: 30px; font-size: 10px; padding: 0 0.65rem; }
+.ld-dose-btn.block { width: 100%; min-height: 42px; margin-top: 0.6rem; }
+
+.ld-dose-linkbtn {
+  margin-left: auto;
+  color: var(--vc-data-live);
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.ld-dose-linkbtn:hover { text-decoration: underline; }
+
+/* ---------- narrow stop: triage cards ---------- */
+
+.ld-dose-panel.narrow { display: flex; flex-direction: column; }
+
+.ld-dose-lead {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  padding-bottom: 0.4rem;
+}
+.ld-dose-lead-count {
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.ld-dose-lead-count.missed, .ld-dose-lead-count.due { color: var(--vc-state-due); }
+.ld-dose-lead-count.given { color: var(--vc-state-complete); }
+
+.ld-dose-subcount {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  padding-bottom: 0.7rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+
+.ld-dose-cards { display: flex; flex-direction: column; gap: 0.55rem; }
+
+/* Time bands in the narrow panel. The header is sticky so the slot you are
+   scrolled into stays named — with a day of doses the list is long. */
+.ld-dose-panel.narrow .ld-dose-slot + .ld-dose-slot { margin-top: 0.9rem; }
+.ld-dose-panel.narrow .ld-dose-day + .ld-dose-day { margin-top: 1.1rem; }
+.ld-dose-panel.narrow .ld-dose-slot-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.45rem;
+  padding: 0.35rem 0;
+  background: var(--vc-bg-sheet);
+  border-bottom: 1px solid var(--vc-line-strong);
+}
+.ld-dose-panel.narrow .ld-dose-slot-time { font-size: 14px; }
+.ld-dose-panel.narrow .ld-dose-slot-count {
+  min-width: 18px;
+  padding: 0.05rem 0.35rem;
+  border-radius: 999px;
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-secondary);
+  text-align: center;
+  font-size: 10px;
+}
+.ld-dose-panel.narrow .ld-dose-day-head {
+  margin-bottom: 0.5rem;
+  border-bottom: none;
+  padding-bottom: 0;
+  color: var(--vc-state-due);
+}
+
+.ld-dose-card {
+  border: 1px solid var(--vc-line-hairline);
+  border-left: 3px solid var(--vc-line-strong);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+.ld-dose-card.missed, .ld-dose-card.due { border-left-color: var(--vc-state-due); }
+.ld-dose-card.given { border-left-color: var(--vc-state-complete); }
+.ld-dose-card.selected { border-color: var(--vc-data-live); }
+
+.ld-dose-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  width: 100%;
+  padding: 0.7rem 0.8rem 0.5rem;
+  text-align: left;
+  cursor: pointer;
+}
+.ld-dose-card-body:hover { background: var(--vc-bg-raised); }
+.ld-dose-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 0;
+}
+.ld-dose-name {
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--vc-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ld-dose-amount {
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  color: var(--vc-text-secondary);
+}
+.ld-dose-schedule {
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.ld-dose-card-actions {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0 0.8rem 0.7rem;
+}
+.ld-dose-card-actions .ld-dose-btn.primary { flex: 1; min-width: 0; }
+.ld-dose-card-actions .ld-dose-btn.ghost { flex: 0 0 auto; min-width: 64px; }
+
+/* ---------- wide stop: tiles, table, detail ---------- */
+
+.ld-dose-panel.wide {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 380px);
+  gap: 1rem;
+  align-items: start;
+}
+.ld-dose-main { min-width: 0; }
+.ld-dose-side { min-width: 0; }
+
+.ld-dose-tiles {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+.ld-dose-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+}
+.ld-dose-tile.alert {
+  border-color: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
+  background: color-mix(in srgb, var(--vc-state-due) 10%, var(--vc-bg-surface));
+}
+.ld-dose-tile-label {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.ld-dose-tile-count {
+  font-family: var(--vc-font-mono);
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--vc-text-primary);
+}
+.ld-dose-tile.missed .ld-dose-tile-count { color: var(--vc-state-due); }
+.ld-dose-tile.given .ld-dose-tile-count { color: var(--vc-state-complete); }
+
+.ld-dose-slot + .ld-dose-slot { margin-top: 1.1rem; }
+.ld-dose-slot-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  padding-bottom: 0.5rem;
+}
+.ld-dose-slot-time {
+  font-family: var(--vc-font-mono);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--vc-data-live);
+  font-variant-numeric: tabular-nums;
+}
+.ld-dose-slot-count {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+
+.ld-dose-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--vc-font-mono);
+  /* Each time slot renders its own table, so the columns only line up down the
+     page if their widths are fixed rather than content-derived. */
+  table-layout: fixed;
+}
+.ld-dose-table th:nth-child(1) { width: auto; }
+.ld-dose-table th:nth-child(2) { width: 15%; }
+.ld-dose-table th:nth-child(3) { width: 22%; }
+.ld-dose-table th:nth-child(4) { width: 14%; }
+.ld-dose-table th:nth-child(5) { width: 15%; }
+.ld-dose-table td, .ld-dose-table th { overflow: hidden; text-overflow: ellipsis; }
+.ld-dose-table th,
+.ld-dose-table td {
+  padding: 0.6rem 0.7rem;
+  text-align: left;
+  border-bottom: 1px solid var(--vc-line-hairline);
+  font-weight: 400;
+}
+.ld-dose-table thead th {
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  border-bottom-color: var(--vc-line-strong);
+}
+.ld-dose-table tbody td { font-size: 12px; color: var(--vc-text-secondary); }
+.ld-dose-table tbody tr { cursor: pointer; border-left: 3px solid transparent; }
+.ld-dose-table tbody tr:hover { background: var(--vc-bg-surface); }
+.ld-dose-table tbody tr.selected {
+  background: var(--vc-bg-surface);
+  border-left-color: var(--vc-data-live);
+}
+.ld-dose-table tbody th[scope='row'] { padding-left: 0.7rem; }
+.ld-dose-rowbtn {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--vc-text-primary);
+  cursor: pointer;
+  text-align: left;
+}
+.ld-dose-rowbtn:hover { color: var(--vc-data-live); }
+.ld-dose-actions-col { white-space: nowrap; text-align: right; }
+
+/* ---------- detail pane ---------- */
+
+.ld-dose-detail {
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 12px;
+  background: var(--vc-bg-surface);
+  padding: 0.9rem 1rem 1rem;
+}
+.ld-dose-detail.empty {
+  color: var(--vc-text-tertiary);
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  text-align: center;
+  padding: 2rem 1rem;
+}
+.ld-dose-detail.empty p { margin: 0; }
+
+.ld-dose-detail-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding-bottom: 0.7rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.ld-dose-detail-name {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+.ld-dose-detail-amount {
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  color: var(--vc-text-secondary);
+  white-space: nowrap;
+}
+
+.ld-dose-detail-rows { margin: 0.8rem 0; display: flex; flex-direction: column; gap: 0.5rem; }
+.ld-dose-detail-rows > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+.ld-dose-detail-rows dt {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.ld-dose-detail-rows dd {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  color: var(--vc-text-primary);
+  text-align: right;
+}
+.ld-dose-detail-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.ld-dose-detail-status.missed, .ld-dose-detail-status.due { color: var(--vc-state-due); }
+.ld-dose-detail-status.given { color: var(--vc-state-complete); }
+.ld-dose-detail-status.skipped { color: var(--vc-text-tertiary); }
+
+.ld-dose-detail-label {
+  display: block;
+  margin-top: 0.6rem;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.ld-dose-note {
+  width: 100%;
+  margin-top: 0.35rem;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  background: var(--vc-bg-base);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 12.5px;
+  resize: vertical;
+}
+.ld-dose-note:focus {
+  outline: none;
+  border-color: var(--vc-data-live);
+  box-shadow: 0 0 0 1px var(--vc-data-live);
+}
+
+.ld-dose-detail-actions {
+  margin-top: 1rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--vc-line-hairline);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.ld-dose-detail-actions .ld-dose-detail-label { margin-top: 0; margin-bottom: 0.25rem; }
+.ld-dose-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-base);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+.ld-dose-action:hover { border-color: var(--vc-line-strong); }
+.ld-dose-action:disabled { opacity: 0.5; cursor: default; }
+.ld-dose-action em {
+  display: block;
+  font-style: normal;
+  font-size: 11px;
+  color: var(--vc-text-tertiary);
+  margin-top: 0.1rem;
+}
+
+.ld-dose-history {
+  margin-top: 0.7rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.ld-dose-history-empty {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  color: var(--vc-text-tertiary);
+}
+.ld-dose-history-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-base);
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+}
+.ld-dose-history-when { color: var(--vc-text-secondary); }
+.ld-dose-history-status {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 9.5px;
+}
+.ld-dose-history-status.given { color: var(--vc-state-complete); }
+.ld-dose-history-status.skipped { color: var(--vc-text-tertiary); }
+.ld-dose-history-dose { margin-left: auto; color: var(--vc-text-primary); }
+.ld-dose-history-note {
+  flex-basis: 100%;
+  color: var(--vc-text-tertiary);
+  font-family: var(--vc-font-sans);
+}
+
+.ld-dose-detail-footer {
+  margin: 0.9rem 0 0;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--vc-line-hairline);
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+
+/* Below the dock's breakpoint the panel is the whole screen, so the wide
+   layout's two columns stack rather than squeezing the detail pane. */
+@media (max-width: 900px) {
+  .ld-dose-panel.wide { grid-template-columns: minmax(0, 1fr); }
+  .ld-dose-tiles { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+/* Yesterday's uncompleted doses come back alongside today's so nothing missed
+   drops off the board; they need their own band or they read as duplicate rows
+   of the same medication at the same time. */
+.ld-dose-day + .ld-dose-day { margin-top: 1.4rem; }
+.ld-dose-day-head {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+  margin-bottom: 0.7rem;
+}
+.ld-dose-yesterday { font-style: normal; color: var(--vc-state-due); }

--- a/frontend/src/components/schedule/scheduleRollup.js
+++ b/frontend/src/components/schedule/scheduleRollup.js
@@ -71,11 +71,18 @@ export function rollupSchedule(items = []) {
     if (bucket === 'missed' || bucket === 'due') attention.push(item);
   }
 
+  // An unparseable scheduled_time would make the comparator return NaN, which
+  // leaves the sort order up to the engine. Undated items sort last here, the
+  // same place groupBySlot puts them.
+  const at = (item) => {
+    const t = item.scheduled_time ? new Date(item.scheduled_time).getTime() : NaN;
+    return Number.isNaN(t) ? Infinity : t;
+  };
   attention.sort((a, b) => {
     const aMissed = bucketFor(a.status) === 'missed';
     const bMissed = bucketFor(b.status) === 'missed';
     if (aMissed !== bMissed) return aMissed ? -1 : 1;
-    return new Date(a.scheduled_time) - new Date(b.scheduled_time);
+    return at(a) - at(b);
   });
 
   return {

--- a/frontend/src/components/schedule/scheduleRollup.js
+++ b/frontend/src/components/schedule/scheduleRollup.js
@@ -1,0 +1,151 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Folds ScheduleList's six-value status taxonomy (see scheduleStatus.js) into
+ * the four buckets the dose panel reports: what was given, what is coming due,
+ * what was missed, what was skipped.
+ *
+ * This is a *presentation* rollup only. It deliberately does not redefine when
+ * something is missed — `computeScheduleStatus` owns that, and the backend
+ * already carries three status taxonomies that disagree with each other. A
+ * fourth would be worse than the two we have.
+ */
+
+// Order matters: it is the order the tiles appear, and the order attention is
+// paid to. `due_late` never comes out of computeScheduleStatus today but is in
+// ScheduleList's declared taxonomy, so it is mapped rather than left to fall
+// through to the default.
+const STATUS_BUCKET = {
+  completed: 'given',
+  skipped: 'skipped',
+  missed: 'missed',
+  pending: 'due',
+  upcoming: 'due',
+  due_on_time: 'due',
+  due_warning: 'due',
+  due_late: 'due',
+};
+
+export const BUCKETS = ['given', 'due', 'missed', 'skipped'];
+
+export const BUCKET_LABELS = {
+  given: 'Given',
+  due: 'Due',
+  missed: 'Missed',
+  skipped: 'Skipped',
+};
+
+/** Which of the four tiles an item belongs under. Unknown statuses count as due
+ *  rather than vanishing — an unrecognised state still needs a human to look. */
+export function bucketFor(status) {
+  return STATUS_BUCKET[status] || 'due';
+}
+
+/**
+ * Roll a list of normalized schedule items up into tile counts plus the subset
+ * that still wants a caregiver: anything missed or due, missed first, then
+ * oldest scheduled time first within each.
+ */
+export function rollupSchedule(items = []) {
+  const counts = { given: 0, due: 0, missed: 0, skipped: 0 };
+  const attention = [];
+
+  for (const item of items) {
+    const bucket = bucketFor(item.status);
+    counts[bucket] += 1;
+    if (bucket === 'missed' || bucket === 'due') attention.push(item);
+  }
+
+  attention.sort((a, b) => {
+    const aMissed = bucketFor(a.status) === 'missed';
+    const bMissed = bucketFor(b.status) === 'missed';
+    if (aMissed !== bMissed) return aMissed ? -1 : 1;
+    return new Date(a.scheduled_time) - new Date(b.scheduled_time);
+  });
+
+  return {
+    counts,
+    total: items.length,
+    needsAttention: attention,
+    // The headline the narrow panel leads with: what is worst, and when.
+    lead: attention.length ? { item: attention[0], bucket: bucketFor(attention[0].status) } : null,
+  };
+}
+
+/** "08:00" in the viewer's local clock, from an item's scheduled_time. */
+export function slotLabel(scheduledTime) {
+  // Guard falsy explicitly: `new Date(null)` is epoch 0, a perfectly valid
+  // date, so a missing time would otherwise be labelled with the local epoch
+  // hour and grouped under it.
+  if (!scheduledTime) return '';
+  const d = new Date(scheduledTime);
+  if (isNaN(d.getTime())) return '';
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+/**
+ * Group items by their local time slot, earliest first — the "08:00 · 2
+ * MEDICATIONS" bands in both layouts. Items whose scheduled_time is unparseable
+ * are kept in a trailing slot rather than dropped.
+ */
+export function groupBySlot(items = []) {
+  const slots = new Map();
+  for (const item of items) {
+    const key = slotLabel(item.scheduled_time);
+    if (!slots.has(key)) slots.set(key, []);
+    slots.get(key).push(item);
+  }
+  return [...slots.entries()]
+    .map(([time, slotItems]) => ({ time, items: slotItems }))
+    .sort((a, b) => {
+      if (!a.time) return 1;
+      if (!b.time) return -1;
+      return a.time.localeCompare(b.time);
+    });
+}
+
+/**
+ * Day, then time slot. `/api/schedule/daily?include_prior_day=true` returns
+ * yesterday's uncompleted doses alongside today's so nothing missed drops off
+ * the board — but a bare time grouping would merge yesterday's 08:00 into
+ * today's, which reads as duplicate rows of the same medication.
+ *
+ * Yesterday sorts first: it is the older debt, and it is what "missed" means.
+ */
+export function groupByDaySlot(items = []) {
+  const yesterday = items.filter(i => i.is_yesterday);
+  const today = items.filter(i => !i.is_yesterday);
+  return [
+    { day: 'yesterday', label: 'Yesterday', slots: groupBySlot(yesterday) },
+    { day: 'today', label: 'Today', slots: groupBySlot(today) },
+  ].filter(group => group.slots.length > 0);
+}
+
+// Recurrence text from the API spells out every weekday and repeats the time
+// ("Sun, Mon, Tue, Wed, Thu, Fri, Sat at 08:00"). The slot header already
+// carries the time, so trim it and collapse a full week to "Daily".
+const WEEKDAYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+export function recurrenceLabel(description) {
+  const text = (description || '').trim();
+  if (!text) return '';
+  const withoutTime = text.replace(/\s+at\s+\d{1,2}:\d{2}\s*(am|pm)?$/i, '').trim();
+  const days = withoutTime.split(/[,\s]+/).map(d => d.toLowerCase().slice(0, 3)).filter(Boolean);
+  if (days.length === 7 && WEEKDAYS.every(d => days.includes(d))) return 'Daily';
+  return withoutTime;
+}

--- a/frontend/src/components/schedule/scheduleRollup.test.js
+++ b/frontend/src/components/schedule/scheduleRollup.test.js
@@ -1,0 +1,151 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The presentation rollup behind the dose panel's four counts. The suite pins
+// TZ=America/New_York, so the local slot labels are deterministic.
+import { describe, it, expect } from 'vitest';
+import {
+  BUCKETS, bucketFor, rollupSchedule, slotLabel, groupBySlot,
+} from './scheduleRollup';
+
+const at = (h, m = 0) => new Date(2026, 7, 17, h, m, 0).toISOString();
+const dose = (name, status, hour, extra = {}) => ({
+  id: `${name}-${hour}`, name, status, scheduled_time: at(hour), ...extra,
+});
+
+describe('bucketFor', () => {
+  it('maps every status ScheduleList declares', () => {
+    expect(bucketFor('completed')).toBe('given');
+    expect(bucketFor('skipped')).toBe('skipped');
+    expect(bucketFor('missed')).toBe('missed');
+    for (const due of ['pending', 'upcoming', 'due_on_time', 'due_warning', 'due_late']) {
+      expect(bucketFor(due)).toBe('due');
+    }
+  });
+
+  it('counts an unknown status as due rather than dropping it', () => {
+    // Something a human still has to look at is better than a vanished row.
+    expect(bucketFor('something_new')).toBe('due');
+    expect(bucketFor(undefined)).toBe('due');
+  });
+
+  it('only ever returns a declared bucket', () => {
+    const statuses = ['completed', 'skipped', 'missed', 'pending', 'upcoming',
+      'due_on_time', 'due_warning', 'due_late', 'nonsense'];
+    statuses.forEach(s => expect(BUCKETS).toContain(bucketFor(s)));
+  });
+});
+
+describe('rollupSchedule', () => {
+  it('counts each bucket and totals the day', () => {
+    const { counts, total } = rollupSchedule([
+      dose('a', 'completed', 8), dose('b', 'completed', 8),
+      dose('c', 'missed', 8),
+      dose('d', 'due_on_time', 12),
+      dose('e', 'skipped', 16),
+    ]);
+    expect(counts).toEqual({ given: 2, due: 1, missed: 1, skipped: 1 });
+    expect(total).toBe(5);
+  });
+
+  it('needs attention means missed or due — never given or skipped', () => {
+    const { needsAttention } = rollupSchedule([
+      dose('given', 'completed', 8),
+      dose('skipped', 'skipped', 9),
+      dose('missed', 'missed', 10),
+      dose('due', 'due_warning', 11),
+    ]);
+    expect(needsAttention.map(i => i.name)).toEqual(['missed', 'due']);
+  });
+
+  it('puts missed ahead of due, and orders each by scheduled time', () => {
+    const { needsAttention } = rollupSchedule([
+      dose('due-late', 'due_on_time', 16),
+      dose('missed-late', 'missed', 12),
+      dose('due-early', 'pending', 14),
+      dose('missed-early', 'missed', 8),
+    ]);
+    expect(needsAttention.map(i => i.name))
+      .toEqual(['missed-early', 'missed-late', 'due-early', 'due-late']);
+  });
+
+  it('leads with the most pressing item', () => {
+    const { lead } = rollupSchedule([
+      dose('later', 'due_on_time', 16),
+      dose('overdue', 'missed', 8),
+    ]);
+    expect(lead.item.name).toBe('overdue');
+    expect(lead.bucket).toBe('missed');
+  });
+
+  it('has no lead when the day is clear', () => {
+    const { lead, counts, needsAttention } = rollupSchedule([
+      dose('a', 'completed', 8), dose('b', 'skipped', 9),
+    ]);
+    expect(lead).toBeNull();
+    expect(needsAttention).toEqual([]);
+    expect(counts.given).toBe(1);
+  });
+
+  it('handles an empty day', () => {
+    const { counts, total, needsAttention, lead } = rollupSchedule([]);
+    expect(counts).toEqual({ given: 0, due: 0, missed: 0, skipped: 0 });
+    expect(total).toBe(0);
+    expect(needsAttention).toEqual([]);
+    expect(lead).toBeNull();
+  });
+
+  it('defaults to an empty list rather than throwing', () => {
+    expect(rollupSchedule().total).toBe(0);
+  });
+});
+
+describe('slotLabel', () => {
+  it('is the zero-padded local clock time', () => {
+    expect(slotLabel(at(8, 0))).toBe('08:00');
+    expect(slotLabel(at(16, 5))).toBe('16:05');
+  });
+
+  it('is empty for an unparseable time', () => {
+    expect(slotLabel('not a date')).toBe('');
+    expect(slotLabel(null)).toBe('');
+  });
+});
+
+describe('groupBySlot', () => {
+  it('buckets by local time, earliest first', () => {
+    const groups = groupBySlot([
+      dose('c', 'pending', 16), dose('a', 'missed', 8),
+      dose('b', 'missed', 8), dose('d', 'pending', 12),
+    ]);
+    expect(groups.map(g => g.time)).toEqual(['08:00', '12:00', '16:00']);
+    expect(groups[0].items.map(i => i.name)).toEqual(['a', 'b']);
+  });
+
+  it('keeps undated items in a trailing slot instead of dropping them', () => {
+    const groups = groupBySlot([
+      { id: 'x', name: 'broken', status: 'pending', scheduled_time: 'nope' },
+      dose('a', 'missed', 8),
+    ]);
+    expect(groups.map(g => g.time)).toEqual(['08:00', '']);
+    expect(groups[1].items.map(i => i.name)).toEqual(['broken']);
+  });
+
+  it('handles an empty day', () => {
+    expect(groupBySlot([])).toEqual([]);
+  });
+});

--- a/frontend/src/components/schedule/scheduleRollup.test.js
+++ b/frontend/src/components/schedule/scheduleRollup.test.js
@@ -101,6 +101,20 @@ describe('rollupSchedule', () => {
     expect(counts.given).toBe(1);
   });
 
+  it('orders undated items last instead of leaving it to the engine', () => {
+    // A NaN comparator makes the sort order implementation-defined, and
+    // groupBySlot explicitly keeps undated items — so they do occur.
+    const { needsAttention } = rollupSchedule([
+      { id: 'no-date', name: 'undated', status: 'due_on_time', scheduled_time: null },
+      dose('late', 'due_on_time', 16),
+      { id: 'bad-date', name: 'unparseable', status: 'due_on_time', scheduled_time: 'nope' },
+      dose('early', 'due_on_time', 8),
+    ]);
+    expect(needsAttention.slice(0, 2).map(i => i.name)).toEqual(['early', 'late']);
+    expect(needsAttention.slice(2).map(i => i.name).sort())
+      .toEqual(['undated', 'unparseable']);
+  });
+
   it('handles an empty day', () => {
     const { counts, total, needsAttention, lead } = rollupSchedule([]);
     expect(counts).toEqual({ given: 0, due: 0, missed: 0, skipped: 0 });

--- a/frontend/src/contexts/ModalDockContext.jsx
+++ b/frontend/src/contexts/ModalDockContext.jsx
@@ -28,7 +28,11 @@ import { createContext, useContext } from 'react';
  * Outside a provider the default is inert, so every other ModalBase consumer
  * (the PIN challenge, quick-add, the alert detail sheet) is untouched.
  */
-const INERT = { docked: false, expanded: false, toggleExpand: null };
+// `setExpanded` is separate from `toggleExpand` because content inside a panel
+// sometimes needs to *reach* the wide stop rather than flip it — tapping a dose
+// card in the narrow medications panel opens it in the detail pane, which only
+// exists once expanded.
+const INERT = { docked: false, expanded: false, toggleExpand: null, setExpanded: null };
 
 const ModalDockContext = createContext(INERT);
 

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -965,6 +965,7 @@ export default function Dashboard() {
     docked: !isMobile,
     expanded: panelExpanded,
     toggleExpand: () => setPanelExpanded(v => !v),
+    setExpanded: setPanelExpanded,
   }), [isMobile, panelExpanded]);
 
   return (

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -208,14 +208,19 @@ export default function Dashboard() {
       const set = (name, px) => target.style.setProperty(name, `${Math.round(px)}px`);
       const board = root.getBoundingClientRect();
 
-      // Fallback: locked (single centred column) and any state without the
-      // charts/cards columns has nothing to dock beside, so the panel takes
-      // the whole board below the top bar.
+      // Locked (a single centred tiles column) and any state without the
+      // charts/cards columns: dock to the right of the tiles rather than over
+      // them. An auth prompt gates *actions*, not the reading of vitals — the
+      // pulse ox keeps streaming while the board is locked, so covering the
+      // tiles would hide live values that are there to be seen.
       if (!main || !charts || !cards) {
+        const tiles = root.querySelector('.ld-tiles');
+        const gap = main ? parseFloat(getComputedStyle(main).columnGap) || 0 : 0;
+        const left = tiles ? tiles.getBoundingClientRect().right - board.left + gap : 0;
         set('--ld-panel-top', topbar?.offsetHeight ?? 60);
         set('--ld-panel-bottom', strip?.offsetHeight ?? 0);
-        set('--ld-panel-left', 0);
-        set('--ld-panel-left-wide', 0);
+        set('--ld-panel-left', left);
+        set('--ld-panel-left-wide', left);
         set('--ld-panel-right', 0);
         return;
       }
@@ -1223,6 +1228,11 @@ export default function Dashboard() {
           </div>
         )}
       </div>
+
+      {/* Portal target for screen-level auth prompts. Inside `.live-dash` so
+          they inherit the board's dark tokens and its measured panel geometry
+          instead of landing on <body> in the app's default palette. */}
+      <div id="ld-auth-slot" />
 
       <StatusStrip
         wsStatus={wsStatus}

--- a/frontend/src/pages/admin-v2/vc-content.css
+++ b/frontend/src/pages/admin-v2/vc-content.css
@@ -32,8 +32,13 @@
  * actions. */
 @import '../../styles/vc-tokens.css';
 
-/* ---------- ScheduleList status palette (consumed as inline-style vars) ---------- */
-:root:not(.light) {
+/* ---------- ScheduleList status palette (consumed as inline-style vars) ----------
+   `.force-dark` is included because the live dashboard pins itself dark through
+   that class rather than through the html theme class. Without it, a user whose
+   theme is light gets ScheduleList's bootstrap *light* fallbacks on the dark
+   board. */
+:root:not(.light),
+.force-dark {
   --sched-ontime-bg: color-mix(in srgb, var(--vc-state-due) 8%, var(--vc-bg-raised));
   --sched-ontime-border: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
   --sched-ontime-text: var(--vc-text-primary);


### PR DESCRIPTION
## The problem

The dock got two stops in #113–#115, but the section content never caught up. Medications, Care Tasks and Nutrition all render through `ScheduleList`, which picks its layout from `window.innerWidth <= 768` — so a **380px panel on a 1920px screen gets the desktop layout at mobile width**, with name + dose + description + category chip + status pill + two buttons fighting over one flex line. That same viewport test is repeated in five places.

## The two readings

`DoseScheduleView` sizes itself from the dock instead, off the **same normalized items** `MedicationModal` already produces — no data-layer change:

- **narrow (and phone)** — triage. What is overdue, banded by day and time, `Record dose` on each card.
- **expanded** — Given / Due / Missed / Skipped counts, a time-grouped table, and a detail pane for the selected dose with its history.

The wide layout is opt-in on `expanded`, not on `docked`: a phone is narrow and has no expand control, so keying off `docked` handed it the table. Tapping a card in the narrow panel selects the dose and expands (the detail pane only exists at the wide stop); `Record dose` and `Skip` `stopPropagation` so they act in place.

Per your note, the time separation is explicit in **both** sizes — day header, then a time band per slot with its own count and `Record all`, rather than the time repeated inside every card.

## Two things the data made me fix

**Yesterday vs today.** The endpoint is called with `include_prior_day` so nothing missed drops off the board. A plain time grouping merged them, which read as the same medication listed twice at 08:00. Grouping is day, then time.

**Recurrence text.** The API returns `"Sun, Mon, Tue, Wed, Thu, Fri, Sat at 08:00"` — that's `Daily` next to a band header that already says 08:00.

## Detail pane

Its actions call `MedicationModal`'s existing handlers, so the 409 paths survive untouched — the off-window confirm and the insufficient-quantity gate both still fire from the pane. Selection is keyed on the **schedule slot, not the normalized id**: that id embeds `log_id`, which appears the moment a dose is recorded, so selecting by it would drop the selection on the refetch that follows.

## Two backend fixes the pane depends on

| | |
|---|---|
| **`administered_by` was never written** | The column has existed since the initial migration and is read back as `completed_by`, so every medication reported `None` while care tasks recorded it properly. Now set from the current user on all three administer paths. |
| **History filtered by name substring** | `"Pro"` returns Propranolol *and* Propafenone. Added an exact `medication_id` filter — every schedule row already carries the id — and surfaced `administered_by` on the records. |

Both tested. The `/api/schedule/daily` contract, the 409 envelopes and undo's quantity restore are untouched.

## One theming fix

`vc-content.css` defines the `--sched-*` palette under `:root:not(.light)`, but the dashboard pins itself dark through `.force-dark` — so a light-theme user got `ScheduleList`'s bootstrap **light** fallbacks on the dark board. Widened the selector, which fixes Care Tasks and Nutrition too.

## Deliberately not in this pass

- **Structured skip reasons.** A skip is `dose_amount == 0` with the reason as free text in `notes`; there is no reason list, column or enum anywhere. Doing it properly means a migration and care-task parity — not a layout change. Skip stays wired to today's behaviour.
- **Care Tasks and Nutrition**, per the scope call. Both keep `ScheduleList`.
- **Day navigation**, per your call — today only; admin has the day view.
- **The Active tab** is kept rather than dropped, though the mockup's expanded tabs don't show it.

## Verification

- 1920×1080: narrow sits on the cards column, no horizontal overflow; tapping a card widens to 1554 and opens that dose; recording through the off-window confirm moves Given 0→1 and Missed 24→23 with the selection intact and the note on the record
- Mobile 390×844: cards, no expand control, no overflow
- Care Tasks and Nutrition unchanged at both stops
- 422 frontend tests (33 new), 587 backend (2 new), lint and build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011u7gjNWppXao35QPLtBBQe