### PR TITLE
Alerts in the docked panel

### DIFF
--- a/frontend/src/components/AlertDetailInline.jsx
+++ b/frontend/src/components/AlertDetailInline.jsx
@@ -17,6 +17,7 @@
  */
 import { useState, useEffect, useMemo } from 'react';
 import SimpleEventChart from './SimpleEventChart';
+import './alerts/alerts-panel.css';
 import config from '../config';
 import ZoomableVideo from './ZoomableVideo';
 import { AlertIcon, CheckIcon, ClockIcon, HeartIcon, CameraIcon } from './Icons';
@@ -32,9 +33,8 @@ import {
   SelectContent,
   SelectItem,
 } from '@/components/ui/select';
-import { cn } from '@/lib/utils';
 
-const AlertDetailInline = ({ alert, onClose, onAcknowledge, initiateAcknowledge = false }) => {
+const AlertDetailInline = ({ alert, onClose, onAcknowledge, initiateAcknowledge = false, showBack = true }) => {
   const [eventData, setEventData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -196,82 +196,59 @@ const AlertDetailInline = ({ alert, onClose, onAcknowledge, initiateAcknowledge 
   if (alert.hr_alarm_triggered) triggeredAlarms.push('BPM');
 
   const infoItem = (label, value) => (
-    <div className="flex min-w-0 flex-col gap-1 rounded-lg border border-border bg-card px-3 py-2.5">
-      <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-        {label}
-      </span>
-      <span className="break-words text-sm font-medium text-foreground">
-        {value}
-      </span>
+    <div className="al-info">
+      <span className="al-info-label">{label}</span>
+      <span className="al-info-value">{value}</span>
     </div>
   );
 
   return (
-    <div className="tw flex flex-col gap-4 text-foreground">
-      {/* Back button + title */}
-      <div className="flex items-center gap-3 border-b border-border pb-3">
-        <Button variant="outline" size="sm" onClick={onClose}>← Back</Button>
-        <h3 className="m-0 text-lg font-semibold">Alert Event Details</h3>
+    <div className="al-detail tw text-foreground">
+      {/* Back button + title. The host supplies the back control when the
+          detail replaces the list; beside the list there is nowhere to go. */}
+      <div className="al-detail-head">
+        {showBack && (
+          <button type="button" className="al-btn ghost" onClick={onClose}>← Back</button>
+        )}
+        <h3 className="al-detail-title">Episode detail</h3>
       </div>
 
       {/* Status banner */}
-      <div
-        style={{ borderLeftWidth: 4, borderLeftColor: SEV.accent }}
-        className="flex flex-wrap items-center gap-2.5 rounded-lg border border-border bg-card px-3.5 py-2.5"
-      >
-        <span className={cn(
-          'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-bold',
-          SEV.badge
-        )}>
-          {SEV.icon} {SEV.label}
-        </span>
+      <div className={`al-status ${severity}`}>
+        <span className={`al-badge ${severity}`}>{SEV.label}</span>
         {triggeredAlarms.length > 0 && (
-          <span className="text-sm text-muted-foreground">
-            Alarms: <strong className="text-foreground">{triggeredAlarms.join(', ')}</strong>
+          <span className="al-status-alarms">
+            Alarms <strong>{triggeredAlarms.join(', ')}</strong>
           </span>
         )}
       </div>
 
       {/* Info grid */}
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
-        gap: 10,
-      }}>
+      <div className="al-grid">
         {infoItem('Start Time', formatDateTime(alert.start_time))}
         {infoItem('End Time', alert.end_time ? formatDateTime(adjustedEnd(alert.end_time)) : 'Ongoing')}
       </div>
 
-      {/* Metric cards */}
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
-        gap: 12,
-      }}>
-        <div className="rounded-xl border border-success/20 bg-success/10 px-4 py-3.5">
-          <div className="mb-1.5 flex items-center justify-between">
-            <span className="text-sm font-semibold text-success">SpO₂ Range</span>
-            {alert.spo2_alarm_triggered && (
-              <span className="rounded-full bg-destructive px-2 py-0.5 text-[10px] font-bold text-destructive-foreground">ALARM</span>
-            )}
+      {/* Metric cards — the two numbers the episode is about. */}
+      <div className="al-grid">
+        <div className="al-metric spo2">
+          <div className="al-metric-head">
+            <span className="al-metric-label">SpO₂ range</span>
+            {alert.spo2_alarm_triggered && <span className="al-alarm">Alarm</span>}
           </div>
-          <div className="text-2xl font-bold text-foreground">
+          <div className="al-metric-value">
             {alert.spo2_min !== null && alert.spo2_max !== null
               ? (alert.spo2_min === alert.spo2_max ? `${alert.spo2_min}%` : `${alert.spo2_min}–${alert.spo2_max}%`)
               : 'N/A'}
           </div>
         </div>
 
-        <div className="rounded-xl border border-destructive/20 bg-destructive/10 px-4 py-3.5">
-          <div className="mb-1.5 flex items-center justify-between">
-            <span className="flex items-center gap-1.5 text-sm font-semibold text-destructive">
-              <HeartIcon size={14} /> Heart Rate Range
-            </span>
-            {alert.hr_alarm_triggered && (
-              <span className="rounded-full bg-destructive px-2 py-0.5 text-[10px] font-bold text-destructive-foreground">ALARM</span>
-            )}
+        <div className="al-metric hr">
+          <div className="al-metric-head">
+            <span className="al-metric-label"><HeartIcon size={13} /> Heart rate range</span>
+            {alert.hr_alarm_triggered && <span className="al-alarm">Alarm</span>}
           </div>
-          <div className="text-2xl font-bold text-foreground">
+          <div className="al-metric-value">
             {alert.bpm_min !== null && alert.bpm_max !== null
               ? (alert.bpm_min === alert.bpm_max ? `${alert.bpm_min} BPM` : `${alert.bpm_min}–${alert.bpm_max} BPM`)
               : 'N/A'}
@@ -291,10 +268,10 @@ const AlertDetailInline = ({ alert, onClose, onAcknowledge, initiateAcknowledge 
       ) : (
         <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}>
           <div className="h-64 rounded-xl border border-border bg-card p-3">
-            <SimpleEventChart title="Blood Oxygen" color="#48BB78" unit="SpO₂ (%)" data={spo2ChartData} />
+            <SimpleEventChart title="Blood Oxygen" color="#4da7bd" unit="SpO₂ (%)" data={spo2ChartData} />
           </div>
           <div className="h-64 rounded-xl border border-border bg-card p-3">
-            <SimpleEventChart title="Pulse Rate" color="#F56565" unit="BPM" data={bpmChartData} />
+            <SimpleEventChart title="Pulse Rate" color="#3fbf6a" unit="BPM" data={bpmChartData} />
           </div>
         </div>
       )}

--- a/frontend/src/components/AlertDetailInline.jsx
+++ b/frontend/src/components/AlertDetailInline.jsx
@@ -34,7 +34,7 @@ import {
   SelectItem,
 } from '@/components/ui/select';
 
-const AlertDetailInline = ({ alert, onClose, onAcknowledge, initiateAcknowledge = false, showBack = true }) => {
+const AlertDetailInline = ({ alert, onClose, onAcknowledge, initiateAcknowledge = false }) => {
   const [eventData, setEventData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -204,12 +204,9 @@ const AlertDetailInline = ({ alert, onClose, onAcknowledge, initiateAcknowledge 
 
   return (
     <div className="al-detail tw text-foreground">
-      {/* Back button + title. The host supplies the back control when the
-          detail replaces the list; beside the list there is nowhere to go. */}
+      {/* No back control here: the host renders one above the detail when it
+          replaces the list, and beside the list there is nowhere to go. */}
       <div className="al-detail-head">
-        {showBack && (
-          <button type="button" className="al-btn ghost" onClick={onClose}>← Back</button>
-        )}
         <h3 className="al-detail-title">Episode detail</h3>
       </div>
 
@@ -321,14 +318,13 @@ const AlertDetailInline = ({ alert, onClose, onAcknowledge, initiateAcknowledge 
 
       {/* Actions */}
       {!showOxygenForm ? (
-        <div className="flex justify-end gap-2.5 border-t border-border pt-3">
-          <Button variant="secondary" onClick={onClose}>Back to List</Button>
-          {!alert.acknowledged && (
+        !alert.acknowledged && (
+          <div className="flex justify-end gap-2.5 border-t border-border pt-3">
             <Button onClick={() => setShowOxygenForm(true)}>
               <CheckIcon size={14} /> Acknowledge
             </Button>
-          )}
-        </div>
+          </div>
+        )
       ) : (
         <div className="rounded-xl border border-border bg-card p-4">
           <h4 className="m-0 mb-3 text-base font-semibold">Acknowledge Alert</h4>

--- a/frontend/src/components/AlertsModal.jsx
+++ b/frontend/src/components/AlertsModal.jsx
@@ -19,6 +19,7 @@ import { useMemo, useState } from 'react';
 import ModalBase from './ModalBase';
 import AlertsList from './alerts/AlertsList';
 import AlertsHistory from './alerts/AlertsHistory';
+import './alerts/alerts-panel.css';
 import PanelViewSwitcher from './section-panel/PanelViewSwitcher';
 import { useAdminPatient } from '../contexts/AdminPatientContext';
 import './section-panel/section-panel.css';
@@ -63,9 +64,16 @@ export default function AlertsModal({ isOpen, onClose, alertsCount, onAlertAckno
         <PanelViewSwitcher views={views} value={tab} onChange={setTab} />
 
         <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
-          {tab === 'history'
-            ? <AlertsHistory patientId={selectedPatient?.id} />
-            : <AlertsList onAlertAcknowledge={handleAlertAcknowledge} patientId={selectedPatient?.id} />}
+          {/* With no patient chosen the alert queries drop their patient filter
+              and return every patient's episodes, so hold off entirely — the
+              same bail the medication and care-task panels make. */}
+          {!selectedPatient ? (
+            <div className="al-empty">Select a patient to see alerts</div>
+          ) : tab === 'history' ? (
+            <AlertsHistory patientId={selectedPatient.id} />
+          ) : (
+            <AlertsList onAlertAcknowledge={handleAlertAcknowledge} patientId={selectedPatient.id} />
+          )}
         </div>
       </div>
     </ModalBase>

--- a/frontend/src/components/AlertsModal.jsx
+++ b/frontend/src/components/AlertsModal.jsx
@@ -15,129 +15,59 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect } from 'react';
+import { useMemo, useState } from 'react';
 import ModalBase from './ModalBase';
 import AlertsList from './alerts/AlertsList';
 import AlertsHistory from './alerts/AlertsHistory';
+import PanelViewSwitcher from './section-panel/PanelViewSwitcher';
+import { useAdminPatient } from '../contexts/AdminPatientContext';
+import './section-panel/section-panel.css';
 
 export default function AlertsModal({ isOpen, onClose, alertsCount, onAlertAcknowledged }) {
   const [tab, setTab] = useState('list');
-
-  // Mark alerts as viewed when modal opens
-  useEffect(() => {
-    if (alertsCount > 0 && isOpen) {
-      // You can add alerts viewed logic here if needed
-    }
-  }, [alertsCount, isOpen]);
+  const { selectedPatient } = useAdminPatient();
 
   const handleAlertAcknowledge = (alertId) => {
-    if (onAlertAcknowledged) {
-      onAlertAcknowledged(alertId);
-    }
+    if (onAlertAcknowledged) onAlertAcknowledged(alertId);
   };
 
-  const renderContent = () => {
-    switch (tab) {
-      case 'list':
-        return <AlertsList onAlertAcknowledge={handleAlertAcknowledge} />;
-      case 'history':
-        return <AlertsHistory />;
-      default:
-        return <AlertsList onAlertAcknowledge={handleAlertAcknowledge} />;
-    }
-  };
-
-  // If not using modal wrapper (for future noModal prop)
-  const renderInnerContent = () => (
-    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      {renderContent()}
-    </div>
-  );
+  // The second view is not an alert history — it is the day’s pulse-ox
+  // analysis. The sublabel says so rather than the tab quietly misnaming it.
+  const views = useMemo(() => ([
+    {
+      value: 'list',
+      label: 'Alerts',
+      sublabel: 'Pulse ox episodes',
+      note: alertsCount > 0 ? `${alertsCount} unreviewed` : 'All reviewed',
+      tone: alertsCount > 0 ? 'due' : 'given',
+    },
+    {
+      value: 'history',
+      label: 'History',
+      sublabel: 'Daily pulse-ox analysis',
+    },
+  ]), [alertsCount]);
 
   return (
     <ModalBase isOpen={isOpen} onClose={onClose} title={
-      <div style={{ display: 'flex', gap: '8px' }}>
-        <button
-          onClick={() => setTab('list')}
-          style={{
-            padding: '8px 16px',
-            border: 'none',
-            borderRadius: '6px',
-            backgroundColor: tab === 'list' ? 'var(--primary)' : 'var(--secondary)',
-            color: tab === 'list' ? 'var(--primary-foreground)' : 'var(--secondary-foreground)',
-            cursor: 'pointer',
-            fontWeight: '500',
-            fontSize: '14px',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px'
-          }}
-        >
-          Alert List
-          {alertsCount > 0 && (
-            <span style={{
-              backgroundColor: 'var(--destructive)',
-              color: 'var(--destructive-foreground)',
-              borderRadius: '12px',
-              padding: '2px 8px',
-              fontSize: '12px',
-              fontWeight: 'bold'
-            }}>
-              {alertsCount}
-            </span>
-          )}
-        </button>
-        <button
-          onClick={() => setTab('history')}
-          style={{
-            padding: '8px 16px',
-            border: 'none',
-            borderRadius: '6px',
-            backgroundColor: tab === 'history' ? 'var(--primary)' : 'var(--secondary)',
-            color: tab === 'history' ? 'var(--primary-foreground)' : 'var(--secondary-foreground)',
-            cursor: 'pointer',
-            fontWeight: '500',
-            fontSize: '14px'
-          }}
-        >
-          History
-        </button>
-        {/* Future navigation tabs can be added here */}
-        {/* 
-        <button
-          onClick={() => setTab('analytics')}
-          style={{
-            padding: '8px 16px',
-            border: 'none',
-            borderRadius: '6px',
-            backgroundColor: tab === 'analytics' ? '#007bff' : '#f8f9fa',
-            color: tab === 'analytics' ? '#fff' : '#333',
-            cursor: 'pointer',
-            fontWeight: '500',
-            fontSize: '14px'
-          }}
-        >
-          Analytics
-        </button>
-        <button
-          onClick={() => setTab('settings')}
-          style={{
-            padding: '8px 16px',
-            border: 'none',
-            borderRadius: '6px',
-            backgroundColor: tab === 'settings' ? '#007bff' : '#f8f9fa',
-            color: tab === 'settings' ? '#fff' : '#333',
-            cursor: 'pointer',
-            fontWeight: '500',
-            fontSize: '14px'
-          }}
-        >
-          Settings
-        </button>
-        */}
-      </div>
+      <span className="mp-modal-title">
+        <span>Alerts</span>
+        <span className="mp-modal-title-sub">
+          {selectedPatient
+            ? `${selectedPatient.first_name} ${selectedPatient.last_name} · ${tab === 'history' ? 'Analysis' : 'Episodes'}`
+            : 'No patient selected'}
+        </span>
+      </span>
     }>
-      {renderInnerContent()}
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <PanelViewSwitcher views={views} value={tab} onChange={setTab} />
+
+        <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+          {tab === 'history'
+            ? <AlertsHistory patientId={selectedPatient?.id} />
+            : <AlertsList onAlertAcknowledge={handleAlertAcknowledge} patientId={selectedPatient?.id} />}
+        </div>
+      </div>
     </ModalBase>
   );
 }

--- a/frontend/src/components/alerts/AlertsList.jsx
+++ b/frontend/src/components/alerts/AlertsList.jsx
@@ -179,7 +179,6 @@ const AlertsList = ({ onAlertAcknowledge, patientId }) => {
       onClose={() => { setSelectedId(null); setShowAcknowledgeForm(false); }}
       onAcknowledge={acknowledgeAlert}
       initiateAcknowledge={showAcknowledgeForm}
-      showBack={!expanded}
     />
   ) : null;
 

--- a/frontend/src/components/alerts/AlertsList.jsx
+++ b/frontend/src/components/alerts/AlertsList.jsx
@@ -18,21 +18,19 @@
 import { useState, useEffect } from 'react';
 import config from '../../config';
 import AlertDetailInline from '../AlertDetailInline';
-import { AlertIcon, CheckIcon, ClockIcon, HeartIcon } from '../Icons';
-import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
-import { Alert } from '@/components/ui/alert';
-import { cn } from '@/lib/utils';
+import { CheckIcon, ChevronLeftIcon, SearchIcon } from '../Icons';
+import { useModalDock } from '../../contexts/ModalDockContext';
+import './alerts-panel.css';
 
 const AlertsList = ({ onAlertAcknowledge, patientId }) => {
   const [alerts, setAlerts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showAcknowledged, setShowAcknowledged] = useState(false);
-  const [selectedAlert, setSelectedAlert] = useState(null);
+  const [selectedId, setSelectedId] = useState(null);
   const [showAcknowledgeForm, setShowAcknowledgeForm] = useState(false);
   const [acknowledgeAllLoading, setAcknowledgeAllLoading] = useState(false);
+  const { expanded } = useModalDock();
 
   useEffect(() => {
     fetchAlerts();
@@ -104,11 +102,12 @@ const AlertsList = ({ onAlertAcknowledge, patientId }) => {
   };
 
   const handleViewDetails = (alert) => {
-    setSelectedAlert(alert);
+    setSelectedId(alert.id);
+    setShowAcknowledgeForm(false);
   };
 
   const handleAcknowledge = async (alertId) => {
-    setSelectedAlert(alerts.find(a => a.id === alertId));
+    setSelectedId(alertId);
     setShowAcknowledgeForm(true);
   };
 
@@ -147,156 +146,192 @@ const AlertsList = ({ onAlertAcknowledge, patientId }) => {
     return 'acknowledged';
   };
 
-  // Theme-aware severity styling: Tailwind utilities driven by semantic tokens,
-  // plus a CSS-var accent for the card's colored left border.
+  // An alert is the clinical concern the palette reserves red for: ongoing is
+  // red, waiting on a human is amber, reviewed is green. (The schedule panels
+  // deliberately never use red — being late is not an emergency.)
   const SEVERITY = {
-    active:         { label: 'Active',         icon: <AlertIcon size={14} />, badge: 'bg-destructive/10 text-destructive border-destructive/30', accent: 'var(--destructive)' },
-    unacknowledged: { label: 'Unacknowledged', icon: <ClockIcon size={14} />, badge: 'bg-warning/10 text-warning border-warning/30',             accent: 'var(--warning)' },
-    acknowledged:   { label: 'Acknowledged',   icon: <CheckIcon size={14} />, badge: 'bg-success/10 text-success border-success/30',             accent: 'var(--success)' },
+    active: 'Active',
+    unacknowledged: 'Unreviewed',
+    acknowledged: 'Reviewed',
   };
 
-  const triggeredAlarms = (alert) => {
-    const out = [];
-    if (alert.alarm1_triggered) out.push('Alarm 1');
-    if (alert.alarm2_triggered) out.push('Alarm 2');
-    if (alert.spo2_alarm_triggered) out.push('SpO₂');
-    if (alert.hr_alarm_triggered) out.push('BPM');
-    return out;
+  // What the episode actually was, from the alarms it tripped — the API has no
+  // event name of its own.
+  const eventTitle = (alert) => {
+    const parts = [];
+    if (alert.spo2_alarm_triggered) parts.push('Low oxygen');
+    if (alert.hr_alarm_triggered) parts.push('High heart rate');
+    if (!parts.length) return 'Pulse ox alert';
+    return parts.join(' + ');
   };
 
-  if (selectedAlert) {
+  const range = (min, max, suffix = '') => {
+    if (min === null || min === undefined || max === null || max === undefined) return null;
+    return min === max ? `${min}${suffix}` : `${min}–${max}${suffix}`;
+  };
+
+  const selectedAlert = alerts.find(a => a.id === selectedId) || null;
+  const unreviewed = alerts.filter(a => !a.acknowledged).length;
+
+  const detail = selectedAlert ? (
+    <AlertDetailInline
+      alert={selectedAlert}
+      onClose={() => { setSelectedId(null); setShowAcknowledgeForm(false); }}
+      onAcknowledge={acknowledgeAlert}
+      initiateAcknowledge={showAcknowledgeForm}
+      showBack={!expanded}
+    />
+  ) : null;
+
+  // Narrow: the detail takes the panel, because there is no room beside the
+  // list. Expanded: it sits alongside, so the list stays in view.
+  if (!expanded && selectedAlert) {
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-        <AlertDetailInline
-          alert={selectedAlert}
-          onClose={() => {
-            setSelectedAlert(null);
-            setShowAcknowledgeForm(false);
-          }}
-          onAcknowledge={acknowledgeAlert}
-          initiateAcknowledge={showAcknowledgeForm}
-        />
+      <div className="al-panel stacked">
+        <button
+          type="button"
+          className="al-back"
+          onClick={() => { setSelectedId(null); setShowAcknowledgeForm(false); }}
+        >
+          <ChevronLeftIcon size={16} />
+          Back to alerts
+        </button>
+        {detail}
       </div>
     );
   }
 
-  return (
-    <div className="tw flex flex-col gap-4">
-      {/* Controls bar */}
-      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-card px-3.5 py-3">
-        <div className="flex flex-wrap items-center gap-2">
-          <Button variant="secondary" onClick={fetchAlerts} disabled={loading}>
-            {loading ? 'Loading…' : 'Refresh'}
-          </Button>
-          <Button onClick={acknowledgeAllAlerts} disabled={acknowledgeAllLoading || loading}>
-            <CheckIcon size={14} />
-            {acknowledgeAllLoading ? 'Acknowledging…' : 'Acknowledge All'}
-          </Button>
-        </div>
-        <div className="flex items-center gap-2">
-          <Checkbox
-            id="show-acknowledged"
-            checked={showAcknowledged}
-            onCheckedChange={() => setShowAcknowledged(!showAcknowledged)}
-          />
-          <Label htmlFor="show-acknowledged" className="cursor-pointer">Show Acknowledged</Label>
-        </div>
+  const list = (
+    <>
+      <div className="al-head">
+        <span className="al-count">
+          {alerts.length} shown{unreviewed > 0 && <> · <strong>{unreviewed} unreviewed</strong></>}
+        </span>
+        <span className="al-head-actions">
+          <label className="al-toggle">
+            <input
+              type="checkbox"
+              checked={showAcknowledged}
+              onChange={() => setShowAcknowledged(!showAcknowledged)}
+            />
+            Show reviewed
+          </label>
+          <button
+            type="button"
+            className="al-btn ghost"
+            onClick={acknowledgeAllAlerts}
+            disabled={acknowledgeAllLoading || loading || unreviewed === 0}
+          >
+            {acknowledgeAllLoading ? 'Working…' : 'Ack all'}
+          </button>
+        </span>
       </div>
 
-      {error && <Alert variant="destructive">{error}</Alert>}
+      {error && <div className="al-error" role="alert">{error}</div>}
 
       {loading ? (
-        <div className="py-10 text-center text-muted-foreground">Loading alerts…</div>
+        <div className="al-empty">Loading alerts…</div>
       ) : alerts.length === 0 ? (
-        <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border py-10 text-center text-muted-foreground">
-          <CheckIcon size={28} />
-          No alerts to show.
-        </div>
+        <div className="al-empty">No alerts to show</div>
+      ) : expanded ? (
+        /* Wide: a table. At this size a column of cards is mostly whitespace,
+           and the point of the wide view is scanning many episodes at once. */
+        <table className="al-table">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Event</th>
+              <th>Values</th>
+              <th>Duration</th>
+              <th>Status</th>
+              <th className="al-actions-col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {alerts.map((alert) => {
+              const severity = getAlertSeverity(alert);
+              const spo2 = range(alert.spo2_min, alert.spo2_max, '%');
+              const bpm = range(alert.bpm_min, alert.bpm_max);
+              return (
+                <tr
+                  key={alert.id}
+                  className={alert.id === selectedId ? 'selected' : ''}
+                  onClick={() => handleViewDetails(alert)}
+                >
+                  <td className="al-td-time">{formatDateTime(alert.start_time)}</td>
+                  <th scope="row">
+                    <button type="button" className="al-rowbtn">{eventTitle(alert)}</button>
+                  </th>
+                  <td className="al-vitals">
+                    {spo2 && <>SpO₂ <b className={alert.spo2_alarm_triggered ? 'breach' : ''}>{spo2}</b></>}
+                    {spo2 && bpm && <span className="sep">·</span>}
+                    {bpm && <>HR <b className={alert.hr_alarm_triggered ? 'breach' : ''}>{bpm}</b></>}
+                  </td>
+                  <td>{formatDuration(alert.start_time, alert.end_time)}</td>
+                  <td><span className={`al-badge ${severity}`}>{SEVERITY[severity]}</span></td>
+                  <td className="al-actions-col">
+                    {!alert.acknowledged && (
+                      <button
+                        type="button"
+                        className="al-btn primary sm"
+                        onClick={(e) => { e.stopPropagation(); handleAcknowledge(alert.id); }}
+                      >
+                        <CheckIcon size={13} /> Ack
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       ) : (
-        <div className="flex flex-col gap-2.5">
-          {alerts.map(alert => {
+        <div className="al-list">
+          {alerts.map((alert, i) => {
             const severity = getAlertSeverity(alert);
-            const sev = SEVERITY[severity];
-            const alarms = triggeredAlarms(alert);
+            const spo2 = range(alert.spo2_min, alert.spo2_max, '%');
+            const bpm = range(alert.bpm_min, alert.bpm_max);
             return (
               <div
                 key={alert.id}
-                style={{ borderLeftWidth: 4, borderLeftColor: sev.accent }}
-                className={cn(
-                  'flex flex-col gap-3 rounded-xl border border-border bg-card p-4 shadow-sm',
-                  severity === 'acknowledged' && 'opacity-75'
-                )}
+                className={`al-card ${severity}${alert.id === selectedId ? ' selected' : ''}`}
               >
-                {/* Top row: status + timestamp */}
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <span className={cn(
-                    'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-bold',
-                    sev.badge
-                  )}>
-                    {sev.icon} {sev.label}
+                <button
+                  type="button"
+                  className="al-card-body"
+                  onClick={() => handleViewDetails(alert)}
+                  aria-label={`${eventTitle(alert)}, ${SEVERITY[severity]}. Open details.`}
+                >
+                  <span className="al-card-head">
+                    <span className="al-seq">{i + 1}</span>
+                    <span className="al-title">{eventTitle(alert)}</span>
+                    <span className="al-when">{formatDateTime(alert.start_time)}</span>
                   </span>
-                  <span className="text-xs font-medium text-muted-foreground">
-                    {formatDateTime(alert.start_time)}
+                  <span className={`al-badge ${severity}`}>{SEVERITY[severity]}</span>
+                  <span className="al-vitals">
+                    {spo2 && <>SpO₂ <b className={alert.spo2_alarm_triggered ? 'breach' : ''}>{spo2}</b></>}
+                    {spo2 && bpm && <span className="sep">·</span>}
+                    {bpm && <>HR <b className={alert.hr_alarm_triggered ? 'breach' : ''}>{bpm}</b></>}
+                    <span className="sep">·</span>
+                    <span className="ok">{formatDuration(alert.start_time, alert.end_time)}</span>
                   </span>
-                </div>
-
-                {/* Metric row: SpO2, BPM, Duration */}
-                <div className="grid gap-2.5" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))' }}>
-                  <div className="rounded-lg border border-success/20 bg-success/10 px-3 py-2">
-                    <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-success">
-                      SpO₂
-                    </div>
-                    <div className="mt-0.5 text-base font-bold text-foreground">
-                      {alert.spo2_min !== null && alert.spo2_max !== null
-                        ? (alert.spo2_min === alert.spo2_max
-                            ? `${alert.spo2_min}%`
-                            : `${alert.spo2_min}–${alert.spo2_max}%`)
-                        : '—'}
-                    </div>
-                  </div>
-                  <div className="rounded-lg border border-destructive/20 bg-destructive/10 px-3 py-2">
-                    <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-destructive">
-                      <HeartIcon size={12} /> BPM
-                    </div>
-                    <div className="mt-0.5 text-base font-bold text-foreground">
-                      {alert.bpm_min !== null && alert.bpm_max !== null
-                        ? (alert.bpm_min === alert.bpm_max
-                            ? alert.bpm_min
-                            : `${alert.bpm_min}–${alert.bpm_max}`)
-                        : '—'}
-                    </div>
-                  </div>
-                  <div className="rounded-lg border border-ring/20 bg-ring/10 px-3 py-2">
-                    <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-ring">
-                      <ClockIcon size={12} /> Duration
-                    </div>
-                    <div className="mt-0.5 text-base font-bold text-foreground">
-                      {formatDuration(alert.start_time, alert.end_time)}
-                    </div>
-                  </div>
-                </div>
-
-                {/* Alarms */}
-                {alarms.length > 0 && (
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    <span className="text-xs font-medium text-muted-foreground">Alarms:</span>
-                    {alarms.map(a => (
-                      <span key={a} className="rounded-full border border-destructive/40 bg-destructive/15 px-2 py-0.5 text-[11px] font-semibold text-destructive">
-                        {a}
-                      </span>
-                    ))}
-                  </div>
-                )}
-
-                {/* Actions */}
-                <div className="flex justify-end gap-2 border-t border-border pt-2.5">
-                  <Button variant="secondary" size="sm" onClick={() => handleViewDetails(alert)}>
-                    View Details
-                  </Button>
+                </button>
+                <div className="al-card-actions">
+                  <button
+                    type="button"
+                    className="al-btn ghost"
+                    onClick={(e) => { e.stopPropagation(); handleViewDetails(alert); }}
+                  >
+                    <SearchIcon size={13} /> Inspect
+                  </button>
                   {!alert.acknowledged && (
-                    <Button size="sm" onClick={() => handleAcknowledge(alert.id)}>
-                      <CheckIcon size={14} /> Acknowledge
-                    </Button>
+                    <button
+                      type="button"
+                      className="al-btn primary"
+                      onClick={(e) => { e.stopPropagation(); handleAcknowledge(alert.id); }}
+                    >
+                      <CheckIcon size={13} /> Acknowledge
+                    </button>
                   )}
                 </div>
               </div>
@@ -304,9 +339,22 @@ const AlertsList = ({ onAlertAcknowledge, patientId }) => {
           })}
         </div>
       )}
-
-    </div>
+    </>
   );
+
+  if (expanded) {
+    return (
+      <div className="al-panel wide">
+        <div className="al-main">{list}</div>
+        <div className="al-side">
+          {detail || <div className="al-empty">Select an alert to see its detail</div>}
+        </div>
+      </div>
+    );
+  }
+
+  return <div className="al-panel">{list}</div>;
 };
+
 
 export default AlertsList;

--- a/frontend/src/components/alerts/alerts-panel.css
+++ b/frontend/src/components/alerts/alerts-panel.css
@@ -1,0 +1,445 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Alert episodes at both dock stops.
+ *
+ * Colour roles differ from the schedule panels on purpose. There, adherence is
+ * never red — being late is not an emergency. Here red *is* correct: an alert
+ * is the clinical concern the palette reserves it for. So an ongoing episode is
+ * red (--vc-state-alert), one waiting on a human is amber (--vc-state-due), and
+ * a reviewed one is green.
+ *
+ * Rendered outside the `.tw` island, so box-sizing and the bare <button> paint
+ * are asserted; `:where()` keeps that reset at element specificity. */
+@import '../../styles/vc-tokens.css';
+
+.al-panel, .al-panel * { box-sizing: border-box; }
+:where(.al-panel) button {
+  font-family: var(--vc-font-mono);
+  padding: 0;
+  border: 1px solid transparent;
+  background: none;
+  color: inherit;
+}
+
+.al-panel.wide {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
+  gap: 1rem;
+  align-items: start;
+}
+.al-list { min-width: 0; display: flex; flex-direction: column; gap: 0.55rem; }
+.al-side { min-width: 0; }
+
+/* ---- header line ---- */
+
+.al-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  row-gap: 0.45rem;
+  gap: 0.6rem;
+  padding-bottom: 0.6rem;
+  margin-bottom: 0.7rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.al-count {
+  white-space: nowrap;
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.al-count strong { color: var(--vc-state-due); font-weight: 700; }
+.al-head-actions { display: flex; align-items: center; gap: 0.5rem; margin-left: auto; }
+
+/* ---- episode card ---- */
+
+.al-card {
+  border: 1px solid var(--vc-line-hairline);
+  border-left: 3px solid var(--vc-line-strong);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+.al-card.active { border-left-color: var(--vc-state-alert); }
+.al-card.unacknowledged { border-left-color: var(--vc-state-due); }
+.al-card.acknowledged { border-left-color: var(--vc-state-complete); }
+.al-card.selected { border-color: var(--vc-data-live); }
+
+.al-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  width: 100%;
+  padding: 0.7rem 0.8rem 0.55rem;
+  text-align: left;
+  cursor: pointer;
+}
+.al-card-body:hover { background: var(--vc-bg-raised); }
+.al-card-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+.al-seq {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 50%;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--vc-text-secondary);
+}
+.al-title {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.al-when {
+  flex-shrink: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  white-space: nowrap;
+}
+.al-badge {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.12rem 0.45rem;
+  border: 1px solid;
+  border-radius: 999px;
+  font-family: var(--vc-font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.al-badge.active {
+  color: var(--vc-state-alert);
+  border-color: color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
+  background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
+}
+.al-badge.unacknowledged {
+  color: var(--vc-state-due);
+  border-color: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
+  background: color-mix(in srgb, var(--vc-state-due) 12%, transparent);
+}
+.al-badge.acknowledged {
+  color: var(--vc-state-complete);
+  border-color: color-mix(in srgb, var(--vc-state-complete) 45%, transparent);
+  background: color-mix(in srgb, var(--vc-state-complete) 10%, transparent);
+}
+
+/* The one line a caregiver actually scans. */
+.al-vitals {
+  font-family: var(--vc-font-mono);
+  font-size: 11.5px;
+  color: var(--vc-text-secondary);
+}
+/* Red marks the signal that actually tripped its alarm, not every number on
+   the row — an episode where SpO2 breached and the heart rate did not should
+   say so. */
+.al-vitals b { color: var(--vc-text-primary); font-weight: 700; }
+.al-vitals b.breach { color: var(--vc-state-alert); }
+.al-vitals .ok { color: var(--vc-text-primary); font-weight: 700; }
+.al-vitals .sep { color: var(--vc-text-tertiary); margin: 0 0.3rem; }
+
+.al-card-actions { display: flex; gap: 0.4rem; padding: 0 0.8rem 0.7rem; }
+.al-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 32px;
+  padding: 0 0.75rem;
+  border-radius: 8px;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.al-btn.primary {
+  border: 1px solid var(--vc-data-live);
+  background: color-mix(in srgb, var(--vc-data-live) 16%, transparent);
+  color: var(--vc-text-primary);
+  flex: 1;
+}
+.al-btn.primary:hover:not(:disabled) { background: color-mix(in srgb, var(--vc-data-live) 28%, transparent); }
+.al-btn.ghost { border: 1px solid var(--vc-line-strong); color: var(--vc-text-secondary); flex: 1; }
+.al-btn.ghost:hover:not(:disabled) { color: var(--vc-text-primary); border-color: var(--vc-text-tertiary); }
+.al-btn:disabled { opacity: 0.45; cursor: default; }
+
+.al-empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--vc-text-tertiary);
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.al-error {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-size: 12.5px;
+}
+
+.al-toggle {
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  cursor: pointer;
+}
+.al-toggle input { accent-color: var(--vc-data-live); width: 14px; height: 14px; }
+
+/* ---- stacked detail (narrow) ---- */
+
+.al-panel.stacked { display: flex; flex-direction: column; gap: 0.7rem; }
+.al-back {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: 38px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.al-back:hover { color: var(--vc-text-primary); border-color: var(--vc-line-strong); }
+
+/* ---- episode detail ---- */
+
+.al-detail { display: flex; flex-direction: column; gap: 0.9rem; }
+.al-detail-head {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding-bottom: 0.7rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.al-detail-title {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+
+.al-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-left: 3px solid var(--vc-line-strong);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+}
+.al-status.active { border-left-color: var(--vc-state-alert); }
+.al-status.unacknowledged { border-left-color: var(--vc-state-due); }
+.al-status.acknowledged { border-left-color: var(--vc-state-complete); }
+.al-status-alarms {
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.al-status-alarms strong { color: var(--vc-text-primary); }
+
+.al-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.6rem;
+}
+.al-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+}
+.al-info-label {
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.al-info-value {
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  color: var(--vc-text-primary);
+  word-break: break-word;
+}
+
+/* The two series keep the board's own colours so the episode reads as the
+   same data the charts behind it are showing. */
+.al-metric {
+  padding: 0.65rem 0.8rem;
+  border: 1px solid;
+  border-radius: 10px;
+}
+.al-metric.spo2 {
+  border-color: color-mix(in srgb, var(--vc-data-live) 40%, transparent);
+  background: color-mix(in srgb, var(--vc-data-live) 10%, transparent);
+}
+.al-metric.hr {
+  border-color: color-mix(in srgb, var(--vc-state-complete) 40%, transparent);
+  background: color-mix(in srgb, var(--vc-state-complete) 10%, transparent);
+}
+.al-metric-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.3rem;
+}
+.al-metric-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.al-metric.spo2 .al-metric-label { color: var(--vc-data-live); }
+.al-metric.hr .al-metric-label { color: var(--vc-state-complete); }
+.al-metric-value {
+  font-family: var(--vc-font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+  color: var(--vc-text-primary);
+}
+/* Red only here: an alarm actually tripped. */
+.al-alarm {
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: var(--vc-state-alert);
+  color: var(--vc-bg-base);
+  font-family: var(--vc-font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+/* ---- wide: table ----
+   Same visual language as the schedule panels' tables so the sections read as
+   one board. Fixed layout because the columns should line up down the page
+   regardless of how long an event name happens to be. */
+.al-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-family: var(--vc-font-mono);
+}
+.al-table th, .al-table td {
+  padding: 0.6rem 0.7rem;
+  text-align: left;
+  border-bottom: 1px solid var(--vc-line-hairline);
+  font-weight: 400;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.al-table thead th {
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  border-bottom-color: var(--vc-line-strong);
+}
+.al-table th:nth-child(1) { width: 20%; }
+.al-table th:nth-child(2) { width: auto; }
+.al-table th:nth-child(3) { width: 22%; }
+.al-table th:nth-child(4) { width: 11%; }
+.al-table th:nth-child(5) { width: 13%; }
+.al-table th:nth-child(6) { width: 11%; }
+.al-table tbody td { font-size: 12px; color: var(--vc-text-secondary); }
+.al-table tbody tr { cursor: pointer; border-left: 3px solid transparent; }
+.al-table tbody tr:hover { background: var(--vc-bg-surface); }
+.al-table tbody tr.selected {
+  background: var(--vc-bg-surface);
+  border-left-color: var(--vc-data-live);
+}
+.al-td-time { white-space: nowrap; }
+.al-rowbtn {
+  font-size: 12.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--vc-text-primary);
+  cursor: pointer;
+  text-align: left;
+}
+.al-rowbtn:hover { color: var(--vc-data-live); }
+.al-actions-col { white-space: nowrap; text-align: right; }
+.al-btn.sm { min-height: 28px; font-size: 9.5px; padding: 0 0.55rem; flex: none; }

--- a/frontend/src/components/dashboard/live-dashboard.css
+++ b/frontend/src/components/dashboard/live-dashboard.css
@@ -520,3 +520,39 @@
   .ld-topbar { gap: 0.7rem; }
   .ld-action svg { width: 22px; height: 22px; }
 }
+
+/* ---- Mobile modal header ----
+ * App.css styles this bar for the pre-vc app: a 65px band with a #60a5fa
+ * "← Back" that belongs to no palette here. It appears on every section on a
+ * phone, so its weight is felt across the whole board. Tighter, and on-token.
+ * Specificity is doubled deliberately — App.css is injected after this sheet. */
+.live-dash .modal-header.mobile {
+  height: auto;
+  min-height: 0;
+  padding: 0.55rem 0.75rem;
+  gap: 0.6rem;
+  border-bottom: 1px solid var(--dash-border);
+  background: none;
+}
+.live-dash .modal-header .modal-back-button {
+  flex-shrink: 0;
+  min-height: 34px;
+  padding: 0 0.6rem;
+  border: 1px solid var(--dash-border);
+  border-radius: 8px;
+  background: var(--dash-surface);
+  color: var(--dash-text-muted);
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  gap: 0.3rem;
+}
+.live-dash .modal-header .modal-back-button:hover {
+  background: var(--dash-surface-2);
+  color: var(--dash-text);
+  border-color: var(--dash-border-strong);
+}
+/* The title carries the section, so it gets the space the button gives back. */
+.live-dash .modal-header.mobile .modal-title { font-size: 12.5px; min-width: 0; }


### PR DESCRIPTION
Two sizes, as asked: **narrow**, tapping an episode swaps the panel to its detail with a way back; **expanded**, the detail sits beside the list. Unlike the schedule sections, tapping narrow doesn't widen the panel — an alert is something you read where you are.

Per your follow-up, the list is **cards narrow, table expanded** (Time / Event / Values / Duration / Status). A column of cards at 1150px is mostly whitespace, and the point of the wide view is scanning many episodes at once.

## Theming is ours, not the mockup's

The mockup paints every number red. Here red means **the signal that actually tripped its alarm**, so an episode where SpO₂ breached and the heart rate didn't says exactly that.

Red is right for this section at all, though — an alert is the clinical concern the palette reserves it for. So an ongoing episode is red, one waiting on a human is amber, a reviewed one is green. That's deliberately the opposite of the schedule panels, where adherence is never red because being late isn't an emergency. The two event charts now use the board's own series colours (cyan SpO₂, green heart rate) instead of a separate palette.

The API has no event name, so the title is derived from the alarms an episode tripped — "Low oxygen", "High heart rate", or both.

## Not invented

- **The review classification** (valid / artifact / unsure) has nothing behind it. What acknowledgement actually captures is whether oxygen was administered — which already exists and is more useful — so that flow is kept as-is.
- **Multi-select "acknowledge selected"** — "Ack all" already covers the bulk case.
- **The second view isn't an alert history**, it's the day's pulse-ox analysis. Rather than rename a tab people know, the switcher's sublabel says what it is. Its internals are unchanged and still want their own pass.

## Also, from the phone

App.css styles the modal header bar for the pre-vc app: a 65px band with a `#60a5fa` back button belonging to no palette here. It shows on every section on a phone, so its weight is felt across the whole board. Now **55px** with an on-token mono back control — verified across all four sections.

459 frontend tests unchanged: this is presentation over an existing data layer, and the acknowledge/oxygen flow it wraps is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011u7gjNWppXao35QPLtBBQe