### PR TITLE
Daily pulse-ox analysis at the panel's two sizes

### DIFF
--- a/frontend/src/components/alerts/AlertsHistory.jsx
+++ b/frontend/src/components/alerts/AlertsHistory.jsx
@@ -15,255 +15,375 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect } from 'react';
-import config from '../../config';
-import { Alert } from '@/components/ui/alert';
-import { Label } from '@/components/ui/label';
+// A day of pulse oximetry, at the panel's two sizes.
+//
+// Narrow gets the full reading of the day: the scalars, the shape of the two
+// traces, when the sensor was actually on, where the dips were. Wide keeps the
+// arrangement it always had — rollup then distribution, at the analyzer's own
+// thirteen-bucket resolution — moved onto vc tokens.
+//
+// Sizing comes from useModalDock(), never from window.innerWidth: a 380px
+// panel on a 1920px screen is narrow, and the viewport cannot tell you that.
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, ReferenceLine, ResponsiveContainer } from 'recharts';
+import * as Select from '@radix-ui/react-select';
+import config, { apiFetch } from '../../config';
+import { useModalDock } from '../../contexts/ModalDockContext';
+import { CHART_CHROME } from '../../contexts/DashboardThemeContext';
+import { ChevronLeftIcon, ChevronRightIcon, CalendarIcon, CheckIcon, AlertIcon, ClockIcon, InfoIcon } from '../Icons';
 import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
-import { cn } from '@/lib/utils';
+  findEpisodes, coverageBuckets, downsample, collapseDistribution,
+  atAGlance, formatDuration, formatHours, WATCH_SPO2,
+} from './pulseOxDay';
+import './alerts-history.css';
+
+const SPO2_COLOR = '#4da7bd';
+const BPM_COLOR = '#3fbf6a';
+
+// The analyzer's full bucket set, in clinical order, for the wide view. Tone
+// follows the project rule: red is reserved for the sub-90 buckets.
+const FULL_BANDS = [
+  ['high_90s_97_plus', 'High 90s (97%+)', 'complete'],
+  ['mid_90s_94_96', 'Mid 90s (94-96%)', 'live'],
+  ['low_90s_90_93', 'Low 90s (90-93%)', 'due'],
+  ['high_eighties_85_89', 'High 80s (85-89%)', 'alert'],
+  ['low_eighties_80_84', 'Low 80s (80-84%)', 'alert'],
+  ['seventies_70_79', '70s (70-79%)', 'alert'],
+  ['sixties_60_69', '60s (60-69%)', 'alert'],
+  ['fifties_50_59', '50s (50-59%)', 'alert'],
+  ['forties_40_49', '40s (40-49%)', 'alert'],
+  ['thirties_30_39', '30s (30-39%)', 'alert'],
+  ['twenties_20_29', '20s (20-29%)', 'alert'],
+  ['below_twenty', 'Below 20%', 'alert'],
+  ['zero_errors', 'Sensor errors', 'idle'],
+];
+
+const GLANCE_ICON = {
+  ok: <CheckIcon size={10} />,
+  alert: <AlertIcon size={10} />,
+  due: <ClockIcon size={10} />,
+  info: <InfoIcon size={10} />,
+};
+
+const clockTime = (msValue) =>
+  new Date(msValue).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+
+// Parsed as a local date. `new Date('2026-08-18')` is UTC midnight, which
+// renders as the previous day for anyone west of Greenwich.
+const parseDay = (iso) => {
+  if (!iso) return null;
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
+};
+
+const shortDay = (iso) => {
+  const d = parseDay(iso);
+  return d ? d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' }) : '';
+};
+
+const longDay = (iso) => {
+  const d = parseDay(iso);
+  return d ? d.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }) : '';
+};
 
 const AlertsHistory = ({ patientId }) => {
+  const { expanded } = useModalDock();
   const [availableDates, setAvailableDates] = useState([]);
   const [selectedDate, setSelectedDate] = useState('');
   const [analysis, setAnalysis] = useState(null);
+  const [readings, setReadings] = useState([]);
+  const [alarmSpo2, setAlarmSpo2] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
+  const withPatient = useCallback(
+    (path) => `${config.apiUrl}${path}${patientId != null ? `${path.includes('?') ? '&' : '?'}patient_id=${patientId}` : ''}`,
+    [patientId]
+  );
+
+  // The alarm threshold decides which dips count as alert-level, so it is read
+  // from settings rather than assumed.
   useEffect(() => {
+    let live = true;
+    apiFetch(`${config.apiUrl}/api/settings`, { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(s => { if (live && s && s.min_spo2 != null) setAlarmSpo2(Number(s.min_spo2)); })
+      .catch(() => {});
+    return () => { live = false; };
+  }, []);
+
+  useEffect(() => {
+    let live = true;
     setAnalysis(null);
-    fetchAvailableDates();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchAvailableDates is recreated each render; effect is intentionally keyed on the patient only
-  }, [patientId]);
+    setReadings([]);
+    apiFetch(withPatient('/api/monitoring/history/dates'), { credentials: 'include' })
+      .then(r => { if (!r.ok) throw new Error('Failed to fetch dates'); return r.json(); })
+      .then(data => {
+        if (!live) return;
+        const dates = data.dates || [];
+        setAvailableDates(dates);
+        setSelectedDate(dates[0] || '');
+      })
+      .catch(() => { if (live) setError('Failed to load available dates'); });
+    return () => { live = false; };
+  }, [withPatient]);
 
-  const fetchAvailableDates = async () => {
-    try {
-      let url = `${config.apiUrl}/api/monitoring/history/dates`;
-      if (patientId != null) {
-        url += `?patient_id=${patientId}`;
-      }
-      const response = await fetch(url, { credentials: 'include' });
-      if (!response.ok) throw new Error('Failed to fetch dates');
-      const data = await response.json();
-      console.log('Received dates data:', data);
-      setAvailableDates(data.dates || []);
-      
-      // Auto-select the most recent date
-      if (data.dates && data.dates.length > 0) {
-        setSelectedDate(data.dates[0]);
-      }
-    } catch (err) {
-      console.error('Error fetching available dates:', err);
-      setError('Failed to load available dates');
-    }
-  };
-
-  const fetchAnalysis = async (date) => {
+  useEffect(() => {
+    if (!selectedDate) return;
+    let live = true;
     setLoading(true);
     setError(null);
-    try {
-      let url = `${config.apiUrl}/api/monitoring/history/analyze/${date}`;
-      if (patientId != null) {
-        url += `?patient_id=${patientId}`;
-      }
-      const response = await fetch(url, { credentials: 'include' });
-      if (!response.ok) throw new Error('Failed to fetch analysis');
-      const data = await response.json();
-      console.log('Received analysis data:', data);
-      setAnalysis(data);
-    } catch (err) {
-      console.error('Error fetching analysis:', err);
-      setError('Failed to load analysis data');
-    } finally {
-      setLoading(false);
-    }
-  };
+    // The raw readings back the traces, the coverage strip and the episode
+    // list; only the narrow stop draws those, so wide does not pay for them.
+    const wants = expanded
+      ? [apiFetch(withPatient(`/api/monitoring/history/analyze/${selectedDate}`), { credentials: 'include' })]
+      : [
+        apiFetch(withPatient(`/api/monitoring/history/analyze/${selectedDate}`), { credentials: 'include' }),
+        apiFetch(withPatient(`/api/monitoring/history/raw/${selectedDate}`), { credentials: 'include' }),
+      ];
+    Promise.all(wants)
+      .then(async ([aRes, rRes]) => {
+        if (!aRes.ok) throw new Error('Failed to fetch analysis');
+        const a = await aRes.json();
+        const r = rRes && rRes.ok ? await rRes.json() : null;
+        if (!live) return;
+        setAnalysis(a);
+        setReadings(r?.readings || []);
+      })
+      .catch(() => { if (live) setError('Failed to load analysis data'); })
+      .finally(() => { if (live) setLoading(false); });
+    return () => { live = false; };
+  }, [selectedDate, withPatient, expanded]);
 
-  const handleDateChange = (date) => {
-    setSelectedDate(date);
-    if (date) {
-      fetchAnalysis(date);
-    }
-  };
+  const series = useMemo(() => downsample(readings, 260), [readings]);
+  const episodes = useMemo(
+    () => findEpisodes(readings, { watch: WATCH_SPO2, alarm: alarmSpo2 }),
+    [readings, alarmSpo2]
+  );
+  const coverage = useMemo(() => coverageBuckets(readings, 90), [readings]);
+  const glance = useMemo(() => atAGlance(analysis, episodes, alarmSpo2), [analysis, episodes, alarmSpo2]);
+  const bands = useMemo(() => collapseDistribution(analysis?.spo2_distribution), [analysis]);
 
-  // Auto-load analysis for initial date
-  useEffect(() => {
-    if (selectedDate) {
-      fetchAnalysis(selectedDate);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchAnalysis is recreated each render; effect is intentionally keyed on selected date/patient only
-  }, [selectedDate, patientId]);
+  const idx = availableDates.indexOf(selectedDate);
+  // availableDates is newest-first, so "older" walks forward through it.
+  const goOlder = () => { if (idx >= 0 && idx < availableDates.length - 1) setSelectedDate(availableDates[idx + 1]); };
+  const goNewer = () => { if (idx > 0) setSelectedDate(availableDates[idx - 1]); };
 
-  const formatDate = (dateString) => {
-    // Parse as local date to avoid timezone conversion
-    const [year, month, day] = dateString.split('-');
-    const date = new Date(year, month - 1, day);
-    return date.toLocaleDateString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    });
-  };
+  const errorPct = analysis && analysis.total_readings
+    ? Math.round((analysis.error_spo2_readings / analysis.total_readings) * 1000) / 10
+    : 0;
+  const validPct = analysis && analysis.total_readings
+    ? Math.round((analysis.valid_spo2_readings / analysis.total_readings) * 100)
+    : 0;
 
-  const getSpo2Color = (category) => {
-    const colors = {
-      'high_90s_97_plus': '#059669',     // Dark Green
-      'mid_90s_94_96': '#22c55e',        // Green
-      'low_90s_90_93': '#65a30d',        // Lime Green
-      'high_eighties_85_89': '#eab308',  // Yellow
-      'low_eighties_80_84': '#f59e0b',   // Amber
-      'seventies_70_79': '#f97316',      // Orange
-      'sixties_60_69': '#ea580c',        // Dark Orange
-      'fifties_50_59': '#ef4444',        // Red
-      'forties_40_49': '#dc2626',        // Dark Red
-      'thirties_30_39': '#b91c1c',       // Darker Red
-      'twenties_20_29': '#991b1b',       // Very Dark Red
-      'below_twenty': '#7c2d12',         // Darkest Red
-      'zero_errors': '#6b7280'           // Gray
-    };
-    return colors[category] || '#6b7280';
-  };
-
-  const getCategoryLabel = (category) => {
-    const labels = {
-      'high_90s_97_plus': 'High 90s (97%+)',
-      'mid_90s_94_96': 'Mid 90s (94-96%)',
-      'low_90s_90_93': 'Low 90s (90-93%)',
-      'high_eighties_85_89': 'High 80s (85-89%)',
-      'low_eighties_80_84': 'Low 80s (80-84%)',
-      'seventies_70_79': '70s (70-79%)',
-      'sixties_60_69': '60s (60-69%)',
-      'fifties_50_59': '50s (50-59%)',
-      'forties_40_49': '40s (40-49%)',
-      'thirties_30_39': '30s (30-39%)',
-      'twenties_20_29': '20s (20-29%)',
-      'below_twenty': 'Below 20%',
-      'zero_errors': 'Sensor Errors (0%)'
-    };
-    return labels[category] || category;
-  };
-
-  const summaryCards = analysis ? [
-    { title: 'Time Logged', value: `${analysis.time_logged_hours}h`, valueClass: 'text-ring',
-      subtitle: `(${analysis.time_logged_minutes} minutes)` },
-    { title: 'Total Readings', value: analysis.total_readings.toLocaleString(), valueClass: 'text-success',
-      subtitle: `(${analysis.valid_spo2_readings} valid SpO₂${analysis.error_spo2_readings > 0 ? `, ${analysis.error_spo2_readings} errors` : ''})` },
-    { title: 'Average SpO₂', value: `${analysis.avg_spo2}%`, valueClass: 'text-warning',
-      subtitle: `Range: ${analysis.min_spo2}% - ${analysis.max_spo2}%` },
-    { title: 'Average BPM', value: analysis.avg_bpm, valueClass: 'text-ring',
-      subtitle: `Range: ${analysis.min_bpm} - ${analysis.max_bpm}` },
-  ] : [];
-
-  return (
-    <div className="tw flex flex-col gap-4 text-foreground">
-      {/* Header + date picker (stacks on mobile) */}
-      <div className="flex flex-col gap-3 border-b border-border pb-4 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="m-0 text-xl font-semibold">Pulse Oximetry Analysis</h2>
-        <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-2.5">
-          <Label htmlFor="date-select" className="text-muted-foreground">Select Date:</Label>
-          <Select
-            value={selectedDate || undefined}
-            onValueChange={handleDateChange}
-            disabled={loading}
-          >
-            <SelectTrigger id="date-select" className="w-full sm:w-auto sm:min-w-[240px]">
-              <SelectValue placeholder="Choose a date..." />
-            </SelectTrigger>
-            <SelectContent>
-              {availableDates.map(date => (
-                <SelectItem key={date} value={date}>
-                  {formatDate(date)}
-                </SelectItem>
+  const dateBar = (
+    <div className="ah-datebar">
+      <button type="button" className="ah-step" onClick={goOlder}
+        disabled={idx < 0 || idx >= availableDates.length - 1} aria-label="Previous day">
+        <ChevronLeftIcon size={16} />
+      </button>
+      {/* Radix Select rather than a Popover: the repo already ships Select, and
+          picking one of a list of days is exactly what it is for. */}
+      {/* Controlled from the first render: `undefined` until the dates land
+          would flip Radix from uncontrolled to controlled and warn. */}
+      <Select.Root value={selectedDate} onValueChange={setSelectedDate}>
+        <Select.Trigger className="ah-date" disabled={!availableDates.length} aria-label="Select date">
+          <CalendarIcon size={14} />
+          <Select.Value>{selectedDate ? shortDay(selectedDate) : 'No data'}</Select.Value>
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Content className="ah-date-menu" position="popper" sideOffset={6}>
+            <Select.Viewport>
+              {availableDates.map(d => (
+                <Select.Item key={d} value={d} className="ah-date-option" data-active={d === selectedDate}>
+                  <Select.ItemText>{longDay(d)}</Select.ItemText>
+                </Select.Item>
               ))}
-            </SelectContent>
-          </Select>
-        </div>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>
+      <button type="button" className="ah-step" onClick={goNewer} disabled={idx <= 0} aria-label="Next day">
+        <ChevronRightIcon size={16} />
+      </button>
+    </div>
+  );
+
+  const stat = (label, value, unit, sub, tone) => (
+    <div className={`ah-stat ah-tone-${tone || 'info'}`} key={label}>
+      <span className="ah-stat-label">{label}</span>
+      <span className="ah-stat-value">{value}{unit && <small>{unit}</small>}</span>
+      {sub && <span className="ah-stat-sub">{sub}</span>}
+    </div>
+  );
+
+  const rollup = analysis && (
+    <div className="ah-rollup">
+      {stat('Coverage', formatHours(analysis.time_logged_minutes), '', `${analysis.time_logged_minutes} minutes`, 'live')}
+      {stat('Valid readings', analysis.valid_spo2_readings.toLocaleString(), '', `${validPct}% of readings`, 'info')}
+      {stat('Average SpO₂', analysis.avg_spo2, '%', `Range ${analysis.min_spo2}-${analysis.max_spo2}%`, 'live')}
+      {stat('Average HR', analysis.avg_bpm, ' BPM', `Range ${analysis.min_bpm}-${analysis.max_bpm}`, 'complete')}
+      {stat('Sensor errors', errorPct, '%', `${analysis.error_spo2_readings.toLocaleString()} readings`,
+        analysis.error_spo2_readings > 0 ? 'due' : 'info')}
+    </div>
+  );
+
+  const distRow = (key, label, tone, count, percentage) => (
+    <div className={`ah-dist-row ah-tone-${tone}`} key={key}>
+      <span className="ah-swatch" />
+      <span className="ah-dist-label">{label}</span>
+      <div className="ah-dist-bar">
+        {/* A band that occurred at all keeps a visible sliver; one that did not
+            stays empty, so "rare" and "never" do not look alike. */}
+        <div className="ah-dist-fill" style={{ width: count > 0 ? `${Math.max(percentage, 1)}%` : 0 }} />
       </div>
+      <span className="ah-dist-stat">
+        <span className="ah-dist-pct">{percentage}%</span>
+        <span className="ah-dist-count">({count.toLocaleString()})</span>
+      </span>
+    </div>
+  );
 
-      {error && <Alert variant="destructive">{error}</Alert>}
+  const timeTicks = series.length
+    ? [series[0].t, series[Math.floor(series.length / 2)].t, series[series.length - 1].t]
+    : [];
 
-      {loading && (
-        <div className="flex items-center justify-center gap-3 py-10 text-muted-foreground">
-          <span className="h-6 w-6 animate-spin rounded-full border-[3px] border-muted border-t-ring" />
-          Loading analysis…
+  const trace = (label, key, color, refLine) => (
+    <>
+      <span className="ah-chart-label">{label}</span>
+      <div className="ah-chart">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={series} margin={{ top: 4, right: 6, bottom: 0, left: -18 }}>
+            <CartesianGrid stroke={CHART_CHROME.grid} vertical={false} />
+            <XAxis dataKey="t" type="number" domain={['dataMin', 'dataMax']} ticks={timeTicks}
+              tickFormatter={clockTime} stroke={CHART_CHROME.axis}
+              tick={{ fill: CHART_CHROME.textDim, fontSize: 9 }} tickLine={false} />
+            {/* Fixed SpO2 scale with even ticks: a percentage the reader
+                already has a feel for should not re-scale per day, and letting
+                recharts pick gave 88/91/94/100. */}
+            <YAxis domain={key === 'spo2' ? [88, 100] : ['dataMin - 10', 'dataMax + 10']}
+              ticks={key === 'spo2' ? [88, 92, 96, 100] : undefined}
+              stroke={CHART_CHROME.axis} tick={{ fill: CHART_CHROME.textDim, fontSize: 9 }}
+              tickLine={false} width={38} />
+            {refLine != null && (
+              <ReferenceLine y={refLine} stroke="var(--vc-state-due)" strokeDasharray="3 3" />
+            )}
+            <Line type="monotone" dataKey={key} stroke={color} strokeWidth={1.4} dot={false} isAnimationActive={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </>
+  );
+
+  const body = () => {
+    if (loading) return <div className="ah-note">Loading analysis…</div>;
+    if (!selectedDate) return <div className="ah-empty">No pulse oximetry data recorded</div>;
+    if (!analysis) return <div className="ah-empty">No data for {shortDay(selectedDate)}</div>;
+
+    if (expanded) {
+      return (
+        <>
+          {rollup}
+          <div className="ah-block">
+            <div className="ah-block-head">
+              <h4 className="ah-block-title">SpO&#8322; distribution</h4>
+              <span className="ah-tag">{longDay(analysis.date)}</span>
+            </div>
+            <div className="ah-dist">
+              {FULL_BANDS.map(([k, label, tone]) => {
+                const d = analysis.spo2_distribution?.[k];
+                return distRow(k, label, tone, d?.count || 0, d?.percentage || 0);
+              })}
+            </div>
+          </div>
+        </>
+      );
+    }
+
+    const alertLevel = episodes.filter(e => e.alertLevel).length;
+    return (
+      <>
+        {rollup}
+
+        {series.length > 0 && (
+          <div className="ah-block">
+            <div className="ah-block-head">
+              <h4 className="ah-block-title">Oxygen + heart rate</h4>
+              {alarmSpo2 != null && <span className="ah-tag">{alarmSpo2}% alarm</span>}
+            </div>
+            {trace('SpO₂ (%)', 'spo2', SPO2_COLOR, alarmSpo2)}
+            {trace('Heart rate (BPM)', 'bpm', BPM_COLOR, null)}
+            {coverage.buckets.length > 0 && (
+              <>
+                <span className="ah-chart-label">Sensor coverage</span>
+                <div className="ah-coverage">
+                  {coverage.buckets.map((on, i) => (
+                    <span key={i} className={`ah-cov-slot${on ? ' on' : ''}`} />
+                  ))}
+                </div>
+                <div className="ah-cov-axis">
+                  <span>{clockTime(coverage.startMs)}</span>
+                  <span>{formatHours(analysis.time_logged_minutes)} of data</span>
+                  <span>{clockTime(coverage.endMs)}</span>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        <div className="ah-block">
+          <h4 className="ah-block-title">SpO&#8322; distribution</h4>
+          <div className="ah-dist">
+            {bands.map(b => distRow(b.key, b.label, b.tone, b.count, b.percentage))}
+          </div>
         </div>
-      )}
 
-      {analysis && !loading && (
-        <div className="flex flex-col gap-5 rounded-xl border border-border bg-card p-4 sm:p-5">
-          <h3 className="m-0 text-center text-lg font-semibold">
-            Pulse Oximetry Analysis for {formatDate(analysis.date)}
-          </h3>
-
-          {/* Summary cards */}
-          <div className="grid gap-3 sm:gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))' }}>
-            {summaryCards.map(card => (
-              <div key={card.title} className="rounded-xl border border-border bg-muted/40 p-4 text-center">
-                <div className="mb-2 text-sm font-medium text-muted-foreground">{card.title}</div>
-                <div className={cn('text-2xl font-bold', card.valueClass)}>{card.value}</div>
-                <div className="mt-1 text-xs text-muted-foreground">{card.subtitle}</div>
+        <div className="ah-block">
+          <h4 className="ah-block-title">At a glance</h4>
+          <div className="ah-glance">
+            {glance.map((l, i) => (
+              <div className={`ah-glance-row ah-tone-${l.tone}`} key={i}>
+                <span className="ah-glance-dot">{GLANCE_ICON[l.tone]}</span>
+                {l.text}
               </div>
             ))}
           </div>
+        </div>
 
-          {/* SpO₂ distribution */}
-          <div className="rounded-xl border border-border bg-muted/30 p-4 sm:p-5">
-            <h4 className="m-0 mb-4 text-center text-base font-semibold">SpO₂ Distribution</h4>
-            <div className="flex flex-col gap-3">
-              {analysis.spo2_distribution && Object.entries(analysis.spo2_distribution).map(([category, data]) => (
-                <div
-                  key={category}
-                  className="flex flex-col gap-1.5 sm:grid sm:grid-cols-[minmax(140px,200px)_1fr_auto] sm:items-center sm:gap-4 sm:gap-y-0"
-                >
-                  {/* Label (+ inline stats on mobile) */}
-                  <div className="flex items-center justify-between gap-2 sm:justify-start">
-                    <div className="flex items-center gap-2 font-medium">
-                      <span className="h-3.5 w-3.5 shrink-0 rounded" style={{ backgroundColor: getSpo2Color(category) }} />
-                      <span className="text-sm">{getCategoryLabel(category)}</span>
-                    </div>
-                    <div className="flex items-baseline gap-1.5 sm:hidden">
-                      <span className="text-sm font-semibold text-foreground">{data.percentage}%</span>
-                      <span className="text-xs text-muted-foreground">({data.count.toLocaleString()})</span>
-                    </div>
-                  </div>
-
-                  {/* Bar */}
-                  <div className="h-2.5 overflow-hidden rounded-full bg-muted sm:h-5">
-                    <div
-                      className="h-full rounded-full transition-[width] duration-300"
-                      style={{ width: `${Math.max(data.percentage, 0.5)}%`, minWidth: 2, backgroundColor: getSpo2Color(category) }}
-                    />
-                  </div>
-
-                  {/* Stats (desktop column) */}
-                  <div className="hidden flex-col items-end gap-0.5 sm:flex">
-                    <span className="text-sm font-semibold text-foreground">{data.percentage}%</span>
-                    <span className="text-xs text-muted-foreground">({data.count.toLocaleString()})</span>
-                  </div>
+        <div className="ah-block">
+          <div className="ah-block-head">
+            <h4 className="ah-block-title">Low-oxygen episodes</h4>
+            <span className={`ah-tag${alertLevel ? ' ah-tone-alert' : ''}`}>
+              {alertLevel ? `${alertLevel} alert-level` : 'No alert-level episodes'}
+            </span>
+          </div>
+          {episodes.length === 0 ? (
+            <div className="ah-note">Nothing below {WATCH_SPO2}%</div>
+          ) : (
+            <div className="ah-eps">
+              {episodes.map(e => (
+                <div className={`ah-ep ah-tone-${e.alertLevel ? 'alert' : 'due'}`} key={e.startMs}>
+                  <span className="ah-ep-time">{clockTime(e.startMs)}</span>
+                  <span />
+                  <span className="ah-ep-nadir">{e.nadir}%</span>
+                  <span className="ah-ep-meta">
+                    {formatDuration(e.durationMs)} &middot; {e.readings} reading{e.readings === 1 ? '' : 's'}
+                    {e.bpmAtNadir != null && ` · ${e.bpmAtNadir} BPM at nadir`}
+                  </span>
                 </div>
               ))}
             </div>
-          </div>
+          )}
         </div>
-      )}
+      </>
+    );
+  };
 
-      {!analysis && !loading && selectedDate && (
-        <div className="rounded-xl border border-border bg-card p-10 text-center text-muted-foreground">
-          No pulse oximetry data found for {formatDate(selectedDate)}
-        </div>
-      )}
-
-      {!selectedDate && !loading && (
-        <div className="rounded-xl border border-border bg-card p-10 text-center text-muted-foreground">
-          Please select a date to view pulse oximetry analysis
-        </div>
-      )}
+  return (
+    <div className={`ah-panel${expanded ? ' wide' : ''}`}>
+      {dateBar}
+      {error && <div className="ah-error">{error}</div>}
+      {body()}
     </div>
   );
 };

--- a/frontend/src/components/alerts/AlertsHistory.test.jsx
+++ b/frontend/src/components/alerts/AlertsHistory.test.jsx
@@ -1,0 +1,171 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The day-analysis panel at its two sizes. The size comes from the dock, not
+// the viewport, so these render the same component under both dock values.
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ModalDockProvider } from '../../contexts/ModalDockContext';
+import AlertsHistory from './AlertsHistory';
+
+// recharts needs a real box to lay out in; jsdom reports zero.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual('recharts');
+  return { ...actual, ResponsiveContainer: ({ children }) => <div style={{ width: 400, height: 120 }}>{children}</div> };
+});
+
+const DATES = { dates: ['2026-08-18', '2026-08-17'] };
+
+const ANALYSIS = {
+  date: '2026-08-18',
+  total_readings: 100,
+  valid_spo2_readings: 100,
+  valid_bpm_readings: 100,
+  error_spo2_readings: 0,
+  error_bpm_readings: 0,
+  time_logged_minutes: 181,
+  time_logged_hours: 3.02,
+  avg_spo2: 98.2, min_spo2: 91, max_spo2: 100,
+  avg_bpm: 88.2, min_bpm: 74, max_bpm: 121,
+  spo2_distribution: {
+    high_90s_97_plus: { count: 80, percentage: 80 },
+    mid_90s_94_96: { count: 17, percentage: 17 },
+    low_90s_90_93: { count: 3, percentage: 3 },
+    high_eighties_85_89: { count: 0, percentage: 0 },
+    low_eighties_80_84: { count: 0, percentage: 0 },
+    seventies_70_79: { count: 0, percentage: 0 },
+    sixties_60_69: { count: 0, percentage: 0 },
+    fifties_50_59: { count: 0, percentage: 0 },
+    forties_40_49: { count: 0, percentage: 0 },
+    thirties_30_39: { count: 0, percentage: 0 },
+    twenties_20_29: { count: 0, percentage: 0 },
+    below_twenty: { count: 0, percentage: 0 },
+    zero_errors: { count: 0, percentage: 0 },
+  },
+};
+
+const T0 = Date.UTC(2026, 7, 18, 14, 0, 0);
+const RAW = {
+  readings: [
+    { timestamp: new Date(T0).toISOString(), spo2: 98, bpm: 85 },
+    { timestamp: new Date(T0 + 2000).toISOString(), spo2: 92, bpm: 94 },
+    { timestamp: new Date(T0 + 4000).toISOString(), spo2: 91, bpm: 96 },
+    { timestamp: new Date(T0 + 6000).toISOString(), spo2: 98, bpm: 86 },
+    { timestamp: new Date(T0 + 8000).toISOString(), spo2: 87, bpm: 110 },
+    { timestamp: new Date(T0 + 10000).toISOString(), spo2: 99, bpm: 84 },
+  ],
+};
+
+const route = (url) => {
+  if (url.includes('/api/settings')) return { min_spo2: 90 };
+  if (url.includes('/history/dates')) return DATES;
+  if (url.includes('/history/analyze/')) return ANALYSIS;
+  if (url.includes('/history/raw/')) return RAW;
+  return {};
+};
+
+let fetchMock;
+const stubFetch = (fn) => { fetchMock = vi.fn(fn); vi.stubGlobal('fetch', fetchMock); };
+
+beforeEach(() => {
+  stubFetch((url) => Promise.resolve({ ok: true, json: () => Promise.resolve(route(String(url))) }));
+});
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+const show = (expanded) =>
+  render(
+    <ModalDockProvider value={{ docked: true, expanded, toggleExpand: vi.fn(), setExpanded: vi.fn() }}>
+      <AlertsHistory patientId={2} />
+    </ModalDockProvider>
+  );
+
+describe('AlertsHistory', () => {
+  it('shows the day rollup at both sizes', async () => {
+    show(false);
+    await waitFor(() => expect(screen.getByText('Coverage')).toBeInTheDocument());
+    expect(screen.getByText('3h 01m')).toBeInTheDocument();
+    expect(screen.getByText('Range 91-100%')).toBeInTheDocument();
+  });
+
+  it('narrow draws the traces, the coverage strip and the episodes', async () => {
+    const { container } = show(false);
+    await waitFor(() => expect(screen.getByText('Oxygen + heart rate')).toBeInTheDocument());
+    expect(container.querySelectorAll('.ah-chart')).toHaveLength(2);
+    expect(container.querySelectorAll('.ah-cov-slot').length).toBeGreaterThan(0);
+    expect(screen.getByText('At a glance')).toBeInTheDocument();
+    // Two dips: 92→91 recovers, then a single reading at 87.
+    expect(container.querySelectorAll('.ah-ep')).toHaveLength(2);
+  });
+
+  it('narrow folds the thirteen buckets into five bands', async () => {
+    const { container } = show(false);
+    await waitFor(() => expect(screen.getByText('At a glance')).toBeInTheDocument());
+    expect(container.querySelectorAll('.ah-dist-row')).toHaveLength(5);
+    expect(screen.getByText('Below 90%')).toBeInTheDocument();
+  });
+
+  it('wide keeps the analyzer resolution and drops the narrow-only blocks', async () => {
+    const { container } = show(true);
+    await waitFor(() => expect(container.querySelectorAll('.ah-dist-row').length).toBe(13));
+    expect(screen.queryByText('Oxygen + heart rate')).not.toBeInTheDocument();
+    expect(screen.queryByText('At a glance')).not.toBeInTheDocument();
+    expect(container.querySelector('.ah-panel.wide')).toBeTruthy();
+  });
+
+  it('does not fetch the raw readings it will not draw', async () => {
+    show(true);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const urls = fetchMock.mock.calls.map(c => String(c[0]));
+    expect(urls.some(u => u.includes('/history/analyze/'))).toBe(true);
+    expect(urls.some(u => u.includes('/history/raw/'))).toBe(false);
+  });
+
+  it('marks only the dip past the configured alarm threshold as alert level', async () => {
+    const { container } = show(false);
+    await waitFor(() => expect(container.querySelectorAll('.ah-ep')).toHaveLength(2));
+    const tones = [...container.querySelectorAll('.ah-ep')].map(e => e.className);
+    expect(tones[0]).toContain('ah-tone-due');
+    expect(tones[1]).toContain('ah-tone-alert');
+    expect(screen.getByText('1 alert-level')).toBeInTheDocument();
+  });
+
+  it('scopes every request to the patient', async () => {
+    show(false);
+    await waitFor(() => expect(screen.getByText('At a glance')).toBeInTheDocument());
+    const monitoring = fetchMock.mock.calls
+      .map(c => String(c[0])).filter(u => u.includes('/api/monitoring/'));
+    expect(monitoring.length).toBeGreaterThan(0);
+    expect(monitoring.every(u => u.includes('patient_id=2'))).toBe(true);
+  });
+
+  it('reports a failed load instead of rendering an empty day', async () => {
+    stubFetch((url) => String(url).includes('/history/analyze/')
+      ? Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) })
+      : Promise.resolve({ ok: true, json: () => Promise.resolve(route(String(url))) }));
+    show(false);
+    await waitFor(() => expect(screen.getByText('Failed to load analysis data')).toBeInTheDocument());
+  });
+
+  it('says so when the patient has no recorded days at all', async () => {
+    stubFetch((url) => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(String(url).includes('/history/dates') ? { dates: [] } : route(String(url))),
+    }));
+    show(false);
+    await waitFor(() => expect(screen.getByText('No pulse oximetry data recorded')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/alerts/alerts-history.css
+++ b/frontend/src/components/alerts/alerts-history.css
@@ -1,0 +1,370 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Daily pulse-ox analysis, in the vc aesthetic.
+ *
+ * Rendered outside the `.tw` island, so box-sizing and the bare <button> paint
+ * are asserted here; `:where()` keeps the reset at element specificity. */
+@import '../../styles/vc-tokens.css';
+
+.ah-panel, .ah-panel * { box-sizing: border-box; }
+:where(.ah-panel) button {
+  font-family: var(--vc-font-mono);
+  padding: 0;
+  border: 1px solid transparent;
+  background: none;
+  color: inherit;
+}
+
+.ah-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding: 0.15rem 0 0.6rem;
+  color: var(--vc-text-primary);
+}
+
+/* Band colours. One place, so the legend swatch, the bar and the chart
+   reference line can never drift apart. */
+.ah-panel {
+  --ah-complete: var(--vc-state-complete);
+  --ah-live: var(--vc-data-live);
+  --ah-due: var(--vc-state-due);
+  --ah-alert: var(--vc-state-alert);
+  --ah-idle: var(--vc-text-tertiary);
+}
+.ah-tone-complete { --ah-tone: var(--ah-complete); }
+.ah-tone-live     { --ah-tone: var(--ah-live); }
+.ah-tone-due      { --ah-tone: var(--ah-due); }
+.ah-tone-alert    { --ah-tone: var(--ah-alert); }
+.ah-tone-idle     { --ah-tone: var(--ah-idle); }
+.ah-tone-ok       { --ah-tone: var(--ah-complete); }
+.ah-tone-info     { --ah-tone: var(--vc-text-tertiary); }
+
+/* ---- date bar ---- */
+
+.ah-datebar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.ah-step {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+.ah-step:hover:not(:disabled) { color: var(--vc-text-primary); border-color: var(--vc-line-strong); }
+.ah-step:disabled { opacity: 0.3; cursor: default; }
+
+.ah-date {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 34px;
+  padding: 0 0.6rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ah-date:hover { border-color: var(--vc-data-live); }
+.ah-date-menu {
+  z-index: 1300;
+  max-height: min(320px, 60vh);
+  overflow-y: auto;
+  padding: 0.3rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  background: var(--vc-bg-sheet);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.55);
+}
+.ah-date-option {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  border-radius: 6px;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.06em;
+  text-align: left;
+  cursor: pointer;
+}
+.ah-date-option:hover { background: var(--vc-bg-surface); color: var(--vc-text-primary); }
+.ah-date-option[data-active='true'] { color: var(--vc-data-live); }
+
+/* ---- rollup ---- */
+
+/* auto-fit rather than a fixed count: the same strip serves the narrow column
+   (two per row) and the wide stop (all five). */
+.ah-rollup {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+.ah-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.6rem 0.7rem;
+  border-right: 1px solid var(--vc-line-hairline);
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.ah-stat-label {
+  font-family: var(--vc-font-mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.ah-stat-value {
+  font-family: var(--vc-font-mono);
+  font-size: 21px;
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--ah-tone, var(--vc-text-primary));
+  font-variant-numeric: tabular-nums;
+}
+.ah-stat-value small { font-size: 11px; font-weight: 600; margin-left: 0.15rem; }
+.ah-stat-sub {
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.06em;
+  color: var(--vc-text-tertiary);
+}
+
+/* ---- blocks ---- */
+
+.ah-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 0.7rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+}
+.ah-block-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.ah-block-title {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.ah-tag {
+  padding: 0.15rem 0.45rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 999px;
+  font-family: var(--vc-font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.ah-tag.ah-tone-alert { border-color: color-mix(in srgb, var(--ah-tone) 55%, transparent); color: var(--ah-tone); }
+
+/* ---- charts ---- */
+
+.ah-chart-label {
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.ah-chart { width: 100%; height: 118px; }
+
+/* Presence, not amplitude: one column per slot, dim where the sensor was off. */
+.ah-coverage {
+  display: flex;
+  gap: 1px;
+  height: 18px;
+  border-radius: 3px;
+  overflow: hidden;
+}
+.ah-cov-slot { flex: 1; background: var(--vc-bg-raised); }
+.ah-cov-slot.on { background: color-mix(in srgb, var(--vc-data-live) 70%, transparent); }
+.ah-cov-axis {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.06em;
+  color: var(--vc-text-tertiary);
+}
+
+/* ---- distribution ---- */
+
+.ah-dist { display: flex; flex-direction: column; gap: 0.45rem; }
+.ah-dist-row {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+.ah-swatch { width: 10px; height: 10px; border-radius: 2px; background: var(--ah-tone); }
+.ah-dist-label {
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--vc-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ah-dist-bar {
+  grid-column: 2 / 3;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--vc-bg-raised);
+  overflow: hidden;
+}
+.ah-dist-fill { height: 100%; border-radius: 999px; background: var(--ah-tone); }
+.ah-dist-stat {
+  grid-row: 1 / 3;
+  grid-column: 3 / 4;
+  text-align: right;
+  font-family: var(--vc-font-mono);
+  font-variant-numeric: tabular-nums;
+}
+.ah-dist-pct { display: block; font-size: 11.5px; font-weight: 700; color: var(--vc-text-primary); }
+.ah-dist-count { display: block; font-size: 9.5px; color: var(--vc-text-tertiary); }
+
+/* ---- at a glance ---- */
+
+.ah-glance { display: flex; flex-direction: column; gap: 0.4rem; }
+.ah-glance-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--vc-font-sans);
+  font-size: 12px;
+  color: var(--vc-text-primary);
+}
+.ah-glance-dot {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border: 1.5px solid var(--ah-tone);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ah-tone);
+}
+.ah-glance-dot svg { width: 10px; height: 10px; }
+
+/* ---- episodes ---- */
+
+.ah-eps { display: flex; flex-direction: column; gap: 0.35rem; }
+.ah-ep {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 0.15rem 0.55rem;
+  padding: 0.5rem 0.6rem;
+  border-left: 2px solid var(--ah-tone);
+  border-radius: 0 8px 8px 0;
+  background: var(--vc-bg-raised);
+}
+.ah-ep-time {
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--vc-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.ah-ep-nadir {
+  font-family: var(--vc-font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--ah-tone);
+  font-variant-numeric: tabular-nums;
+}
+.ah-ep-meta {
+  grid-column: 1 / -1;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--vc-text-tertiary);
+}
+
+.ah-note, .ah-empty {
+  padding: 1.1rem 0.8rem;
+  text-align: center;
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.ah-error {
+  padding: 0.6rem 0.7rem;
+  border: 1px solid color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
+  font-family: var(--vc-font-sans);
+  font-size: 12px;
+  color: var(--vc-text-primary);
+}
+
+/* ---- wide stop ----
+   Same blocks, rethemed; only the arrangement changes. The rollup spreads to
+   five across via auto-fit above, and the distribution keeps all thirteen
+   analyzer buckets because there is room to read them. */
+.ah-panel.wide { gap: 0.85rem; }
+.ah-panel.wide .ah-datebar { max-width: 460px; }
+.ah-panel.wide .ah-stat-value { font-size: 26px; }
+.ah-panel.wide .ah-dist-row { grid-template-columns: 10px minmax(150px, 220px) minmax(0, 1fr) auto; }
+.ah-panel.wide .ah-dist-bar { grid-column: 3 / 4; height: 10px; }
+.ah-panel.wide .ah-dist-stat { grid-row: 1 / 2; grid-column: 4 / 5; display: flex; align-items: baseline; gap: 0.4rem; }
+.ah-panel.wide .ah-dist-pct { font-size: 12.5px; }

--- a/frontend/src/components/alerts/pulseOxDay.js
+++ b/frontend/src/components/alerts/pulseOxDay.js
@@ -1,0 +1,224 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Derivations over a day of raw pulse-ox readings.
+ *
+ * `GET /api/monitoring/history/analyze/{date}` already returns the day's
+ * scalars and its SpO2 distribution, but not the shape of the day: when the
+ * sensor was on, where the dips were, how long they lasted. All of that is
+ * recoverable from `GET /api/monitoring/history/raw/{date}`, so it is computed
+ * here rather than added to the API.
+ *
+ * Pure and side-effect free, so the arithmetic can be tested without a DOM. */
+
+/* The boundary between "worth listing" and "unremarkable".
+ *
+ * Not an invented number: the analyzer's own distribution buckets put the
+ * mid-90s band at 94-96 and the low-90s band at 90-93, so anything under 94
+ * has already fallen out of the normal band by the backend's taxonomy.
+ * Whether an episode is *alert-level* is a separate question, answered by the
+ * patient's configured `min_spo2` alarm threshold. */
+export const WATCH_SPO2 = 94;
+
+/* A reading with no usable SpO2. The analyzer counts these as
+ * `error_spo2_readings`; they are sensor dropouts, not desaturations, and
+ * must never be read as a dip. */
+const invalid = (r) => r == null || r.spo2 == null || r.spo2 <= 0;
+
+const ms = (r) => new Date(r.timestamp).getTime();
+
+/** Median gap between consecutive readings, in ms. Used to give a
+ *  single-sample episode a duration rather than reporting zero. */
+export function samplePeriodMs(readings) {
+  if (!readings || readings.length < 2) return 0;
+  const gaps = [];
+  for (let i = 1; i < readings.length; i++) {
+    const g = ms(readings[i]) - ms(readings[i - 1]);
+    if (g > 0) gaps.push(g);
+  }
+  if (!gaps.length) return 0;
+  gaps.sort((a, b) => a - b);
+  return gaps[Math.floor(gaps.length / 2)];
+}
+
+/**
+ * Contiguous runs of valid readings below `watch`.
+ *
+ * A run ends at the first valid reading at or above the threshold. Invalid
+ * readings do not end a run and do not extend it — a dropout in the middle of
+ * a desaturation is missing information, not a recovery.
+ */
+export function findEpisodes(readings, { watch = WATCH_SPO2, alarm = null } = {}) {
+  if (!readings || !readings.length) return [];
+  const period = samplePeriodMs(readings);
+  const out = [];
+  let run = null;
+
+  const close = () => {
+    if (!run) return;
+    const span = run.lastMs - run.firstMs;
+    out.push({
+      startMs: run.firstMs,
+      endMs: run.lastMs,
+      // One sample covers the period up to the next one, so a lone reading is
+      // reported as one sample period rather than as an instant.
+      durationMs: span > 0 ? span : period,
+      nadir: run.nadir,
+      bpmAtNadir: run.bpmAtNadir,
+      readings: run.count,
+      // Alert-level only when the patient's own alarm threshold was breached.
+      alertLevel: alarm != null && run.nadir < alarm,
+    });
+    run = null;
+  };
+
+  for (const r of readings) {
+    if (invalid(r)) continue;
+    if (r.spo2 < watch) {
+      const t = ms(r);
+      if (!run) run = { firstMs: t, lastMs: t, nadir: r.spo2, bpmAtNadir: r.bpm ?? null, count: 0 };
+      run.lastMs = t;
+      run.count += 1;
+      if (r.spo2 < run.nadir) { run.nadir = r.spo2; run.bpmAtNadir = r.bpm ?? null; }
+    } else {
+      close();
+    }
+  }
+  close();
+  return out;
+}
+
+/**
+ * Presence buckets across the covered window, for the coverage strip.
+ * Returns `count` slots, each true when at least one valid reading lands in it.
+ */
+export function coverageBuckets(readings, count = 96) {
+  const valid = (readings || []).filter(r => !invalid(r));
+  if (valid.length < 2 || count < 1) return { buckets: [], startMs: null, endMs: null };
+  const startMs = ms(valid[0]);
+  const endMs = ms(valid[valid.length - 1]);
+  const span = endMs - startMs;
+  if (span <= 0) return { buckets: [], startMs, endMs };
+  const buckets = new Array(count).fill(false);
+  for (const r of valid) {
+    const i = Math.min(count - 1, Math.floor(((ms(r) - startMs) / span) * count));
+    buckets[i] = true;
+  }
+  return { buckets, startMs, endMs };
+}
+
+/**
+ * Thin the series for plotting. Keeps the extremes of each bucket rather than
+ * an average, so a brief desaturation cannot be smoothed out of the picture.
+ */
+export function downsample(readings, maxPoints = 240) {
+  const valid = (readings || []).filter(r => !invalid(r));
+  if (valid.length <= maxPoints) {
+    return valid.map(r => ({ t: ms(r), spo2: r.spo2, bpm: r.bpm ?? null }));
+  }
+  const size = Math.ceil(valid.length / Math.max(1, Math.floor(maxPoints / 2)));
+  const out = [];
+  for (let i = 0; i < valid.length; i += size) {
+    const slice = valid.slice(i, i + size);
+    let lo = slice[0], hi = slice[0];
+    for (const r of slice) {
+      if (r.spo2 < lo.spo2) lo = r;
+      if (r.spo2 > hi.spo2) hi = r;
+    }
+    // Emit in time order so the line does not zig-zag backwards.
+    const pair = ms(lo) <= ms(hi) ? [lo, hi] : [hi, lo];
+    for (const r of pair) out.push({ t: ms(r), spo2: r.spo2, bpm: r.bpm ?? null });
+  }
+  return out;
+}
+
+/** Whole seconds, as "18s" / "2m 04s". */
+export function formatDuration(msSpan) {
+  const total = Math.max(0, Math.round((msSpan || 0) / 1000));
+  if (total < 60) return `${total}s`;
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}m ${String(s).padStart(2, '0')}s`;
+}
+
+/**
+ * The "at a glance" lines: the reading of the day a caregiver wants without
+ * doing the arithmetic. `tone` drives the icon, and follows the project rule
+ * that amber is attention and red is clinical concern.
+ */
+export function atAGlance(analysis, episodes, alarm) {
+  if (!analysis) return [];
+  const dist = analysis.spo2_distribution || {};
+  const lowNineties = dist.low_90s_90_93?.count || 0;
+  const belowNinety = Object.entries(dist)
+    .filter(([k]) => k !== 'zero_errors' && BELOW_90_KEYS.has(k))
+    .reduce((a, [, v]) => a + (v?.count || 0), 0);
+  const alertLevel = (episodes || []).filter(e => e.alertLevel).length;
+
+  const lines = [];
+  lines.push(belowNinety > 0
+    ? { tone: 'alert', text: `${belowNinety.toLocaleString()} readings below 90%` }
+    : { tone: 'ok', text: 'No readings below 90%' });
+  if (lowNineties > 0) lines.push({ tone: 'due', text: `${lowNineties.toLocaleString()} readings between 90-93%` });
+  if (alertLevel > 0) {
+    lines.push({ tone: 'alert', text: `${alertLevel} episode${alertLevel === 1 ? '' : 's'} below the ${alarm}% alarm threshold` });
+  }
+  if (analysis.error_spo2_readings > 0) {
+    lines.push({ tone: 'due', text: `${analysis.error_spo2_readings.toLocaleString()} sensor errors` });
+  }
+  lines.push({ tone: 'info', text: `Coverage: ${formatHours(analysis.time_logged_minutes)} of selected day` });
+  return lines;
+}
+
+const BELOW_90_KEYS = new Set([
+  'high_eighties_85_89', 'low_eighties_80_84', 'seventies_70_79', 'sixties_60_69',
+  'fifties_50_59', 'forties_40_49', 'thirties_30_39', 'twenties_20_29', 'below_twenty',
+]);
+
+/** Minutes as "3h 01m" / "47m". */
+export function formatHours(minutes) {
+  const total = Math.max(0, Math.round(minutes || 0));
+  const h = Math.floor(total / 60);
+  const m = total % 60;
+  return h ? `${h}h ${String(m).padStart(2, '0')}m` : `${m}m`;
+}
+
+/* The analyzer returns thirteen SpO2 buckets. That is the right resolution for
+ * the wide view, but at the narrow stop it is thirteen near-empty bars, so the
+ * sub-90 buckets fold into one band. Folding rather than truncating matters:
+ * dropping the tail would hide exactly the readings that matter most.
+ *
+ * Colours follow the project rule — green is good, cyan is the normal band,
+ * amber is attention, red is clinical concern, grey is absent data. */
+export const BANDS = [
+  { key: 'high', label: 'High 90s (97%+)', tone: 'complete', from: ['high_90s_97_plus'] },
+  { key: 'mid', label: 'Mid 90s (94-96%)', tone: 'live', from: ['mid_90s_94_96'] },
+  { key: 'low', label: 'Low 90s (90-93%)', tone: 'due', from: ['low_90s_90_93'] },
+  { key: 'below', label: 'Below 90%', tone: 'alert', from: [...BELOW_90_KEYS] },
+  { key: 'errors', label: 'Sensor errors', tone: 'idle', from: ['zero_errors'] },
+];
+
+/** Fold the thirteen analyzer buckets into the five bands above. */
+export function collapseDistribution(distribution) {
+  const dist = distribution || {};
+  return BANDS.map(band => {
+    const count = band.from.reduce((a, k) => a + (dist[k]?.count || 0), 0);
+    const percentage = band.from.reduce((a, k) => a + (dist[k]?.percentage || 0), 0);
+    return { ...band, count, percentage: Math.round(percentage * 10) / 10 };
+  });
+}

--- a/frontend/src/components/alerts/pulseOxDay.test.js
+++ b/frontend/src/components/alerts/pulseOxDay.test.js
@@ -1,0 +1,247 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  findEpisodes, coverageBuckets, downsample, samplePeriodMs,
+  formatDuration, formatHours, atAGlance, WATCH_SPO2, collapseDistribution,
+} from './pulseOxDay';
+
+const T0 = Date.UTC(2026, 7, 18, 12, 0, 0);
+// Readings two seconds apart, which is the real sampler's cadence.
+const at = (i, spo2, bpm = 90) => ({ timestamp: new Date(T0 + i * 2000).toISOString(), spo2, bpm });
+
+describe('samplePeriodMs', () => {
+  it('takes the median gap, so one long dropout does not skew it', () => {
+    const rs = [at(0, 98), at(1, 98), at(2, 98), { timestamp: new Date(T0 + 600000).toISOString(), spo2: 98 }];
+    expect(samplePeriodMs(rs)).toBe(2000);
+  });
+
+  it('is zero when there is nothing to measure', () => {
+    expect(samplePeriodMs([])).toBe(0);
+    expect(samplePeriodMs([at(0, 98)])).toBe(0);
+  });
+});
+
+describe('findEpisodes', () => {
+  it('finds a run below the watch threshold and reports its nadir', () => {
+    const rs = [at(0, 98), at(1, 93), at(2, 91), at(3, 92), at(4, 97)];
+    const [e] = findEpisodes(rs);
+    expect(e.nadir).toBe(91);
+    expect(e.readings).toBe(3);
+    expect(e.durationMs).toBe(4000);
+  });
+
+  it('reports the heart rate at the nadir, not at the start', () => {
+    const rs = [at(0, 98, 80), at(1, 93, 88), at(2, 90, 121), at(3, 97, 85)];
+    expect(findEpisodes(rs)[0].bpmAtNadir).toBe(121);
+  });
+
+  it('gives a single-sample dip one sample period rather than zero', () => {
+    const rs = [at(0, 98), at(1, 92), at(2, 98)];
+    expect(findEpisodes(rs)[0].durationMs).toBe(2000);
+  });
+
+  it('separates two dips that recover in between', () => {
+    const rs = [at(0, 98), at(1, 92), at(2, 98), at(3, 91), at(4, 99)];
+    expect(findEpisodes(rs)).toHaveLength(2);
+  });
+
+  it('treats a sensor dropout as missing, not as a dip or a recovery', () => {
+    // spo2 0 is how the analyzer's error readings arrive.
+    const rs = [at(0, 98), at(1, 92), at(2, 0), at(3, 91), at(4, 98)];
+    const eps = findEpisodes(rs);
+    expect(eps).toHaveLength(1);
+    expect(eps[0].nadir).toBe(91);
+    expect(eps[0].readings).toBe(2);
+  });
+
+  it('marks alert level only when the configured alarm threshold is breached', () => {
+    const rs = [at(0, 98), at(1, 92), at(2, 98), at(3, 88), at(4, 98)];
+    const eps = findEpisodes(rs, { alarm: 90 });
+    expect(eps.map(e => e.alertLevel)).toEqual([false, true]);
+  });
+
+  it('does not mark alert level when no threshold is known', () => {
+    expect(findEpisodes([at(0, 70), at(1, 98)])[0].alertLevel).toBe(false);
+  });
+
+  it('closes a run that reaches the end of the day', () => {
+    const eps = findEpisodes([at(0, 98), at(1, 91), at(2, 90)]);
+    expect(eps).toHaveLength(1);
+    expect(eps[0].nadir).toBe(90);
+  });
+
+  it('is empty for a clean day', () => {
+    expect(findEpisodes([at(0, 98), at(1, 99), at(2, 100)])).toEqual([]);
+    expect(findEpisodes([])).toEqual([]);
+  });
+
+  it('uses 94 as the watch threshold, the top of the analyzer low-90s band', () => {
+    expect(WATCH_SPO2).toBe(94);
+    expect(findEpisodes([at(0, 94), at(1, 98)])).toHaveLength(0);
+    expect(findEpisodes([at(0, 93), at(1, 98)])).toHaveLength(1);
+  });
+});
+
+describe('coverageBuckets', () => {
+  it('marks only the slots that contain readings', () => {
+    // Readings in the first and last tenth of the window, nothing between.
+    const rs = [at(0, 98), at(1, 98), at(48, 98), at(49, 98)];
+    const { buckets } = coverageBuckets(rs, 10);
+    expect(buckets[0]).toBe(true);
+    expect(buckets[9]).toBe(true);
+    expect(buckets.slice(1, 9).every(b => !b)).toBe(true);
+  });
+
+  it('reports the covered window rather than the whole day', () => {
+    const { startMs, endMs } = coverageBuckets([at(0, 98), at(10, 98)], 8);
+    expect(startMs).toBe(T0);
+    expect(endMs).toBe(T0 + 20000);
+  });
+
+  it('is empty when there is nothing to cover', () => {
+    expect(coverageBuckets([], 10).buckets).toEqual([]);
+    expect(coverageBuckets([at(0, 0), at(1, 0)], 10).buckets).toEqual([]);
+  });
+});
+
+describe('downsample', () => {
+  it('leaves a short series alone', () => {
+    const rs = [at(0, 98), at(1, 97)];
+    expect(downsample(rs, 240)).toHaveLength(2);
+  });
+
+  it('keeps a brief desaturation instead of averaging it away', () => {
+    const rs = Array.from({ length: 400 }, (_, i) => at(i, i === 200 ? 84 : 98));
+    const out = downsample(rs, 40);
+    expect(out.length).toBeLessThanOrEqual(60);
+    expect(Math.min(...out.map(p => p.spo2))).toBe(84);
+  });
+
+  it('emits points in time order', () => {
+    const rs = Array.from({ length: 400 }, (_, i) => at(i, 90 + (i % 10)));
+    const out = downsample(rs, 40);
+    const ts = out.map(p => p.t);
+    expect([...ts].sort((a, b) => a - b)).toEqual(ts);
+  });
+
+  it('drops sensor errors so they cannot plot as a cliff to zero', () => {
+    const out = downsample([at(0, 98), at(1, 0), at(2, 97)], 240);
+    expect(out).toHaveLength(2);
+  });
+});
+
+describe('formatting', () => {
+  it('formats durations under and over a minute', () => {
+    expect(formatDuration(18000)).toBe('18s');
+    expect(formatDuration(124000)).toBe('2m 04s');
+    expect(formatDuration(0)).toBe('0s');
+  });
+
+  it('formats coverage in hours and minutes', () => {
+    expect(formatHours(181)).toBe('3h 01m');
+    expect(formatHours(47)).toBe('47m');
+    expect(formatHours(0)).toBe('0m');
+  });
+});
+
+describe('atAGlance', () => {
+  const analysis = (over = {}) => ({
+    time_logged_minutes: 181,
+    error_spo2_readings: 0,
+    spo2_distribution: {
+      high_90s_97_plus: { count: 4820, percentage: 89.2 },
+      mid_90s_94_96: { count: 569, percentage: 10.5 },
+      low_90s_90_93: { count: 15, percentage: 0.3 },
+      high_eighties_85_89: { count: 0, percentage: 0 },
+      zero_errors: { count: 0, percentage: 0 },
+    },
+    ...over,
+  });
+
+  it('leads with the reassuring line when nothing fell below 90', () => {
+    const lines = atAGlance(analysis(), [], 90);
+    expect(lines[0]).toEqual({ tone: 'ok', text: 'No readings below 90%' });
+    expect(lines[1].text).toBe('15 readings between 90-93%');
+    expect(lines.at(-1).text).toBe('Coverage: 3h 01m of selected day');
+  });
+
+  it('counts every sub-90 bucket, not just the 85-89 one', () => {
+    const a = analysis();
+    a.spo2_distribution.high_eighties_85_89.count = 4;
+    a.spo2_distribution.seventies_70_79 = { count: 2, percentage: 0.1 };
+    const lines = atAGlance(a, [], 90);
+    expect(lines[0]).toEqual({ tone: 'alert', text: '6 readings below 90%' });
+  });
+
+  it('never counts sensor errors as desaturations', () => {
+    const a = analysis({ error_spo2_readings: 12 });
+    a.spo2_distribution.zero_errors = { count: 12, percentage: 0.2 };
+    const lines = atAGlance(a, [], 90);
+    expect(lines[0].text).toBe('No readings below 90%');
+    expect(lines.some(l => l.text === '12 sensor errors')).toBe(true);
+  });
+
+  it('calls out alert-level episodes against the configured threshold', () => {
+    const lines = atAGlance(analysis(), [{ alertLevel: true }, { alertLevel: false }], 90);
+    expect(lines.some(l => l.text === '1 episode below the 90% alarm threshold')).toBe(true);
+  });
+
+  it('omits the low-90s line when there were none', () => {
+    const a = analysis();
+    a.spo2_distribution.low_90s_90_93.count = 0;
+    expect(atAGlance(a, [], 90).some(l => /90-93/.test(l.text))).toBe(false);
+  });
+
+  it('is empty without an analysis', () => {
+    expect(atAGlance(null, [], 90)).toEqual([]);
+  });
+});
+
+describe('collapseDistribution', () => {
+  const dist = {
+    high_90s_97_plus: { count: 4820, percentage: 89.2 },
+    mid_90s_94_96: { count: 569, percentage: 10.5 },
+    low_90s_90_93: { count: 15, percentage: 0.3 },
+    high_eighties_85_89: { count: 3, percentage: 0.1 },
+    seventies_70_79: { count: 2, percentage: 0.1 },
+    zero_errors: { count: 7, percentage: 0.2 },
+  };
+
+  it('folds every sub-90 bucket into one band rather than dropping the tail', () => {
+    const below = collapseDistribution(dist).find(b => b.key === 'below');
+    expect(below.count).toBe(5);
+    expect(below.percentage).toBe(0.2);
+  });
+
+  it('keeps sensor errors out of the clinical bands', () => {
+    const bands = collapseDistribution(dist);
+    expect(bands.find(b => b.key === 'errors').count).toBe(7);
+    expect(bands.find(b => b.key === 'below').count).toBe(5);
+  });
+
+  it('always returns all five bands, so the scale does not move between days', () => {
+    expect(collapseDistribution({}).map(b => b.key)).toEqual(['high', 'mid', 'low', 'below', 'errors']);
+    expect(collapseDistribution(undefined).every(b => b.count === 0)).toBe(true);
+  });
+
+  it('reserves red for the sub-90 band alone', () => {
+    const tones = Object.fromEntries(collapseDistribution(dist).map(b => [b.key, b.tone]));
+    expect(tones).toEqual({ high: 'complete', mid: 'live', low: 'due', below: 'alert', errors: 'idle' });
+  });
+});


### PR DESCRIPTION
The History view was the last section still on its pre-vc rendering: a shadcn card stack with a date `<Select>`, four summary tiles and thirteen distribution bars, sized off `window.innerWidth`. In a 380px dock that's thirteen near-empty bars and nothing about the day itself.

**Narrow** gets the mockup's reading of the day — rollup, SpO₂ and heart-rate traces, sensor-coverage strip, distribution folded to five bands, at-a-glance, low-oxygen episodes.
**Wide** keeps the arrangement it always had — rollup then distribution at the analyzer's own thirteen-bucket resolution — moved onto vc tokens.

## No backend change

Everything new is derived in `pulseOxDay.js` from `GET /api/monitoring/history/raw/{date}`, which already returns the day's readings. The judgement calls, since they're the parts worth disagreeing with:

- **Episodes are contiguous runs below 94%.** Not an invented threshold: the analyzer's own buckets put the mid-90s band at 94–96, so under 94 has already left the normal band *by the backend's taxonomy*. Whether an episode is **alert-level** is a separate question, answered by the patient's configured `min_spo2` (90 here) rather than assumed.
- **A sensor dropout (`spo2 == 0`) is missing data** — it neither starts a dip nor ends one. Reading an error as a desaturation would be the worst failure this panel could have.
- **Downsampling keeps each bucket's extremes, not its mean**, so a brief desaturation can't be smoothed out of the trace.
- **The sub-90 buckets fold rather than truncate.** Nine near-empty bars don't fit the narrow column, but dropping the tail would hide exactly the readings that matter most.

Colour follows the project rule: green good, cyan the normal band, amber attention, **red for the sub-90 readings alone**, grey for absent data.

## Incidental

- Wide doesn't fetch the raw readings it won't draw.
- The date Select is controlled from the first render — this also clears an uncontrolled→controlled warning the previous version emitted.
- Uses the Radix Select already in the repo rather than adding `@radix-ui/react-popover` as a dependency.

## Verification

- Live at 390px and 1920px against patient 2: 9 episodes, none alert-level, `scrollWidth == clientWidth` at both stops; wide renders 13 bands and no traces, narrow renders 5 bands + 2 charts + 90 coverage slots.
- **40 new tests** — 31 on the arithmetic (dropouts, single-sample duration, nadir HR, alert-level threshold, band folding, formatting) and 9 on the component at both dock values.
- `npm run lint` (0), `npx vite build`, `npm test` — 507 passing.

## Not in this pass

The mockup's 7-day/30-day tabs and Export Summary have no backing — `analyze` is per-date only, so those need real aggregation rather than a layout change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011u7gjNWppXao35QPLtBBQe