### PR TITLE
Dashboard nav drawer mirrors the admin drawer

### DIFF
--- a/frontend/src/components/dashboard/DashboardNavDrawer.jsx
+++ b/frontend/src/components/dashboard/DashboardNavDrawer.jsx
@@ -1,0 +1,101 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The live dashboard's phone navigation, built to mirror the admin drawer:
+// its own header, labelled groups, one row per destination.
+//
+// It renders from the same action list the top bar uses (buildTopBarActions),
+// so a section can't appear in one and not the other — which is exactly what
+// happened when Capture Vitals had to be added to a hand-written copy of this
+// list separately.
+import { NAV_GROUPS } from './topBarActions';
+import { SettingsIcon, XIcon } from '../Icons';
+import './dash-nav.css';
+
+export default function DashboardNavDrawer({
+  open,
+  onClose,
+  actions = [],
+  patientName,
+  onSettings,
+}) {
+  if (!open) return null;
+
+  const groups = NAV_GROUPS
+    .map(g => ({ ...g, items: actions.filter(a => a.group === g.key) }))
+    .filter(g => g.items.length > 0);
+
+  const run = (fn) => () => { onClose(); if (fn) fn(); };
+
+  const row = (item) => (
+    <button
+      key={item.key}
+      type="button"
+      className={`dn-item${item.active ? ' active' : ''}`}
+      onClick={run(item.onClick)}
+    >
+      <span className="dn-item-icon" aria-hidden="true">{item.icon}</span>
+      <span className="dn-item-label">{item.label}</span>
+      {item.badge > 0 && <span className="dn-item-badge">{item.badge > 99 ? '99+' : item.badge}</span>}
+    </button>
+  );
+
+  return (
+    <div className="dn-overlay" onClick={onClose} role="presentation">
+      <nav
+        className="dn-drawer"
+        onClick={(e) => e.stopPropagation()}
+        aria-label="Live monitor navigation"
+      >
+        <div className="dn-head">
+          <button type="button" className="dn-close" onClick={onClose} aria-label="Close navigation">
+            <XIcon size={18} />
+            <span>Close</span>
+          </button>
+          <span className="dn-head-title">
+            SHH <span className="dn-head-sep">/</span> Live monitor
+          </span>
+        </div>
+
+        {patientName && (
+          <div className="dn-patient">
+            <span className="dn-patient-label">Patient</span>
+            <span className="dn-patient-name">{patientName}</span>
+          </div>
+        )}
+
+        <div className="dn-groups">
+          {groups.map((group) => (
+            <div key={group.key} className="dn-group">
+              <span className="dn-group-label">{group.label}</span>
+              <div className="dn-group-items">{group.items.map(row)}</div>
+            </div>
+          ))}
+
+          {onSettings && (
+            <div className="dn-group">
+              <span className="dn-group-label">Account</span>
+              <div className="dn-group-items">
+                {row({ key: 'settings', label: 'Settings', icon: <SettingsIcon />, onClick: onSettings, badge: 0 })}
+              </div>
+            </div>
+          )}
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardNavDrawer.test.jsx
+++ b/frontend/src/components/dashboard/DashboardNavDrawer.test.jsx
@@ -1,0 +1,98 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The live dashboard's phone navigation. What is worth pinning down is that it
+// derives from the top bar's action list rather than a copy of it, that a tap
+// both acts and closes, and that a section with no actions leaves no empty
+// group heading behind.
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import DashboardNavDrawer from './DashboardNavDrawer';
+
+const actions = [
+  { key: 'capture', group: 'record', label: 'Capture Vitals', icon: null, onClick: vi.fn(), badge: 0 },
+  { key: 'medications', group: 'care', label: 'Medications', icon: null, onClick: vi.fn(), badge: 3 },
+  { key: 'alerts', group: 'monitoring', label: 'Alerts', icon: null, onClick: vi.fn(), badge: 351 },
+];
+
+const setup = (props = {}) =>
+  render(
+    <DashboardNavDrawer
+      open
+      onClose={vi.fn()}
+      actions={actions}
+      patientName="Test Testerson"
+      onSettings={vi.fn()}
+      {...props}
+    />
+  );
+
+describe('DashboardNavDrawer', () => {
+  it('renders nothing when closed', () => {
+    const { container } = setup({ open: false });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('groups the top bar actions under their section labels', () => {
+    setup();
+    const labels = screen.getAllByText(/^(Record|Care|Monitoring|Account)$/).map(n => n.textContent);
+    expect(labels).toEqual(['Record', 'Care', 'Monitoring', 'Account']);
+    expect(screen.getByText('Capture Vitals')).toBeInTheDocument();
+    expect(screen.getByText('Medications')).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('drops a group heading when nothing is in it', () => {
+    setup({ actions: actions.filter(a => a.group !== 'care') });
+    expect(screen.queryByText('Care')).not.toBeInTheDocument();
+    expect(screen.getByText('Record')).toBeInTheDocument();
+  });
+
+  it('shows the patient the drawer is acting on', () => {
+    setup();
+    expect(screen.getByText('Test Testerson')).toBeInTheDocument();
+  });
+
+  it('caps a large badge rather than widening the row', () => {
+    setup();
+    expect(screen.getByText('99+')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('omits the badge entirely when nothing is due', () => {
+    const { container } = setup({ actions: [actions[0]] });
+    expect(container.querySelectorAll('.dn-item-badge')).toHaveLength(0);
+  });
+
+  it('runs the action and closes on tap', () => {
+    const onClose = vi.fn();
+    const onClick = vi.fn();
+    setup({ onClose, actions: [{ ...actions[1], onClick }] });
+    fireEvent.click(screen.getByText('Medications'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on the scrim but not on the drawer body', () => {
+    const onClose = vi.fn();
+    const { container } = setup({ onClose });
+    fireEvent.click(container.querySelector('.dn-drawer'));
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(container.querySelector('.dn-overlay'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/dashboard/dash-nav.css
+++ b/frontend/src/components/dashboard/dash-nav.css
@@ -1,0 +1,196 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Phone navigation for the live dashboard, shaped like the admin drawer: its
+ * own header, labelled groups, one row per destination.
+ *
+ * Rendered outside the `.tw` island, so box-sizing and the bare <button> paint
+ * are asserted; `:where()` keeps that reset at element specificity. */
+@import '../../styles/vc-tokens.css';
+
+.dn-overlay, .dn-overlay * { box-sizing: border-box; }
+:where(.dn-drawer) button {
+  font-family: var(--vc-font-mono);
+  padding: 0;
+  border: 1px solid transparent;
+  background: none;
+  color: inherit;
+}
+
+.dn-overlay {
+  position: fixed;
+  inset: 0;
+  /* Above the top bar hamburger (z 1001), which otherwise punches through the
+     scrim and overlaps the title. The drawer carries its own CLOSE. */
+  z-index: 1002;
+  display: flex;
+  justify-content: flex-end;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.dn-drawer {
+  display: flex;
+  flex-direction: column;
+  width: min(320px, 88vw);
+  height: 100%;
+  max-height: 100dvh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  border-left: 1px solid var(--vc-line-strong);
+  background: var(--vc-bg-sheet);
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem);
+  box-shadow: -12px 0 32px rgba(0, 0, 0, 0.5);
+}
+
+/* ---- header ---- */
+
+.dn-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: calc(env(safe-area-inset-top, 0px) + 0.7rem) 0.8rem 0.7rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+  background: var(--vc-bg-sheet);
+}
+.dn-close {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 36px;
+  padding: 0 0.65rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.dn-close:hover { color: var(--vc-text-primary); border-color: var(--vc-line-strong); }
+.dn-head-title {
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dn-head-sep { color: var(--vc-text-tertiary); margin: 0 0.15rem; }
+
+.dn-patient {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.dn-patient-label {
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.dn-patient-name {
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+
+/* ---- groups ---- */
+
+.dn-groups { display: flex; flex-direction: column; padding: 0.4rem 0.5rem; }
+.dn-group { display: flex; flex-direction: column; padding: 0.35rem 0 0.45rem; }
+.dn-group + .dn-group {
+  border-top: 1px solid var(--vc-line-hairline);
+  margin-top: 0.25rem;
+  padding-top: 0.6rem;
+}
+.dn-group-label {
+  padding: 0 0.4rem 0.35rem;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.dn-group-items { display: flex; flex-direction: column; gap: 0.15rem; }
+
+.dn-item {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  width: 100%;
+  min-height: 44px;
+  padding: 0 0.55rem;
+  border-radius: 8px;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-align: left;
+  cursor: pointer;
+}
+.dn-item:hover { background: var(--vc-bg-surface); }
+.dn-item.active {
+  background: color-mix(in srgb, var(--vc-data-live) 14%, transparent);
+  color: var(--vc-text-primary);
+}
+.dn-item-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  color: var(--vc-text-secondary);
+}
+.dn-item.active .dn-item-icon { color: var(--vc-data-live); }
+.dn-item-icon svg { width: 20px; height: 20px; }
+.dn-item-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* A count, not a klaxon: the badge keeps the top bar's red so the two agree,
+   but sized as a pill rather than the old 24px circle. */
+.dn-item-badge {
+  flex-shrink: 0;
+  min-width: 22px;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--vc-state-alert) 20%, transparent);
+  border: 1px solid color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
+  color: var(--vc-state-alert);
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/components/dashboard/topBarActions.jsx
+++ b/frontend/src/components/dashboard/topBarActions.jsx
@@ -28,6 +28,15 @@ import {
   VitalsCaptureIcon,
 } from '../Icons';
 
+/* Nav groups, mirroring the admin sidebar's shape. The drawer renders from
+ * this same list as the top bar, so the two can never drift — the capture
+ * action had to be added in two places before this. */
+export const NAV_GROUPS = [
+  { key: 'record', label: 'Record' },
+  { key: 'care', label: 'Care' },
+  { key: 'monitoring', label: 'Monitoring' },
+];
+
 export function buildTopBarActions({
   pulseOxAlerts, medicationDueCount, nutritionDueCount, careTaskDueCount, equipmentDueCount,
   hasCamera, modalOpen, handlers,
@@ -35,16 +44,16 @@ export function buildTopBarActions({
   return [
     // Capture leads: recording a vital set is the one action a caregiver takes
     // at the bedside mid-shift, and it is allowed in monitoring mode.
-    { key: 'capture', label: 'Capture Vitals', icon: <VitalsCaptureIcon />, onClick: handlers.capture, active: modalOpen.capture, badge: 0 },
-    { key: 'alerts', label: 'Alerts', icon: <MinimalistPulseOxIcon />, onClick: handlers.alerts, active: modalOpen.alerts, badge: pulseOxAlerts },
-    { key: 'medications', label: 'Medications', icon: <MedicationIcon />, onClick: handlers.medications, active: modalOpen.medications, badge: medicationDueCount },
-    { key: 'nutrition', label: 'Nutrition', icon: <NutritionIcon />, onClick: handlers.nutrition, active: modalOpen.nutrition, badge: nutritionDueCount },
-    { key: 'careTasks', label: 'Care Tasks', icon: <CareTasksIcon />, onClick: handlers.careTasks, active: modalOpen.careTasks, badge: careTaskDueCount },
-    { key: 'equipment', label: 'Equipment', icon: <MinimalistVentIcon />, onClick: handlers.equipment, active: modalOpen.equipment, badge: equipmentDueCount },
-    { key: 'history', label: 'History', icon: <HistoryIcon />, onClick: handlers.history, active: modalOpen.history, badge: 0 },
+    { key: 'capture', group: 'record', label: 'Capture Vitals', icon: <VitalsCaptureIcon />, onClick: handlers.capture, active: modalOpen.capture, badge: 0 },
+    { key: 'alerts', group: 'monitoring', label: 'Alerts', icon: <MinimalistPulseOxIcon />, onClick: handlers.alerts, active: modalOpen.alerts, badge: pulseOxAlerts },
+    { key: 'medications', group: 'care', label: 'Medications', icon: <MedicationIcon />, onClick: handlers.medications, active: modalOpen.medications, badge: medicationDueCount },
+    { key: 'nutrition', group: 'care', label: 'Nutrition', icon: <NutritionIcon />, onClick: handlers.nutrition, active: modalOpen.nutrition, badge: nutritionDueCount },
+    { key: 'careTasks', group: 'care', label: 'Care Tasks', icon: <CareTasksIcon />, onClick: handlers.careTasks, active: modalOpen.careTasks, badge: careTaskDueCount },
+    { key: 'equipment', group: 'care', label: 'Equipment', icon: <MinimalistVentIcon />, onClick: handlers.equipment, active: modalOpen.equipment, badge: equipmentDueCount },
+    { key: 'history', group: 'monitoring', label: 'History', icon: <HistoryIcon />, onClick: handlers.history, active: modalOpen.history, badge: 0 },
     hasCamera
-      ? { key: 'camera', label: 'Live Camera', icon: <CameraIcon />, onClick: handlers.camera, active: modalOpen.camera, badge: 0 }
-      : { key: 'messages', label: 'Messages', icon: <MessagesIcon />, onClick: handlers.messages, active: modalOpen.messages, badge: 0 },
+      ? { key: 'camera', group: 'monitoring', label: 'Live Camera', icon: <CameraIcon />, onClick: handlers.camera, active: modalOpen.camera, badge: 0 }
+      : { key: 'messages', group: 'monitoring', label: 'Messages', icon: <MessagesIcon />, onClick: handlers.messages, active: modalOpen.messages, badge: 0 },
   ];
 }
 

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1066,7 +1066,7 @@ export default function Dashboard() {
         onClose={() => setIsMobileMenuOpen(false)}
         actions={topBarActions}
         patientName={selectedPatient
-          ? `${selectedPatient.first_name} ${selectedPatient.last_name}`.trim()
+          ? [selectedPatient.first_name, selectedPatient.last_name].filter(Boolean).join(' ')
           : null}
         onSettings={handleSettingsClick}
       />

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -19,20 +19,9 @@ import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } fr
 import DynamicVitalsCard from "../components/DynamicVitalsCard";
 import ModalBase from "../components/ModalBase";
 import SettingsForm from "../components/SettingsForm";
-import {
-  SettingsIcon,
-  MinimalistVentIcon,
-  MinimalistPulseOxIcon,
-  HistoryIcon,
-  MedicationIcon,
-  NutritionIcon,
-  CareTasksIcon,
-  MessagesIcon,
-  CameraIcon,
-  VitalsCaptureIcon
-} from "../components/Icons";
 import TopBar from "../components/dashboard/TopBar";
 import CaptureVitalsModal from "../components/dashboard/CaptureVitalsModal";
+import DashboardNavDrawer from "../components/dashboard/DashboardNavDrawer";
 import { ModalDockProvider } from "../contexts/ModalDockContext";
 import { buildTopBarActions } from "../components/dashboard/topBarActions";
 import StatTile from "../components/dashboard/StatTile";
@@ -1070,72 +1059,18 @@ export default function Dashboard() {
         onToggleMobileMenu={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
       />
 
-      {/* Mobile Menu Overlay */}
-      {isMobile && isMobileMenuOpen && (
-        <div className="mobile-menu-overlay" onClick={() => setIsMobileMenuOpen(false)}>
-          <div className="mobile-menu" onClick={(e) => e.stopPropagation()}>
-            {/* Mirrors buildTopBarActions' order — this list is hand-written
-                because the drawer shows labels, not icon buttons. */}
-            <div className="mobile-menu-item" onClick={() => { handleCaptureClick(); setIsMobileMenuOpen(false); }}>
-              <VitalsCaptureIcon size={24} />
-              <span>Capture Vitals</span>
-            </div>
+      {/* Phone navigation. Rendered from the same action list as the top bar
+          (see DashboardNavDrawer) rather than a hand-written copy of it. */}
+      <DashboardNavDrawer
+        open={isMobile && isMobileMenuOpen}
+        onClose={() => setIsMobileMenuOpen(false)}
+        actions={topBarActions}
+        patientName={selectedPatient
+          ? `${selectedPatient.first_name} ${selectedPatient.last_name}`.trim()
+          : null}
+        onSettings={handleSettingsClick}
+      />
 
-            <div className="mobile-menu-item" onClick={() => { handlePulseOxClick(); setIsMobileMenuOpen(false); }}>
-              <MinimalistPulseOxIcon />
-              <span>Alerts</span>
-              {pulseOxAlerts > 0 && <div className="mobile-badge">{pulseOxAlerts}</div>}
-            </div>
-            
-            <div className="mobile-menu-item" onClick={() => { handleMedicationClick(); setIsMobileMenuOpen(false); }}>
-              <MedicationIcon />
-              <span>Medications</span>
-              {medicationDueCount > 0 && <div className="mobile-badge">{medicationDueCount}</div>}
-            </div>
-
-            <div className="mobile-menu-item" onClick={() => { handleNutritionClick(); setIsMobileMenuOpen(false); }}>
-              <NutritionIcon />
-              <span>Nutrition</span>
-              {nutritionDueCount > 0 && <div className="mobile-badge">{nutritionDueCount}</div>}
-            </div>
-
-            <div className="mobile-menu-item" onClick={() => { handleCareTaskClick(); setIsMobileMenuOpen(false); }}>
-              <CareTasksIcon />
-              <span>Care Tasks</span>
-              {careTaskDueCount > 0 && <div className="mobile-badge">{careTaskDueCount}</div>}
-            </div>
-            
-            <div className="mobile-menu-item" onClick={() => { handleVentClick(); setIsMobileMenuOpen(false); }}>
-              <MinimalistVentIcon />
-              <span>Equipment</span>
-              {equipmentDueCount > 0 && <div className="mobile-badge">{equipmentDueCount}</div>}
-            </div>
-            
-            <div className="mobile-menu-item" onClick={() => { handleHistoryClick(); setIsMobileMenuOpen(false); }}>
-              <HistoryIcon />
-              <span>History</span>
-            </div>
-            
-            {hasCamera ? (
-              <div className="mobile-menu-item" onClick={() => { handleCameraClick(); setIsMobileMenuOpen(false); }}>
-                <CameraIcon />
-                <span>Live Camera</span>
-              </div>
-            ) : (
-              <div className="mobile-menu-item" onClick={() => { handleMessagesClick(); setIsMobileMenuOpen(false); }}>
-                <MessagesIcon />
-                <span>Messages</span>
-              </div>
-            )}
-            
-            <div className="mobile-menu-item" onClick={() => { handleSettingsClick(); setIsMobileMenuOpen(false); }}>
-              <SettingsIcon />
-              <span>Settings</span>
-            </div>
-          </div>
-        </div>
-      )}
-      
       {/* Compact vitals banner shown only while an auth modal is up on
           mobile, so the 3 large readings stay visible above the modal. */}
       {isMobile && authModalActive && (


### PR DESCRIPTION
The live dashboard's phone drawer was a hand-written list of nine rows — no header, no grouping, and a 24px red circle for every count. Admin already answers this (header, labelled groups, compact rows), so this brings the dashboard in line rather than inventing a third pattern.

## What changed

**`DashboardNavDrawer` renders from `buildTopBarActions`** — the same list the top bar uses — with a `group` field added per action:

| Group | Items |
|---|---|
| Record | Capture Vitals |
| Care | Medications, Nutrition, Care Tasks, Equipment |
| Monitoring | Alerts, History, Live Camera / Messages |
| Account | Settings |

The old hand-written copy is why Capture Vitals had to be added to the drawer separately when it shipped. Deriving both from one list removes that failure mode. A group with no actions renders nothing, so a heading can't outlive its contents.

**Chrome**: sticky `SHH / Live monitor` header with its own CLOSE, a `PATIENT` context row, mono uppercase group labels on hairline separators, 44px rows.

**Badges** keep the top bar's red so the two agree, but as small pills rather than circles, capped at `99+`, and only when something is actually due. (Toning the red down across both is still available if you want it — you'd said leave the top bar alone, so I didn't split them.)

**Z-order**: the drawer now sits above the top bar's hamburger (z 1001), which was punching through the scrim and overlapping the title.

## Incidental

Ten dead icon imports removed from `Dashboard.jsx`. Lint doesn't catch these — `no-unused-vars` is configured with `varsIgnorePattern: '^[A-Z_]'`, which exempts every PascalCase component import. Worth knowing: dead component imports accumulate silently repo-wide.

## Verification

- Playwright at 390×844, cookie login, patient 2: header, four group labels, nine rows, badges `31 | 16 | 9 | 3 | 99+`, 320px drawer; tapping Medications opens the panel and closes the drawer.
- 8 new unit tests (grouping, empty-group elision, badge cap and omission, tap-acts-and-closes, scrim vs body click).
- `npm run lint`, `npx vite build`, `npm test` (467 passing).

## Note on ordering

Independent of #119 (alerts) — no shared files. Merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011u7gjNWppXao35QPLtBBQe