### PR TITLE
Nutrition in the docked panel

### DIFF
--- a/backend/crud/nutrition.py
+++ b/backend/crud/nutrition.py
@@ -520,10 +520,18 @@ def get_patient_nutrition_intake(
     limit: int = 50,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
+    schedule_id: Optional[int] = None,
 ) -> List[NutritionIntake]:
     """Get nutrition intake records for a patient, optionally bounded by a
-    consumed_at date range (UTC datetimes)."""
+    consumed_at date range (UTC datetimes).
+
+    `schedule_id` narrows to the intakes recorded against one nutrition
+    schedule — what the dose panel shows as that item's history. Ad-hoc
+    intakes carry no schedule, so they are correctly excluded.
+    """
     query = db.query(NutritionIntake).filter(NutritionIntake.patient_id == patient_id)
+    if schedule_id is not None:
+        query = query.filter(NutritionIntake.schedule_id == schedule_id)
     if start_date:
         query = query.filter(NutritionIntake.consumed_at >= start_date)
     if end_date:

--- a/backend/routes/nutrition.py
+++ b/backend/routes/nutrition.py
@@ -133,12 +133,14 @@ async def get_patient_nutrition_intake_endpoint(
     limit: int = 50,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
+    schedule_id: Optional[int] = None,
     db: Session = Depends(get_db),
     _: bool = Depends(require_read_access)
 ):
     """Get nutrition intake records for a patient, optionally bounded by a
-    consumed_at date range."""
-    intake_records = get_patient_nutrition_intake(db, patient_id, limit, start_date, end_date)
+    consumed_at date range and/or narrowed to one nutrition schedule."""
+    intake_records = get_patient_nutrition_intake(
+        db, patient_id, limit, start_date, end_date, schedule_id=schedule_id)
     return intake_records
 
 @router.get("/patients/{patient_id}/nutrition-intake/daily")

--- a/backend/tests/test_nutrition.py
+++ b/backend/tests/test_nutrition.py
@@ -26,6 +26,54 @@ def _iso_utc(d, hour):
     return f"{d.isoformat()}T{hour:02d}:00:00+00:00"
 
 
+def test_intake_history_filters_by_schedule(admin_client, patient, db_session):
+    """`schedule_id` narrows intake history to one nutrition schedule.
+
+    The dose panel shows this as an item's own history, so it must not mix in
+    other items — and ad-hoc intakes, which carry no schedule at all, must not
+    appear under any of them.
+    """
+    from schemas.nutrition_intake import NutritionIntake
+    from schemas.nutrition_schedule import NutritionSchedule
+    from datetime import datetime, timezone
+
+    def _schedule(name):
+        row = NutritionSchedule(patient_id=patient.id, schedule_type="liquid",
+                                name=name, cron_expression="0 1 * * *")
+        db_session.add(row)
+        db_session.flush()
+        return row.id
+
+    water_id = _schedule("Overnight Water")
+    feed_id = _schedule("Morning Feed")
+
+    def _record(schedule_id, name):
+        db_session.add(NutritionIntake(
+            patient_id=patient.id, schedule_id=schedule_id, item_name=name,
+            item_type="liquid", amount=100.0, amount_unit="ml",
+            consumed_at=datetime.now(timezone.utc),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        ))
+
+    _record(water_id, "Overnight Water")
+    _record(water_id, "Overnight Water")
+    _record(feed_id, "Morning Feed")
+    _record(None, "Ad-hoc sip")
+    db_session.commit()
+
+    scoped = admin_client.get(
+        f"/api/patients/{patient.id}/nutrition-intake?schedule_id={water_id}")
+    assert scoped.status_code == 200, scoped.text
+    names = [r["item_name"] for r in scoped.json()]
+    assert names == ["Overnight Water", "Overnight Water"]
+
+    # Unfiltered still returns everything, ad-hoc included.
+    everything = admin_client.get(f"/api/patients/{patient.id}/nutrition-intake")
+    assert {r["item_name"] for r in everything.json()} == {
+        "Overnight Water", "Morning Feed", "Ad-hoc sip"}
+
+
 def test_create_nutrition_intake(admin_client, patient):
     resp = admin_client.post(f"/api/nutrition-intake?patient_id={patient.id}", json=_intake())
     assert resp.status_code == 200

--- a/frontend/src/components/CareTaskModal.jsx
+++ b/frontend/src/components/CareTaskModal.jsx
@@ -330,9 +330,13 @@ const CareTaskModal = ({ onClose }) => {
             views={viewOptions}
             value={tab}
             onChange={setTab}
-            prnCount={activeTasks.length}
-            prnDisabled={!selectedPatient}
-            onPrn={openPrnPicker}
+            actions={[{
+              label: 'PRN',
+              count: activeTasks.length,
+              onClick: openPrnPicker,
+              disabled: !selectedPatient,
+              title: 'Record an ad-hoc care task',
+            }]}
           />
 
           <div style={{ flex: 1, overflow: 'auto' }}>
@@ -354,8 +358,8 @@ const CareTaskModal = ({ onClose }) => {
                     labels={TASK_LABELS}
                     scheduleHref="/care/care-tasks/schedule"
                     skipNote="Recorded as skipped with your note"
-                    historyQuery={(item) => (item?._raw?.care_task_id
-                      ? `/api/care-tasks/history?task_id=${item._raw.care_task_id}`
+                    historyQuery={(item, pid) => (item?._raw?.care_task_id
+                      ? `/api/care-tasks/history?task_id=${item._raw.care_task_id}&patient_id=${pid}&limit=10`
                       : null)}
                     mapHistoryRow={(row) => ({
                       id: row.id,

--- a/frontend/src/components/MedicationModal.jsx
+++ b/frontend/src/components/MedicationModal.jsx
@@ -342,9 +342,15 @@ const MedicationModal = ({ onClose }) => {
             views={viewOptions}
             value={tab}
             onChange={setTab}
-            prnCount={prnMedications.length}
-            prnDisabled={!selectedPatient || prnMedications.length === 0}
-            onPrn={openPrnPicker}
+            actions={[{
+              label: 'PRN',
+              count: prnMedications.length,
+              onClick: openPrnPicker,
+              disabled: !selectedPatient || prnMedications.length === 0,
+              title: prnMedications.length === 0
+                ? 'No as-needed medications for this patient'
+                : 'Give an as-needed medication',
+            }]}
           />
 
           <div style={{ flex: 1, overflow: 'auto' }}>

--- a/frontend/src/components/NutritionModal.jsx
+++ b/frontend/src/components/NutritionModal.jsx
@@ -27,7 +27,12 @@ import {
 } from '../utils/timezone';
 import IntakeModal from '../pages/admin-v2/components/IntakeModal';
 import OutputModal from '../pages/admin-v2/components/OutputModal';
-import ScheduleList from './schedule/ScheduleList';
+import DoseScheduleView from './schedule/DoseScheduleView';
+import DoseDetailPane from './schedule/DoseDetailPane';
+import { NUTRITION_LABELS } from './schedule/scheduleLabels';
+import { rollupSchedule } from './schedule/scheduleRollup';
+import PanelViewSwitcher from './section-panel/PanelViewSwitcher';
+import './section-panel/section-panel.css';
 import { computeScheduleStatus } from './schedule/scheduleStatus';
 import { Button } from '@/components/ui/button';
 import { Alert } from '@/components/ui/alert';
@@ -54,9 +59,12 @@ const NutritionModal = ({ onClose }) => {
   const { selectedPatient } = useAdminPatient();
   const { user } = useAuth() || {};
   const [tab, setTab] = useState('scheduled');
+  // Keyed on the schedule slot, not the normalized id — see the medication
+  // panel: the id embeds the log and changes the moment an item is recorded.
+  const [selectedId, setSelectedId] = useState(null);
+  const [bulkConfirm, setBulkConfirm] = useState({ open: false, items: [], count: 0 });
   const [scheduled, setScheduled] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [isMobile, setIsMobile] = useState(typeof window !== 'undefined' && window.innerWidth <= 768);
 
   // Off-window confirm (mirrors care-task modal)
   const [windowConfirm, setWindowConfirm] = useState({ open: false, item: null, check: null });
@@ -65,12 +73,6 @@ const NutritionModal = ({ onClose }) => {
   // the shared AdminV2 modal of the same name.
   const [prnMode, setPrnMode] = useState(null); // null | 'pick' | 'intake' | 'output'
   const [prnDefaultDateTime, setPrnDefaultDateTime] = useState('');
-
-  useEffect(() => {
-    const onResize = () => setIsMobile(window.innerWidth <= 768);
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, []);
 
   useEffect(() => {
     if (!selectedPatient) return;
@@ -124,8 +126,31 @@ const NutritionModal = ({ onClose }) => {
     });
   }, [scheduled]);
 
+  const itemKey = (raw) => `${raw?.schedule_id ?? 'prn'}-${raw?.scheduled_time}`;
+  const selectedItem = useMemo(
+    () => scheduledItems.find(i => itemKey(i._raw) === selectedId) || null,
+    [scheduledItems, selectedId]
+  );
+  const recordingAs = user?.full_name || user?.username || null;
+
+  // Nutrition has a single view, so the row shows a heading rather than a
+  // dropdown — the outstanding count still earns its place.
+  const viewOptions = useMemo(() => {
+    const { counts } = rollupSchedule(scheduledItems);
+    const outstanding = counts.missed + counts.due;
+    return [{
+      value: 'scheduled',
+      label: 'Scheduled',
+      sublabel: "Today's nutrition",
+      note: counts.missed > 0
+        ? `${counts.missed} missed`
+        : (outstanding > 0 ? `${outstanding} due` : 'All done'),
+      tone: counts.missed > 0 || outstanding > 0 ? 'due' : 'given',
+    }];
+  }, [scheduledItems]);
+
   // ===== Complete scheduled item =====
-  const submitComplete = async (item, earlyOverride = false) => {
+  const submitComplete = async (item, { earlyOverride = false, note } = {}) => {
     try {
       const res = await fetch(`${config.apiUrl}/api/schedule/complete/nutrition`, {
         method: 'POST',
@@ -137,7 +162,7 @@ const NutritionModal = ({ onClose }) => {
           patient_id: selectedPatient.id,
           user_id: user?.id || null,
           completed_at: null,
-          notes: 'Completed via live dashboard',
+          notes: note || 'Completed via live dashboard',
           early_override: earlyOverride,
         }),
       });
@@ -155,6 +180,7 @@ const NutritionModal = ({ onClose }) => {
         setWindowConfirm({
           open: true,
           item,
+          note,
           check: checkAdministrationWindow(item.scheduled_time),
         });
         return;
@@ -166,12 +192,52 @@ const NutritionModal = ({ onClose }) => {
     }
   };
 
-  const handleMarkCompleted = (item) => submitComplete(item, false);
-
   // ===== PRN entry =====
-  const openPrnPicker = () => {
+  // Seeds the form's default time, which the direct Intake/Output buttons
+  // would otherwise skip.
+  const openPrn = (mode) => {
     setPrnDefaultDateTime(getCurrentLocalDateTime());
-    setPrnMode('pick');
+    setPrnMode(mode);
+  };
+
+  // Bulk uses the unified endpoint, which fills each item's defaults from its
+  // schedule and publishes the due-count change just as the single path does.
+  // It pre-flights the whole batch against the administration window, so one
+  // confirmation covers the slot instead of one dialog per item.
+  const submitBulk = async (items, { earlyOverride = false } = {}) => {
+    if (!selectedPatient || items.length === 0) return;
+    try {
+      const res = await fetch(`${config.apiUrl}/api/schedule/complete/bulk`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          nutrition: items.map(i => ({
+            schedule_id: i.schedule_id,
+            scheduled_time: i.scheduled_time,
+            patient_id: selectedPatient.id,
+            user_id: user?.id || null,
+            completed_at: null,
+            early_override: earlyOverride,
+          })),
+        }),
+      });
+      if (res.ok) { fetchSchedule(); return; }
+      const err = await res.json().catch(() => ({}));
+      const offWindow = res.status === 409 && (
+        err.error === 'early_administration' ||
+        err.error === 'late_administration' ||
+        err.error === 'off_window_administration'
+      );
+      if (offWindow && !earlyOverride) {
+        setBulkConfirm({ open: true, items, count: err.early_items?.length || items.length });
+        return;
+      }
+      alert(err.detail || err.error || 'Failed to record all');
+    } catch (err) {
+      console.error('Error completing nutrition items:', err);
+      alert('Error connecting to server');
+    }
   };
 
   const closePrn = () => setPrnMode(null);
@@ -185,54 +251,71 @@ const NutritionModal = ({ onClose }) => {
   return (
     <>
       <ModalBase isOpen={true} onClose={onClose} title={
-        isMobile ? (
-          <div className="tw flex w-full gap-2">
-            <Select value={tab} onValueChange={setTab}>
-              <SelectTrigger className="flex-1"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="scheduled">Scheduled</SelectItem>
-              </SelectContent>
-            </Select>
-            <Button
-              onClick={openPrnPicker}
-              disabled={!selectedPatient}
-              className="shrink-0 bg-[#6f42c1] text-white hover:bg-[#6f42c1]/90"
-            >PRN</Button>
-          </div>
-        ) : (
-          <div className="tw flex w-full items-center gap-2">
-            <Button
-              size="sm"
-              variant={tab === 'scheduled' ? 'default' : 'secondary'}
-              onClick={() => setTab('scheduled')}
-            >Scheduled</Button>
-            <Button
-              size="sm"
-              onClick={openPrnPicker}
-              disabled={!selectedPatient}
-              className="bg-[#6f42c1] text-white hover:bg-[#6f42c1]/90"
-            >PRN</Button>
-          </div>
-        )
+        <span className="mp-modal-title">
+          <span>Nutrition</span>
+          <span className="mp-modal-title-sub">
+            {selectedPatient
+              ? `${selectedPatient.first_name} ${selectedPatient.last_name} \u00b7 Schedule`
+              : 'No patient selected'}
+          </span>
+        </span>
       }>
         <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-          {/* Patient banner */}
-          <div className="tw" style={{ marginBottom: 16 }}>
-            <Alert variant={selectedPatient ? 'default' : 'warning'}>
-              {selectedPatient
-                ? <>Viewing nutrition for: {selectedPatient.first_name} {selectedPatient.last_name}</>
-                : 'No patient selected'}
-            </Alert>
-          </div>
+          {!selectedPatient && (
+            <div className="tw" style={{ marginBottom: 16 }}>
+              <Alert variant="warning">No patient selected</Alert>
+            </div>
+          )}
+
+          {/* Two entry points rather than one PRN: intake and output are
+              different records, and the extra pick dialog was a tap with
+              nothing else in it. */}
+          <PanelViewSwitcher
+            views={viewOptions}
+            value={tab}
+            onChange={setTab}
+            actions={[
+              { label: 'Intake', onClick: () => openPrn('intake'), disabled: !selectedPatient,
+                title: 'Log an ad-hoc intake' },
+              { label: 'Output', onClick: () => openPrn('output'), disabled: !selectedPatient,
+                title: 'Log an output' },
+            ]}
+          />
 
           <div style={{ flex: 1, overflow: 'auto' }}>
             {tab === 'scheduled' && (
-              <ScheduleList
+              <DoseScheduleView
                 items={scheduledItems}
                 loading={loading}
-                title="Scheduled Nutrition"
                 emptyText="No scheduled nutrition for today"
-                onMarkComplete={(item) => handleMarkCompleted(item._raw)}
+                labels={NUTRITION_LABELS}
+                selectedId={selectedItem?.id || null}
+                onSelect={(item) => setSelectedId(item ? itemKey(item._raw) : null)}
+                onRecord={(item, opts) => submitComplete(item._raw, opts)}
+                onRecordAll={(items) => submitBulk(items.map(i => i._raw))}
+                detail={(
+                  <DoseDetailPane
+                    item={selectedItem}
+                    patientId={selectedPatient?.id}
+                    recordingAs={recordingAs}
+                    labels={NUTRITION_LABELS}
+                    scheduleHref="/care/nutrition/schedule"
+                    historyQuery={(item, pid) => (item?._raw?.schedule_id
+                      ? `/api/patients/${pid}/nutrition-intake?schedule_id=${item._raw.schedule_id}&limit=10`
+                      : null)}
+                    mapHistoryRow={(row) => ({
+                      id: row.id,
+                      at: row.consumed_at,
+                      status: 'Taken',
+                      tone: 'given',
+                      meta: row.amount != null
+                        ? `${row.amount}${row.amount_unit ? ` ${row.amount_unit}` : ''}`
+                        : null,
+                      note: row.notes,
+                    })}
+                    onRecord={(item, opts) => submitComplete(item._raw, opts)}
+                  />
+                )}
               />
             )}
           </div>
@@ -249,7 +332,7 @@ const NutritionModal = ({ onClose }) => {
         const offsetText = isLate
           ? `${formatDurationMinutes(Math.abs(windowConfirm.check.minutesOffset))} ago`
           : `${formatDurationMinutes(windowConfirm.check.minutesOffset)} from now`;
-        const close = () => setWindowConfirm({ open: false, item: null, check: null });
+        const close = () => setWindowConfirm({ open: false, item: null, note: undefined, check: null });
         return (
           <Dialog open onOpenChange={(o) => { if (!o) close(); }}>
             <DialogContent className="sm:max-w-[440px]" aria-describedby={undefined}>
@@ -271,9 +354,9 @@ const NutritionModal = ({ onClose }) => {
                 <Button variant="secondary" onClick={close}>Cancel</Button>
                 <Button
                   onClick={async () => {
-                    const item = windowConfirm.item;
+                    const { item, note } = windowConfirm;
                     close();
-                    await submitComplete(item, true);
+                    await submitComplete(item, { earlyOverride: true, note });
                   }}
                 >Complete Anyway</Button>
               </DialogFooter>
@@ -282,31 +365,30 @@ const NutritionModal = ({ onClose }) => {
         );
       })()}
 
-      {/* PRN pick: intake vs output */}
-      <Dialog open={prnMode === 'pick'} onOpenChange={(o) => { if (!o) closePrn(); }}>
-        <DialogContent className="sm:max-w-[480px]" aria-describedby={undefined}>
+      {/* Off-window confirm for a whole slot */}
+      <Dialog open={bulkConfirm.open} onOpenChange={(o) => { if (!o) setBulkConfirm({ open: false, items: [], count: 0 }); }}>
+        <DialogContent className="sm:max-w-[440px]" aria-describedby={undefined}>
           <DialogHeader>
-            <DialogTitle>Log Ad-Hoc Nutrition</DialogTitle>
+            <DialogTitle className="flex items-center gap-2">
+              <span className="flex h-7 w-7 items-center justify-center rounded-md bg-[rgba(240,136,62,0.2)] text-[#f0883e]">⚠</span>
+              Confirm Off-Window Completion
+            </DialogTitle>
           </DialogHeader>
-          <div className="grid grid-cols-2 gap-3">
-            <Button
-              type="button"
-              onClick={() => setPrnMode('intake')}
-              className="h-auto flex-col gap-1.5 py-6 text-base font-bold"
-            >
-              <span className="text-2xl leading-none">↓</span>
-              Log Intake
-            </Button>
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={() => setPrnMode('output')}
-              className="h-auto flex-col gap-1.5 py-6 text-base font-bold"
-            >
-              <span className="text-2xl leading-none">↑</span>
-              Log Output
-            </Button>
-          </div>
+          <Alert variant="warning">
+            <div className="mb-1.5 font-semibold text-[#f0883e]">Some items are outside their window</div>
+            <div>
+              {bulkConfirm.count} item{bulkConfirm.count === 1 ? ' is' : 's are'} outside the
+              administration window. Record them anyway?
+            </div>
+          </Alert>
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setBulkConfirm({ open: false, items: [], count: 0 })}>Cancel</Button>
+            <Button onClick={async () => {
+              const items = bulkConfirm.items;
+              setBulkConfirm({ open: false, items: [], count: 0 });
+              await submitBulk(items, { earlyOverride: true });
+            }}>Record Anyway</Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 

--- a/frontend/src/components/schedule/DoseDetailPane.jsx
+++ b/frontend/src/components/schedule/DoseDetailPane.jsx
@@ -59,9 +59,9 @@ const fmtDateTime = (iso) => {
 // Medication defaults. Filtering by medication_id, not name: the name filter
 // is a substring match, so "Pro" would pull in every medication starting with
 // it.
-const defaultHistoryQuery = (item) => {
+const defaultHistoryQuery = (item, patientId) => {
   const id = item?._raw?.medication_id;
-  return id ? `/api/medications/history?medication_id=${id}` : null;
+  return id ? `/api/medications/history?medication_id=${id}&patient_id=${patientId}&limit=10` : null;
 };
 
 const HISTORY_STATUS_TONE = { skipped: 'skipped' };
@@ -105,7 +105,7 @@ export default function DoseDetailPane({
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyError, setHistoryError] = useState(false);
 
-  const query = historyQuery ? historyQuery(item) : defaultHistoryQuery(item);
+  const query = historyQuery ? historyQuery(item, patientId) : defaultHistoryQuery(item, patientId);
 
   // The note belongs to the dose in front of you, not to the pane.
   useEffect(() => {
@@ -125,11 +125,11 @@ export default function DoseDetailPane({
     setHistoryError(false);
     (async () => {
       try {
-        const res = await apiFetch(`${config.apiUrl}${query}&patient_id=${patientId}&limit=10`);
+        const res = await apiFetch(`${config.apiUrl}${query}`);
         if (cancelled) return;
         if (!res.ok) { setHistoryError(true); return; }
         const data = await res.json();
-        if (!cancelled) setHistory(data.history || []);
+        if (!cancelled) setHistory(Array.isArray(data) ? data : (data.history || []));
       } catch {
         if (!cancelled) setHistoryError(true);
       }

--- a/frontend/src/components/schedule/DoseScheduleView.test.jsx
+++ b/frontend/src/components/schedule/DoseScheduleView.test.jsx
@@ -24,7 +24,7 @@ import { render, screen, fireEvent, within } from '@testing-library/react';
 
 import DoseScheduleView from './DoseScheduleView';
 import { ModalDockProvider } from '../../contexts/ModalDockContext';
-import { TASK_LABELS } from './scheduleLabels';
+import { TASK_LABELS, NUTRITION_LABELS } from './scheduleLabels';
 
 const at = (h, m = 0) => new Date(2026, 7, 17, h, m, 0).toISOString();
 
@@ -341,5 +341,40 @@ describe('DoseScheduleView — care task vocabulary', () => {
     );
     expect(container.querySelector('.ld-dose-chip')).toBeNull();
     expect(screen.getByText('10 mL')).toBeInTheDocument();
+  });
+});
+
+// Nutrition has no skip concept at all, so the affordance must not appear
+// just because the layout is shared.
+describe('DoseScheduleView — nutrition vocabulary', () => {
+  const FEEDS = [
+    {
+      id: 'water', name: 'Overnight Water', extra: 'Water · 660 ml', description: 'Daily',
+      status: 'missed', is_completed: false, scheduled_time: at(1),
+      _raw: { schedule_id: 3 },
+    },
+  ];
+
+  it('uses the nutrition wording', () => {
+    const { container } = render(
+      <ModalDockProvider value={{ docked: true, expanded: true, setExpanded: vi.fn() }}>
+        <DoseScheduleView items={FEEDS} labels={NUTRITION_LABELS} onRecord={vi.fn()} onRecordAll={vi.fn()} />
+      </ModalDockProvider>
+    );
+    expect(screen.getByRole('button', { name: /mark taken/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /mark all taken/i })).toBeInTheDocument();
+    const heads = [...container.querySelectorAll('.ld-dose-table thead th')].map(t => t.textContent);
+    expect(heads).toEqual(['Item', 'Amount', 'Schedule', 'Status', 'Actions']);
+    expect(container.querySelector('.ld-dose-slot-count').textContent).toBe('1 item');
+  });
+
+  it('offers no skip when the section has no skip', () => {
+    // onSkip is simply not passed; nothing may invent the affordance.
+    render(
+      <ModalDockProvider value={{ docked: true, expanded: false, setExpanded: vi.fn() }}>
+        <DoseScheduleView items={FEEDS} labels={NUTRITION_LABELS} onRecord={vi.fn()} />
+      </ModalDockProvider>
+    );
+    expect(screen.queryByRole('button', { name: /^skip$/i })).toBeNull();
   });
 });

--- a/frontend/src/components/schedule/scheduleLabels.js
+++ b/frontend/src/components/schedule/scheduleLabels.js
@@ -33,3 +33,10 @@ export const TASK_LABELS = {
   primary: 'Mark done', bulk: 'Complete all',
   notePlaceholder: 'Anything worth recording with this task',
 };
+
+export const NUTRITION_LABELS = {
+  one: 'item', many: 'items',
+  nameColumn: 'Item', metaColumn: 'Amount',
+  primary: 'Mark taken', bulk: 'Mark all taken',
+  notePlaceholder: 'Anything worth recording with this item',
+};

--- a/frontend/src/components/section-panel/PanelViewSwitcher.jsx
+++ b/frontend/src/components/section-panel/PanelViewSwitcher.jsx
@@ -41,18 +41,53 @@ export default function PanelViewSwitcher({
   views,
   value,
   onChange,
-  prnCount = 0,
-  prnDisabled = false,
-  onPrn,
+  actions = [],
 }) {
   const current = views.find((v) => v.value === value) || views[0];
+  // Nutrition has a single view; a dropdown that cannot go anywhere is a lie
+  // about what is available, so it renders as a plain heading instead.
+  const single = views.length < 2;
+
+  const actionButtons = actions.map((action) => (
+    <button
+      key={action.label}
+      type="button"
+      className="mp-prn-btn"
+      onClick={action.onClick}
+      disabled={action.disabled}
+      title={action.title || action.label}
+    >
+      <span className="mp-prn-label">{action.label}</span>
+      {action.count != null && <span className="mp-prn-count">{action.count}</span>}
+    </button>
+  ));
+
+  if (single) {
+    return (
+      <div className="mp-viewrow">
+        <span className="mp-viewrow-label">View</span>
+        <div className="mp-viewrow-controls">
+          <div className="mp-view-trigger static">
+            <span className="mp-view-trigger-text">
+              <span className="mp-view-title">{current?.label}</span>
+              {current?.sublabel && <span className="mp-view-sub">{current.sublabel}</span>}
+            </span>
+            {current?.note && (
+              <span className={`mp-view-note ${current.tone || ''}`}>{current.note}</span>
+            )}
+          </div>
+          {actionButtons}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="mp-viewrow">
       <span className="mp-viewrow-label">View</span>
       <div className="mp-viewrow-controls">
         <SelectPrimitive.Root value={value} onValueChange={onChange}>
-          <SelectPrimitive.Trigger className="mp-view-trigger" aria-label="Choose a medication view">
+          <SelectPrimitive.Trigger className="mp-view-trigger" aria-label="Choose a view">
             <span className="mp-view-trigger-text">
               <span className="mp-view-title">{current?.label}</span>
               {current?.sublabel && <span className="mp-view-sub">{current.sublabel}</span>}
@@ -93,16 +128,7 @@ export default function PanelViewSwitcher({
           </SelectPrimitive.Portal>
         </SelectPrimitive.Root>
 
-        <button
-          type="button"
-          className="mp-prn-btn"
-          onClick={onPrn}
-          disabled={prnDisabled}
-          title={prnDisabled ? 'No as-needed medications for this patient' : 'Give an as-needed medication'}
-        >
-          <span className="mp-prn-label">PRN</span>
-          <span className="mp-prn-count">{prnCount}</span>
-        </button>
+        {actionButtons}
       </div>
     </div>
   );

--- a/frontend/src/components/section-panel/PanelViewSwitcher.test.jsx
+++ b/frontend/src/components/section-panel/PanelViewSwitcher.test.jsx
@@ -1,0 +1,93 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The panel's view row: which list you're on, plus the section's entry points.
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PanelViewSwitcher from './PanelViewSwitcher';
+
+const TWO = [
+  { value: 'scheduled', label: 'Scheduled', sublabel: "Today's doses", note: '3 missed', tone: 'due' },
+  { value: 'active', label: 'Active', sublabel: 'All profiles', count: 16 },
+];
+const ONE = [
+  { value: 'scheduled', label: 'Scheduled', sublabel: "Today's nutrition", note: '2 due', tone: 'due' },
+];
+
+describe('PanelViewSwitcher', () => {
+  it('offers a dropdown when there is somewhere to go', () => {
+    const { container } = render(
+      <PanelViewSwitcher views={TWO} value="scheduled" onChange={vi.fn()} />
+    );
+    expect(container.querySelector('.mp-view-trigger.static')).toBeNull();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('is a heading, not a dropdown, when there is only one view', () => {
+    // A control that cannot go anywhere misrepresents what is available.
+    const { container } = render(
+      <PanelViewSwitcher views={ONE} value="scheduled" onChange={vi.fn()} />
+    );
+    expect(container.querySelector('.mp-view-trigger.static')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).toBeNull();
+    // The outstanding count still earns its place.
+    expect(screen.getByText('2 due')).toBeInTheDocument();
+  });
+
+  it('renders one button per entry point, with its count', () => {
+    render(
+      <PanelViewSwitcher views={TWO} value="scheduled" onChange={vi.fn()} actions={[
+        { label: 'PRN', count: 5, onClick: vi.fn() },
+      ]} />
+    );
+    const btn = screen.getByRole('button', { name: /PRN/ });
+    expect(btn).toBeInTheDocument();
+    expect(btn.textContent).toContain('5');
+  });
+
+  it('supports a section with more than one entry point', () => {
+    const intake = vi.fn();
+    const output = vi.fn();
+    render(
+      <PanelViewSwitcher views={ONE} value="scheduled" onChange={vi.fn()} actions={[
+        { label: 'Intake', onClick: intake },
+        { label: 'Output', onClick: output },
+      ]} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Output' }));
+    expect(output).toHaveBeenCalledTimes(1);
+    expect(intake).not.toHaveBeenCalled();
+  });
+
+  it('omits the count where a section has none to report', () => {
+    const { container } = render(
+      <PanelViewSwitcher views={ONE} value="scheduled" onChange={vi.fn()} actions={[
+        { label: 'Intake', onClick: vi.fn() },
+      ]} />
+    );
+    expect(container.querySelector('.mp-prn-count')).toBeNull();
+  });
+
+  it('disables an entry point the section cannot offer', () => {
+    render(
+      <PanelViewSwitcher views={ONE} value="scheduled" onChange={vi.fn()} actions={[
+        { label: 'Intake', onClick: vi.fn(), disabled: true },
+      ]} />
+    );
+    expect(screen.getByRole('button', { name: 'Intake' })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/section-panel/section-panel.css
+++ b/frontend/src/components/section-panel/section-panel.css
@@ -396,3 +396,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* A single-view section (nutrition) shows its heading rather than a dropdown
+   that cannot go anywhere, and the controls wrap when a section offers more
+   than one entry point. */
+.mp-viewrow-controls { flex-wrap: wrap; }
+.mp-view-trigger.static { cursor: default; align-items: center; }
+.mp-view-trigger.static:hover { background: color-mix(in srgb, var(--vc-data-live) 8%, transparent); }


### PR DESCRIPTION
The third and last section onto the shared panel. Nutrition differs from the other two in three ways, and each shaped the result rather than being papered over.

**It has a single view.** A dropdown that can't go anywhere misrepresents what's available, so `PanelViewSwitcher` renders a heading instead when there's only one view. The outstanding count keeps its place either way.

**It has two entry points, not one.** Intake and output are different records, and the old flow spent a tap on a dialog whose only content was that choice. The switcher now takes an `actions` list, so nutrition shows **Intake** and **Output** directly while medications and care tasks keep their single PRN button. Both openers still seed the form's default time — going direct would otherwise have skipped it.

**It has no skip.** Nothing in the schema or the API supports skipping a nutrition item, so `onSkip` simply isn't passed and neither the card nor the detail pane invents the affordance.

## Per-item history

Needed a backend filter, the same shape as the medication one: `NutritionIntake` already carries a `schedule_id` FK, so `GET /patients/{id}/nutrition-intake` takes an optional `schedule_id`. Ad-hoc intakes carry no schedule and are correctly excluded — covered by a test that also asserts the unfiltered call still returns them.

## Bulk is offered here

Unlike care tasks. The unified endpoint fills each item's defaults from its schedule, publishes the due-count change, and pre-flights the whole batch against the administration window — so one confirmation covers a slot instead of one dialog per item. Care tasks were excluded because their completion triggers a per-task nutrition follow-up; nutrition has no such follow-up.

Note plumbing matches the other two, threaded through the off-window confirm.

## All three, side by side

| | primary | columns | entry points |
|---|---|---|---|
| Medications | Record dose | Medication \| Dose | PRN (5) |
| Care Tasks | Mark done | Task \| Category | PRN (4) |
| Nutrition | Mark taken | Item \| Amount | Intake, Output |

One layout implementation, three label sets. Re-verified live side by side, and at 390px all three are narrow with no overflow and the detail reachable with a way back.

459 frontend tests (8 new), 588 backend (1 new), lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011u7gjNWppXao35QPLtBBQe