### PR TITLE
Messages rebuilt in the vc aesthetic, and unhidden from the nav

### DIFF
--- a/backend/crud/user_messages.py
+++ b/backend/crud/user_messages.py
@@ -384,6 +384,10 @@ def sync_low_medication_messages(db: Session) -> None:
                 account_id=med.account_id,
                 data={
                     "medication_id": med.id,
+                    # The reader-facing surfaces name the medication in their
+                    # follow-up link ("Review Ojemda"); the title is prose, so
+                    # the name is carried as data rather than parsed back out.
+                    "medication_name": med.name,
                     "quantity": med.quantity,
                     "quantity_unit": med.quantity_unit,
                     "low_stock_threshold": threshold,

--- a/backend/tests/test_messages.py
+++ b/backend/tests/test_messages.py
@@ -150,5 +150,23 @@ def test_low_medication_message_generated_and_not_dismissible(admin_client, pati
                              json={"minutes": 30}).status_code == 200
 
 
+def test_low_medication_message_carries_medication_identity(admin_client, patient):
+    """The message names the medication in `data`, not only inside the title
+    prose — the readers link to it ("Review Lasix") and must not parse the
+    title back apart to do so."""
+    admin_client.post("/api/add/medication", json={
+        "name": "Lasix", "concentration": "40mg", "quantity": 0,
+        "quantity_unit": "tablets", "instructions": "daily",
+        "start_date": "2026-06-01", "is_patient_specific": True,
+        "admin_patient_id": patient.id,
+    })
+
+    items = admin_client.get("/api/messages/active").json()["items"]
+    msg = next(m for m in items if m["type"] == "low_medication")
+    assert msg["data"]["medication_name"] == "Lasix"
+    assert msg["data"]["medication_id"]
+    assert msg["patient_id"] == patient.id
+
+
 def test_requires_auth(client):
     assert client.get("/api/messages/active").status_code == 401

--- a/frontend/src/components/MessagesModal.jsx
+++ b/frontend/src/components/MessagesModal.jsx
@@ -15,178 +15,64 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect, useCallback } from 'react';
-import config, { apiFetch } from '../config';
-import { CheckIcon } from './Icons';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Alert } from '@/components/ui/alert';
+// Messages as a docked panel: the same board the admin page renders, scoped to
+// what this user has to deal with.
+//
+// Two callers: the Messages nav action, and MessagesAutoPop after login (which
+// hands over the list it already fetched so the generators don't run twice).
+// Outside the dashboard's dock provider ModalBase falls back to a plain slab,
+// which is what the auto-pop wants over an admin page.
+import { useNavigate } from 'react-router-dom';
+import ModalBase from './ModalBase';
+import MessagesBoard from './messages/MessagesBoard';
+import useMessages from './messages/useMessages';
+import { useModalDock } from '../contexts/ModalDockContext';
+import './section-panel/section-panel.css';
 
-const SEVERITY = {
-  critical: { color: '#e53e3e', label: 'Critical' },
-  warning: { color: '#dd6b20', label: 'Warning' },
-  info: { color: '#4299e1', label: 'Info' },
-};
-
-const SNOOZE_OPTIONS = [
-  { label: '1 hour', minutes: 60 },
-  { label: '4 hours', minutes: 240 },
-  { label: '1 day', minutes: 1440 },
-];
-
-/**
- * Pop-up listing the active attention messages (low medication stock,
- * broadcasts, …) with the dismiss/snooze actions each message allows. Used
- * both for the automatic pop-up after login (MessagesAutoPop) and the
- * Messages menu icon.
- */
 const MessagesModal = ({ onClose, initialMessages = null }) => {
-  const [messages, setMessages] = useState(initialMessages || []);
-  const [loading, setLoading] = useState(!initialMessages);
-  const [error, setError] = useState(null);
-  const [busyId, setBusyId] = useState(null);
+  const navigate = useNavigate();
+  const { docked, expanded } = useModalDock();
+  const {
+    status, setStatus, items, total, loading, error, busyId, dismiss, snooze,
+  } = useMessages({ scope: 'mine', initialItems: initialMessages });
 
-  const fetchMessages = useCallback(async () => {
-    try {
-      setError(null);
-      const res = await apiFetch(`${config.apiUrl}/api/messages/active`);
-      if (!res.ok) throw new Error(`Error fetching messages: ${res.statusText}`);
-      const data = await res.json();
-      setMessages(data.items || []);
-    } catch (err) {
-      console.error('Error fetching messages:', err);
-      setError('Failed to load messages. Please try again.');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  // Narrow is the dock's first stop, not a viewport width.
+  const dense = docked && !expanded;
 
-  useEffect(() => {
-    // When the opener already fetched the list (login auto-pop), reuse it
-    // instead of immediately re-running the generators on the backend.
-    if (!initialMessages) fetchMessages();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchMessages]);
+  // Dismiss and snooze are only meaningful on an open message; the other two
+  // tabs are archive, so the cards there carry no actions.
+  const open = status === 'active';
 
-  const act = async (messageId, path, body) => {
-    try {
-      setBusyId(messageId);
-      setError(null);
-      const res = await apiFetch(`${config.apiUrl}/api/messages/${messageId}/${path}`, {
-        method: 'POST',
-        headers: body ? { 'Content-Type': 'application/json' } : undefined,
-        body: body ? JSON.stringify(body) : undefined,
-      });
-      if (!res.ok) {
-        const detail = await res.json().catch(() => ({}));
-        throw new Error(detail.detail || res.statusText);
-      }
-      await fetchMessages();
-    } catch (err) {
-      console.error(`Error on message ${path}:`, err);
-      setError(err.message || 'Action failed. Please try again.');
-    } finally {
-      setBusyId(null);
-    }
+  const handleReview = (message, link) => {
+    onClose();
+    navigate(link.to);
   };
 
   return (
-    <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-w-xl">
-        <DialogHeader>
-          <DialogTitle>Messages</DialogTitle>
-          <DialogDescription className="sr-only">
-            Active messages that need your attention
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="flex flex-col gap-3">
-          {error && <Alert variant="destructive">{error}</Alert>}
-
-          {loading ? (
-            <div className="py-10 text-center text-muted-foreground">Loading messages…</div>
-          ) : messages.length === 0 ? (
-            <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border py-10 text-muted-foreground">
-              <CheckIcon size={28} />
-              All caught up — nothing needs your attention.
-            </div>
-          ) : (
-            messages.map(message => {
-              const sev = SEVERITY[message.severity] || SEVERITY.info;
-              const busy = busyId === message.id;
-              return (
-                <div
-                  key={message.id}
-                  className="flex flex-col gap-2.5 rounded-lg border border-border border-l-4 bg-card p-4 shadow-sm"
-                  style={{ borderLeftColor: sev.color }}
-                >
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <span
-                      className="text-xs font-bold uppercase tracking-wider"
-                      style={{ color: sev.color }}
-                    >
-                      {sev.label}
-                    </span>
-                    {message.created_at && (
-                      <span className="text-xs text-muted-foreground">
-                        {new Date(message.created_at).toLocaleString()}
-                      </span>
-                    )}
-                  </div>
-
-                  <div className="text-base font-semibold text-foreground">
-                    {message.title}
-                    {message.data?.patient_name && (
-                      <span className="ml-2 text-sm font-normal text-muted-foreground">
-                        · {message.data.patient_name}
-                      </span>
-                    )}
-                  </div>
-                  {message.body && (
-                    <div className="whitespace-pre-wrap text-sm text-muted-foreground">{message.body}</div>
-                  )}
-                  {message.ack_scope === 'per_user' && (
-                    <div className="text-xs italic text-muted-foreground">
-                      Each person must acknowledge this message individually.
-                    </div>
-                  )}
-
-                  <div className="flex flex-wrap items-center gap-2">
-                    {message.dismissible && (
-                      <Button onClick={() => act(message.id, 'dismiss')} disabled={busy}>
-                        <CheckIcon size={14} />
-                        {message.ack_scope === 'per_user' ? 'Acknowledge' : 'Dismiss'}
-                      </Button>
-                    )}
-                    {message.snoozable && (
-                      <span className="inline-flex items-center gap-1.5">
-                        <span className="text-sm text-muted-foreground">Snooze:</span>
-                        {SNOOZE_OPTIONS.map(opt => (
-                          <Button
-                            key={opt.minutes}
-                            variant="secondary"
-                            size="sm"
-                            onClick={() => act(message.id, 'snooze', { minutes: opt.minutes })}
-                            disabled={busy}
-                          >
-                            {opt.label}
-                          </Button>
-                        ))}
-                      </span>
-                    )}
-                    {!message.dismissible && (
-                      <span className="text-xs text-muted-foreground">
-                        Clears automatically when the underlying condition is resolved.
-                      </span>
-                    )}
-                  </div>
-                </div>
-              );
-            })
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
+    <ModalBase isOpen={true} onClose={onClose} title={
+      <span className="mp-modal-title">
+        <span>Messages</span>
+        <span className="mp-modal-title-sub">
+          {status === 'active'
+            ? (total > 0 ? `${total} needing attention` : 'All caught up')
+            : `${status.charAt(0).toUpperCase()}${status.slice(1)}`}
+        </span>
+      </span>
+    }>
+      <MessagesBoard
+        items={items}
+        loading={loading}
+        error={error}
+        status={status}
+        onStatusChange={setStatus}
+        statusCount={status === 'active' ? total : null}
+        dense={dense}
+        busyId={busyId}
+        onDismiss={open ? dismiss : undefined}
+        onSnooze={open ? snooze : undefined}
+        onReview={handleReview}
+      />
+    </ModalBase>
   );
 };
 

--- a/frontend/src/components/dashboard/topBarActions.jsx
+++ b/frontend/src/components/dashboard/topBarActions.jsx
@@ -52,9 +52,14 @@ export function buildTopBarActions({
     // heads its own Record group there.
     { key: 'capture', group: 'record', label: 'Capture Vitals', icon: <VitalsCaptureIcon />, onClick: handlers.capture, active: modalOpen.capture, badge: 0 },
     { key: 'history', group: 'monitoring', label: 'History', icon: <HistoryIcon />, onClick: handlers.history, active: modalOpen.history, badge: 0 },
-    hasCamera
-      ? { key: 'camera', group: 'monitoring', label: 'Live Camera', icon: <CameraIcon />, onClick: handlers.camera, active: modalOpen.camera, badge: 0 }
-      : { key: 'messages', group: 'monitoring', label: 'Messages', icon: <MessagesIcon />, onClick: handlers.messages, active: modalOpen.messages, badge: 0 },
+    { key: 'messages', group: 'monitoring', label: 'Messages', icon: <MessagesIcon />, onClick: handlers.messages, active: modalOpen.messages, badge: 0 },
+    // Camera is the only conditional action: it appears when a Frigate camera
+    // is configured for this patient and is simply absent otherwise. It used to
+    // *replace* Messages, which meant configuring a camera hid the messages
+    // list — a whole section unreachable from the board with nothing to say so.
+    ...(hasCamera
+      ? [{ key: 'camera', group: 'monitoring', label: 'Live Camera', icon: <CameraIcon />, onClick: handlers.camera, active: modalOpen.camera, badge: 0 }]
+      : []),
   ];
 }
 

--- a/frontend/src/components/dashboard/topBarActions.test.jsx
+++ b/frontend/src/components/dashboard/topBarActions.test.jsx
@@ -1,0 +1,68 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The single source for the top bar and the nav drawer. The case worth
+// pinning is the camera: it is the one conditional action, and it used to take
+// the Messages slot rather than add one — so configuring a camera silently
+// removed the messages list from the board.
+import { describe, it, expect, vi } from 'vitest';
+import { buildTopBarActions, NAV_GROUPS } from './topBarActions';
+
+const build = (over = {}) => buildTopBarActions({
+  pulseOxAlerts: 0, medicationDueCount: 0, nutritionDueCount: 0,
+  careTaskDueCount: 0, equipmentDueCount: 0,
+  hasCamera: false,
+  modalOpen: {},
+  handlers: {
+    alerts: vi.fn(), medications: vi.fn(), nutrition: vi.fn(), careTasks: vi.fn(),
+    equipment: vi.fn(), history: vi.fn(), camera: vi.fn(), messages: vi.fn(),
+    capture: vi.fn(),
+  },
+  ...over,
+});
+
+describe('buildTopBarActions', () => {
+  it('keeps Messages whether or not a camera is configured', () => {
+    expect(build().map(a => a.key)).toContain('messages');
+    expect(build({ hasCamera: true }).map(a => a.key)).toContain('messages');
+  });
+
+  it('shows the camera only when one is configured', () => {
+    expect(build().map(a => a.key)).not.toContain('camera');
+    expect(build({ hasCamera: true }).map(a => a.key)).toContain('camera');
+  });
+
+  it('adds the camera rather than replacing anything', () => {
+    expect(build({ hasCamera: true })).toHaveLength(build().length + 1);
+  });
+
+  it('puts Capture Vitals immediately before History', () => {
+    const keys = build().map(a => a.key);
+    expect(keys.indexOf('history')).toBe(keys.indexOf('capture') + 1);
+  });
+
+  it('files every action under a real nav group, so none is drawer-only', () => {
+    const groups = NAV_GROUPS.map(g => g.key);
+    build({ hasCamera: true }).forEach(a => expect(groups).toContain(a.group));
+  });
+
+  it('passes the due counts through as badges', () => {
+    const actions = build({ medicationDueCount: 3, pulseOxAlerts: 7 });
+    expect(actions.find(a => a.key === 'medications').badge).toBe(3);
+    expect(actions.find(a => a.key === 'alerts').badge).toBe(7);
+  });
+});

--- a/frontend/src/components/messages/ComposeMessageSheet.jsx
+++ b/frontend/src/components/messages/ComposeMessageSheet.jsx
@@ -1,0 +1,201 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Composing a broadcast, on the same bottom sheet the capture surface uses —
+// the established shape for "fill this in on a phone".
+//
+// Every control maps to a real field on the message: there is deliberately no
+// audience picker, because the API has no audience. A message goes to everyone
+// on the account, and who *clearing* it acts for is the ack_scope row below.
+import { useState } from 'react';
+import BottomSheet from '../../pages/capture/components/BottomSheet';
+import { CheckIcon, InfoIcon } from '../Icons';
+import './messages-panel.css';
+
+const TITLE_MAX = 255;   // matches MessageCreate on the backend
+
+// The mockup's NORMAL / IMPORTANT, plus the urgent stop the API already
+// supports — dropping it would quietly remove a level someone could set before.
+const PRIORITIES = [
+  { value: 'info', label: 'Normal' },
+  { value: 'warning', label: 'Important' },
+  { value: 'critical', label: 'Urgent' },
+];
+
+const SCOPES = [
+  { value: 'anyone', label: 'Clear for everyone', hint: 'One person handling it resolves it for the group' },
+  { value: 'per_user', label: 'Each person clears their own', hint: 'Everyone has to acknowledge it themselves' },
+];
+
+const EMPTY = {
+  title: '', body: '', severity: 'info', ack_scope: 'anyone',
+  dismissible: true, snoozable: true,
+};
+
+function Toggle({ checked, onChange, label, hint, disabled }) {
+  return (
+    <div className={`mx-toggle-row${disabled ? ' disabled' : ''}`}>
+      <span className="mx-toggle-text">
+        <span className="mx-toggle-label">{label}</span>
+        <span className="mx-toggle-hint">{hint}</span>
+      </span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+        className={`mx-switch${checked ? ' on' : ''}`}
+        onClick={() => onChange(!checked)}
+        disabled={disabled}
+      >
+        <span className="mx-switch-knob" />
+      </button>
+    </div>
+  );
+}
+
+export default function ComposeMessageSheet({ open, onClose, onSubmit, saving = false, error = null }) {
+  const [form, setForm] = useState(EMPTY);
+  const set = (patch) => setForm(prev => ({ ...prev, ...patch }));
+  const titleLeft = TITLE_MAX - form.title.length;
+
+  const submit = (e) => {
+    e.preventDefault();
+    if (!form.title.trim() || saving) return;
+    onSubmit({ ...form, title: form.title.trim(), body: form.body.trim() || null });
+  };
+
+  const close = () => { setForm(EMPTY); onClose(); };
+
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={(next) => { if (!next) close(); }}
+      onSwipeDown={close}
+      title="Compose message"
+    >
+      <form className="mx-compose" onSubmit={submit}>
+        <p className="mx-compose-sub">Share an update with everyone on the care team.</p>
+
+        {error && <div className="mx-error">{error}</div>}
+
+        <label className="mx-field">
+          <span className="mx-field-label">
+            Title <span className="mx-req">Required</span>
+          </span>
+          <input
+            className="mx-input"
+            value={form.title}
+            onChange={e => set({ title: e.target.value.slice(0, TITLE_MAX) })}
+            maxLength={TITLE_MAX}
+            placeholder="What should everyone know?"
+            autoFocus
+          />
+          {/* Counted down from the column's real limit rather than an invented
+              one, and only once it is close enough to matter. */}
+          {titleLeft <= 40 && <span className="mx-count">{titleLeft} left</span>}
+        </label>
+
+        <label className="mx-field">
+          <span className="mx-field-label">
+            Message <span className="mx-opt">Optional</span>
+          </span>
+          <textarea
+            className="mx-input mx-textarea"
+            value={form.body}
+            onChange={e => set({ body: e.target.value })}
+            rows={4}
+            placeholder="Add helpful details or next steps…"
+          />
+        </label>
+
+        <div className="mx-field">
+          <span className="mx-field-label">Priority</span>
+          <div className="mx-seg" role="radiogroup" aria-label="Priority">
+            {PRIORITIES.map(p => (
+              <button
+                key={p.value}
+                type="button"
+                role="radio"
+                aria-checked={form.severity === p.value}
+                className={`mx-seg-btn ${p.value}${form.severity === p.value ? ' on' : ''}`}
+                onClick={() => set({ severity: p.value })}
+              >
+                {form.severity === p.value && <CheckIcon size={13} />}
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="mx-card-block">
+          <span className="mx-block-head">Follow-up</span>
+          <Toggle
+            label="Allow clearing"
+            hint="Anyone can mark this handled"
+            checked={form.dismissible}
+            onChange={v => set({ dismissible: v })}
+          />
+          <Toggle
+            label="Allow snoozing"
+            hint="It can be hidden until later"
+            checked={form.snoozable}
+            onChange={v => set({ snoozable: v })}
+          />
+        </div>
+
+        {/* Only asked when it can happen: with clearing off, the message stays
+            up until it is deleted, so who clears it has no answer. */}
+        {form.dismissible && (
+          <div className="mx-field">
+            <span className="mx-field-label">When someone clears it</span>
+            <div className="mx-choices" role="radiogroup" aria-label="When someone clears it">
+              {SCOPES.map(s => (
+                <button
+                  key={s.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={form.ack_scope === s.value}
+                  className={`mx-choice${form.ack_scope === s.value ? ' on' : ''}`}
+                  onClick={() => set({ ack_scope: s.value })}
+                >
+                  <span className="mx-choice-text">
+                    <span className="mx-choice-label">{s.label}</span>
+                    <span className="mx-choice-hint">{s.hint}</span>
+                  </span>
+                  {form.ack_scope === s.value && <CheckIcon size={16} />}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <p className="mx-compose-note">
+          <InfoIcon size={14} />
+          This appears as a <strong>manual message</strong>, filed under Other.
+        </p>
+
+        <div className="vc-sheet-actions mx-compose-actions">
+          <button type="button" className="vc-btn secondary" onClick={close}>Cancel</button>
+          <button type="submit" className="vc-btn primary" disabled={!form.title.trim() || saving}>
+            {saving ? 'Posting…' : 'Post message'}
+          </button>
+        </div>
+      </form>
+    </BottomSheet>
+  );
+}

--- a/frontend/src/components/messages/ComposeMessageSheet.test.jsx
+++ b/frontend/src/components/messages/ComposeMessageSheet.test.jsx
@@ -1,0 +1,126 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Composing a broadcast. Every control has to map onto a real field of the
+// create API — the point of this form is that what you set is what gets stored.
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ComposeMessageSheet from './ComposeMessageSheet';
+
+const setup = (props = {}) => {
+  const onSubmit = vi.fn();
+  const onClose = vi.fn();
+  const utils = render(
+    <ComposeMessageSheet open onClose={onClose} onSubmit={onSubmit} {...props} />
+  );
+  return { ...utils, onSubmit, onClose };
+};
+
+const type = (placeholder, value) =>
+  fireEvent.change(screen.getByPlaceholderText(placeholder), { target: { value } });
+
+describe('ComposeMessageSheet', () => {
+  it('will not post without a title', () => {
+    setup();
+    expect(screen.getByText('Post message').closest('button')).toBeDisabled();
+    type('What should everyone know?', 'Fridge is fixed');
+    expect(screen.getByText('Post message').closest('button')).not.toBeDisabled();
+  });
+
+  it('treats a whitespace-only title as no title', () => {
+    setup();
+    type('What should everyone know?', '   ');
+    expect(screen.getByText('Post message').closest('button')).toBeDisabled();
+  });
+
+  it('posts the defaults a manual broadcast should have', () => {
+    const { onSubmit } = setup();
+    type('What should everyone know?', '  Fridge is fixed  ');
+    fireEvent.click(screen.getByText('Post message'));
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: 'Fridge is fixed',       // trimmed
+      body: null,                     // empty optional body, not ''
+      severity: 'info',
+      ack_scope: 'anyone',
+      dismissible: true,
+      snoozable: true,
+    });
+  });
+
+  it('maps the priority row onto the severity the card will show', () => {
+    const { onSubmit } = setup();
+    type('What should everyone know?', 'Oxygen delivery moved');
+    fireEvent.click(screen.getByText('Important'));
+    fireEvent.click(screen.getByText('Post message'));
+    expect(onSubmit.mock.calls[0][0].severity).toBe('warning');
+  });
+
+  it('keeps the urgent level the API already supports', () => {
+    const { onSubmit } = setup();
+    type('What should everyone know?', 'Call the nurse line');
+    fireEvent.click(screen.getByText('Urgent'));
+    fireEvent.click(screen.getByText('Post message'));
+    expect(onSubmit.mock.calls[0][0].severity).toBe('critical');
+  });
+
+  it('carries the follow-up toggles through', () => {
+    const { onSubmit } = setup();
+    type('What should everyone know?', 'Standing note');
+    fireEvent.click(screen.getByRole('switch', { name: 'Allow snoozing' }));
+    fireEvent.click(screen.getByText('Post message'));
+    expect(onSubmit.mock.calls[0][0].snoozable).toBe(false);
+  });
+
+  it('stops asking who clears it once nothing can clear it', () => {
+    setup();
+    expect(screen.getByText('Clear for everyone')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('switch', { name: 'Allow clearing' }));
+    expect(screen.queryByText('Clear for everyone')).not.toBeInTheDocument();
+  });
+
+  it('records that each person must acknowledge', () => {
+    const { onSubmit } = setup();
+    type('What should everyone know?', 'Read the care plan update');
+    fireEvent.click(screen.getByText('Each person clears their own'));
+    fireEvent.click(screen.getByText('Post message'));
+    expect(onSubmit.mock.calls[0][0].ack_scope).toBe('per_user');
+  });
+
+  it('counts down only as the real 255-character limit approaches', () => {
+    setup();
+    type('What should everyone know?', 'x'.repeat(200));
+    expect(screen.queryByText(/left$/)).toBeNull();
+    type('What should everyone know?', 'x'.repeat(230));
+    expect(screen.getByText('25 left')).toBeInTheDocument();
+  });
+
+  it('clears the form on cancel so the next compose starts empty', () => {
+    const { onClose } = setup();
+    type('What should everyone know?', 'Draft');
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalled();
+    expect(screen.getByPlaceholderText('What should everyone know?')).toHaveValue('');
+  });
+
+  it('does not post twice while the first post is in flight', () => {
+    const { onSubmit } = setup({ saving: true });
+    type('What should everyone know?', 'Fridge is fixed');
+    expect(screen.getByText('Posting…').closest('button')).toBeDisabled();
+    fireEvent.click(screen.getByText('Posting…'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/messages/ConfirmSheet.jsx
+++ b/frontend/src/components/messages/ConfirmSheet.jsx
@@ -1,0 +1,44 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Destructive confirm on the same bottom sheet as the compose form, so the two
+// steps of "post a message / remove one" look like one surface.
+import BottomSheet from '../../pages/capture/components/BottomSheet';
+import './messages-panel.css';
+
+export default function ConfirmSheet({
+  open, title, children, confirmLabel, onConfirm, onClose, busy = false,
+}) {
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={(next) => { if (!next) onClose(); }}
+      onSwipeDown={onClose}
+      title={title}
+    >
+      <div className="mx-confirm">
+        {children}
+        <div className="vc-sheet-actions">
+          <button type="button" className="vc-btn secondary" onClick={onClose}>Cancel</button>
+          <button type="button" className="vc-btn mx-danger" onClick={onConfirm} disabled={busy}>
+            {busy ? 'Working…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/frontend/src/components/messages/MessageCard.jsx
+++ b/frontend/src/components/messages/MessageCard.jsx
@@ -1,0 +1,184 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// One message. Severity is carried by the badge and the icon rather than by a
+// bar down the side of the card — the side bar reads as filler, and the badge
+// is where someone actually looks for the level.
+import { useState } from 'react';
+import {
+  MedicationIcon, MessagesIcon, BellAlertIcon, MoreHorizontalIcon,
+  CheckIcon, ClockIcon, TrashIcon, ChevronRightIcon,
+} from '../Icons';
+import {
+  severityOf, categoryOf, formatWhen, scopeLabel, snoozeNote,
+  reviewLink, primaryAction, SNOOZE_OPTIONS,
+} from './messageMeta';
+
+const ICONS = { medication: MedicationIcon, message: MessagesIcon, system: BellAlertIcon };
+
+export default function MessageCard({
+  message,
+  busy = false,
+  dense = false,
+  onDismiss,
+  onSnooze,
+  onDelete,
+  onReview,
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const severity = severityOf(message);
+  const category = categoryOf(message);
+  const Icon = ICONS[category.icon] || BellAlertIcon;
+  const review = reviewLink(message);
+  const primary = primaryAction(message);
+  const snoozed = snoozeNote(message);
+  const canSnooze = message.snoozable && onSnooze;
+  const showReview = !!review && !!onReview;
+  const showDismiss = !!primary && !!onDismiss;
+  // The explanation belongs where someone would otherwise hunt for a Dismiss
+  // button — not on an archived card, where nothing is offered anyway.
+  const showNote = !primary && !!onDismiss;
+  const hasMenu = canSnooze || !!onDelete;
+  // An archived card takes no actions but delete. Rather than draw a whole
+  // action row to hold one overflow button, the button moves up beside the
+  // category label and the row is not rendered at all.
+  const hasActionRow = showDismiss || showReview || showNote;
+
+  return (
+    <article className={`mx-card ${severity.key}${busy ? ' busy' : ''}`}>
+      <div className="mx-card-top">
+        <span className={`mx-badge ${severity.key}`}>{severity.label}</span>
+        <span className="mx-cat">{category.label}</span>
+        {hasMenu && !hasActionRow && (
+          <button
+            type="button"
+            className={`mx-more${menuOpen ? ' open' : ''}`}
+            onClick={() => setMenuOpen(v => !v)}
+            aria-expanded={menuOpen}
+            aria-label={`More actions for ${message.title}`}
+          >
+            <MoreHorizontalIcon size={16} />
+          </button>
+        )}
+      </div>
+
+      <div className="mx-card-main">
+        <span className={`mx-icon ${severity.key}`} aria-hidden="true">
+          <Icon size={dense ? 22 : 26} />
+        </span>
+        <div className="mx-card-text">
+          <h3 className="mx-title">{message.title}</h3>
+          {message.body && <p className="mx-body">{message.body}</p>}
+          <div className="mx-meta">
+            <span>{formatWhen(message.created_at)}</span>
+            <span className="mx-dot" aria-hidden="true">·</span>
+            <span>{scopeLabel(message)}</span>
+            {message.data?.patient_name && (
+              <>
+                <span className="mx-dot" aria-hidden="true">·</span>
+                <span>{message.data.patient_name}</span>
+              </>
+            )}
+          </div>
+          {snoozed && <div className="mx-snoozed">{snoozed}</div>}
+        </div>
+      </div>
+
+      {hasActionRow && (
+      <div className="mx-card-actions">
+        <div className="mx-card-actions-main">
+          {showDismiss && (
+            <button
+              type="button"
+              className="mx-btn primary"
+              onClick={() => onDismiss(message)}
+              disabled={busy}
+            >
+              <CheckIcon size={13} />
+              {primary.label}
+            </button>
+          )}
+          {showReview && (
+            <button type="button" className="mx-link" onClick={() => onReview(message, review)}>
+              {review.label}
+              <ChevronRightIcon size={14} />
+            </button>
+          )}
+          {/* A missing Dismiss has to be explained rather than just absent:
+              the message is waiting on the condition behind it, not on the
+              reader. Shown even beside a Review link, which is where someone
+              would otherwise look for the button that isn't there. */}
+          {showNote && (
+            <span className="mx-note">Clears when the underlying condition is resolved</span>
+          )}
+        </div>
+        {hasMenu && (
+          <button
+            type="button"
+            className={`mx-more${menuOpen ? ' open' : ''}`}
+            onClick={() => setMenuOpen(v => !v)}
+            aria-expanded={menuOpen}
+            aria-label={`More actions for ${message.title}`}
+          >
+            <MoreHorizontalIcon size={16} />
+          </button>
+        )}
+      </div>
+      )}
+
+      {/* Opens in place rather than as a floating menu: the card lives inside a
+          scrolling docked panel, where an anchored popover drifts off its row. */}
+      {hasMenu && menuOpen && (
+        <div className="mx-menu">
+          {canSnooze && (
+            <div className="mx-menu-row">
+              <span className="mx-menu-label"><ClockIcon size={13} /> Snooze</span>
+              <div className="mx-menu-opts">
+                {SNOOZE_OPTIONS.map(opt => (
+                  <button
+                    key={opt.minutes}
+                    type="button"
+                    className="mx-btn ghost sm"
+                    onClick={() => { setMenuOpen(false); onSnooze(message, opt.minutes); }}
+                    disabled={busy}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          {onDelete && (
+            <div className="mx-menu-row">
+              <span className="mx-menu-label"><TrashIcon size={13} /> Remove</span>
+              <div className="mx-menu-opts">
+                <button
+                  type="button"
+                  className="mx-btn danger sm"
+                  onClick={() => { setMenuOpen(false); onDelete(message); }}
+                  disabled={busy}
+                >
+                  Delete permanently
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/components/messages/MessagesBoard.jsx
+++ b/frontend/src/components/messages/MessagesBoard.jsx
@@ -1,0 +1,147 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The messages list, shared by the admin page and the dashboard panel so both
+// read the same. The hosts own fetching and the create/delete dialogs; this
+// owns the status tabs, the source filter and the grouped cards.
+//
+// `dense` is the narrow dock stop, not "mobile" — a 380px panel on a 1920px
+// screen is narrow, and window.innerWidth would call it desktop.
+import { useMemo, useState } from 'react';
+import MessageCard from './MessageCard';
+import { groupMessages, sourceOptions, filterBySource, STATUS_TABS } from './messageMeta';
+import { ChevronDownIcon } from '../Icons';
+import './messages-panel.css';
+
+export default function MessagesBoard({
+  items,
+  loading = false,
+  error = null,
+  status = 'active',
+  onStatusChange,
+  statusCount = null,
+  dense = false,
+  headerActions = null,
+  footer = null,
+  busyId = null,
+  onDismiss,
+  onSnooze,
+  onDelete,
+  onReview,
+}) {
+  const [source, setSource] = useState('all');
+  const list = useMemo(() => (Array.isArray(items) ? items : []), [items]);
+  const sources = useMemo(() => sourceOptions(list), [list]);
+  // A filter that no longer matches anything would silently strip the list, so
+  // an option that disappeared falls back to showing everything.
+  const activeSource = sources.some(s => s.value === source) ? source : 'all';
+  const groups = useMemo(
+    () => groupMessages(filterBySource(list, activeSource)),
+    [list, activeSource]
+  );
+
+  return (
+    <div className={`mx-board${dense ? ' dense' : ''}`}>
+      <div className="mx-toolbar">
+        {onStatusChange && (
+          <div className="mx-tabs" role="tablist" aria-label="Message status">
+            {STATUS_TABS.map(tab => (
+              <button
+                key={tab.value}
+                type="button"
+                role="tab"
+                aria-selected={status === tab.value}
+                className={`mx-tab${status === tab.value ? ' active' : ''}`}
+                onClick={() => onStatusChange(tab.value)}
+              >
+                {tab.label}
+                {/* Count only where there is one: a "0" chip on the tab you
+                    are already looking at is noise next to its empty state. */}
+                {status === tab.value && statusCount > 0 && (
+                  <span className="mx-tab-count">{statusCount}</span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="mx-toolbar-row">
+          {/* Only worth showing when there is more than one kind of message in
+              hand — a filter with a single option is a control that can't do
+              anything. Native select rather than a portalled menu: the popup is
+              drawn by the OS, so it can't inherit the wrong theme's tokens the
+              way a body-portalled menu over the dark board would. */}
+          {sources.length > 2 && (
+          <label className="mx-source">
+            <span className="mx-sr">Filter by source</span>
+            <select
+              value={activeSource}
+              onChange={e => setSource(e.target.value)}
+            >
+              {sources.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+            <ChevronDownIcon size={14} />
+          </label>
+          )}
+          {headerActions}
+        </div>
+      </div>
+
+      {error && <div className="mx-error">{error}</div>}
+
+      {loading ? (
+        <div className="mx-empty">Loading messages…</div>
+      ) : !groups.length ? (
+        <div className="mx-empty">
+          {/* Only the status can be empty: the source options are derived from
+              the messages in hand, so a source that is showing nothing has
+              already fallen back to "all" above. */}
+          {status === 'active'
+            ? 'All caught up — nothing needs your attention.'
+            : `No ${status} messages.`}
+        </div>
+      ) : (
+        groups.map(group => (
+          <section key={group.key} className="mx-group">
+            <h4 className="mx-group-head">
+              {group.label}
+              <span className="mx-group-count">{group.items.length}</span>
+            </h4>
+            <div className="mx-cards">
+              {group.items.map(message => (
+                <MessageCard
+                  key={message.id}
+                  message={message}
+                  dense={dense}
+                  busy={busyId === message.id}
+                  onDismiss={onDismiss}
+                  onSnooze={onSnooze}
+                  onDelete={onDelete}
+                  onReview={onReview}
+                />
+              ))}
+            </div>
+          </section>
+        ))
+      )}
+
+      {footer}
+    </div>
+  );
+}

--- a/frontend/src/components/messages/MessagesBoard.test.jsx
+++ b/frontend/src/components/messages/MessagesBoard.test.jsx
@@ -1,0 +1,161 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The shared board. Worth pinning: no coloured bar down the side of a card
+// (the reason this was rebuilt), that severity is still legible without one,
+// that the source filter narrows rather than hides, and that a message which
+// cannot be dismissed explains itself instead of showing a dead button.
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MessagesBoard from './MessagesBoard';
+
+const lowMed = (over = {}) => ({
+  id: 1, type: 'low_medication', severity: 'warning',
+  title: 'Ojemda is running low', body: '2 units remain.',
+  dismissible: true, snoozable: true, ack_scope: 'anyone', patient_id: 2,
+  created_at: '2026-06-26T02:22:00Z',
+  data: { medication_id: 9, medication_name: 'Ojemda' }, ...over,
+});
+const manual = (over = {}) => ({
+  id: 2, type: 'general', severity: 'info', title: 'Test', body: 'Testing',
+  dismissible: true, snoozable: true, ack_scope: 'anyone',
+  created_at: '2026-06-26T03:26:00Z', ...over,
+});
+
+const setup = (props = {}) =>
+  render(<MessagesBoard items={[lowMed(), manual()]} {...props} />);
+
+describe('MessagesBoard', () => {
+  it('groups system messages ahead of manual ones', () => {
+    const { container } = setup();
+    const heads = [...container.querySelectorAll('.mx-group-head')].map(n => n.textContent);
+    expect(heads).toEqual(['System messages1', 'Other1']);
+  });
+
+  it('carries severity on the badge and the icon, never on a side bar', () => {
+    const { container } = setup();
+    expect(screen.getByText('Warning')).toHaveClass('mx-badge', 'warning');
+    expect(container.querySelector('.mx-icon.warning')).toBeInTheDocument();
+    // The stripe is what the rebuild removed: no card may reintroduce it.
+    const card = container.querySelector('.mx-card');
+    expect(getComputedStyle(card).borderLeftWidth).toBe(getComputedStyle(card).borderRightWidth);
+  });
+
+  it('filters to one source and back', () => {
+    const { container } = setup();
+    expect(container.querySelectorAll('.mx-card')).toHaveLength(2);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'low_medication' } });
+    expect(container.querySelectorAll('.mx-card')).toHaveLength(1);
+    expect(screen.getByText('Ojemda is running low')).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'all' } });
+    expect(container.querySelectorAll('.mx-card')).toHaveLength(2);
+  });
+
+  it('falls back to every source when the filtered one clears itself', () => {
+    const { container, rerender } = setup();
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'low_medication' } });
+    // The medication is restocked, so its message resolves out of the list. The
+    // filter must not leave the panel looking empty.
+    rerender(<MessagesBoard items={[manual(), manual({ id: 3, title: 'Second' })]} />);
+    expect(container.querySelectorAll('.mx-card')).toHaveLength(2);
+  });
+
+  it('offers no filter when there is only one source to pick from', () => {
+    setup({ items: [manual()] });
+    expect(screen.queryByRole('combobox')).toBeNull();
+  });
+
+  it('dismisses, and labels the action by who it clears for', () => {
+    const onDismiss = vi.fn();
+    setup({ items: [manual({ ack_scope: 'per_user' })], onDismiss });
+    fireEvent.click(screen.getByText('Acknowledge'));
+    expect(onDismiss).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }));
+  });
+
+  it('explains a message that clears itself instead of showing a dead button', () => {
+    setup({ items: [lowMed({ dismissible: false })], onDismiss: vi.fn() });
+    expect(screen.queryByText('Dismiss')).not.toBeInTheDocument();
+    expect(screen.getByText(/Clears when the underlying condition/)).toBeInTheDocument();
+  });
+
+  it('keeps snooze and delete behind the overflow, not on the card face', () => {
+    const onSnooze = vi.fn();
+    const onDelete = vi.fn();
+    const { container } = setup({ items: [manual()], onSnooze, onDelete });
+    expect(container.querySelector('.mx-menu')).toBeNull();
+    fireEvent.click(screen.getByLabelText('More actions for Test'));
+    const menu = container.querySelector('.mx-menu');
+    fireEvent.click(within(menu).getByText('4 hours'));
+    expect(onSnooze).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }), 240);
+  });
+
+  it('shows no overflow control when nothing is behind it', () => {
+    const { container } = setup({ items: [manual({ snoozable: false })], onSnooze: vi.fn() });
+    expect(container.querySelector('.mx-more')).toBeNull();
+  });
+
+  it('leaves no empty action row on an archived card', () => {
+    // Dismissed and resolved messages take no actions but delete, so the row
+    // must not render as a bare strip under the text — the one overflow
+    // button moves up into the header instead.
+    const { container } = setup({ items: [manual()], onDelete: vi.fn() });
+    expect(container.querySelector('.mx-card-actions')).toBeNull();
+    expect(container.querySelector('.mx-card-top .mx-more')).toBeInTheDocument();
+  });
+
+  it('links a low-stock message to the medication it is about', () => {
+    const onReview = vi.fn();
+    setup({ items: [lowMed()], onReview });
+    fireEvent.click(screen.getByText('Review Ojemda'));
+    expect(onReview).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1 }),
+      expect.objectContaining({ to: '/care/medications/manage?patient=2' })
+    );
+  });
+
+  it('switches status and counts only the tab in view', () => {
+    const onStatusChange = vi.fn();
+    setup({ onStatusChange, statusCount: 2, status: 'active' });
+    const tabs = screen.getAllByRole('tab');
+    expect(within(tabs[0]).getByText('2')).toBeInTheDocument();
+    expect(within(tabs[1]).queryByText('2')).not.toBeInTheDocument();
+    fireEvent.click(tabs[1]);
+    expect(onStatusChange).toHaveBeenCalledWith('dismissed');
+  });
+
+  it('drops the tab count when the tab is empty', () => {
+    setup({ items: [], onStatusChange: vi.fn(), statusCount: 0 });
+    expect(within(screen.getAllByRole('tab')[0]).queryByText('0')).toBeNull();
+  });
+
+  it('has no tabs where there is nothing to switch to', () => {
+    setup();
+    expect(screen.queryAllByRole('tab')).toHaveLength(0);
+  });
+
+  it('distinguishes an empty status from an empty filter', () => {
+    const { rerender } = setup({ items: [], status: 'active' });
+    expect(screen.getByText(/All caught up/)).toBeInTheDocument();
+    rerender(<MessagesBoard items={[]} status="dismissed" />);
+    expect(screen.getByText('No dismissed messages.')).toBeInTheDocument();
+  });
+
+  it('marks the narrow dock stop on the board, not from the viewport', () => {
+    const { container } = setup({ dense: true });
+    expect(container.querySelector('.mx-board')).toHaveClass('dense');
+  });
+});

--- a/frontend/src/components/messages/messageMeta.js
+++ b/frontend/src/components/messages/messageMeta.js
@@ -1,0 +1,149 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// What a message *is*, separated from how it is drawn. Both surfaces — the
+// admin page and the dashboard panel — read their labels, grouping, source
+// filter and follow-up link from here, so the two can't drift.
+//
+// Only two types exist today (`low_medication` from the generator, `general`
+// from a manual broadcast), but the type column is a free string, so anything
+// unknown degrades to a humanised label rather than disappearing.
+
+export const SEVERITY = {
+  critical: { key: 'critical', label: 'Critical' },
+  warning: { key: 'warning', label: 'Warning' },
+  info: { key: 'info', label: 'Info' },
+};
+
+export function severityOf(message) {
+  return SEVERITY[message?.severity] || SEVERITY.info;
+}
+
+/* `group` decides which heading a message files under; `icon` is a key the
+ * card maps to an SVG (never an emoji). */
+export const CATEGORIES = {
+  low_medication: { label: 'Medication inventory', icon: 'medication', group: 'system' },
+  general: { label: 'Manual message', icon: 'message', group: 'other' },
+};
+
+export function humanizeType(type) {
+  const words = String(type || '').replace(/[_-]+/g, ' ').trim();
+  if (!words) return 'Message';
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+export function categoryOf(message) {
+  const type = message?.type || 'general';
+  return CATEGORIES[type] || { label: humanizeType(type), icon: 'system', group: 'system' };
+}
+
+/* The three states a message can be read in. 'active' is the only one with
+ * actions on it; the other two are archive. */
+export const STATUS_TABS = [
+  { value: 'active', label: 'Active' },
+  { value: 'dismissed', label: 'Dismissed' },
+  { value: 'resolved', label: 'Resolved' },
+];
+
+export const GROUPS = [
+  // Anything a generator raised comes first: it reflects a live condition and
+  // usually has an action behind it. Hand-written broadcasts follow.
+  { key: 'system', label: 'System messages' },
+  { key: 'other', label: 'Other' },
+];
+
+export function groupMessages(items) {
+  const list = Array.isArray(items) ? items : [];
+  return GROUPS
+    .map(g => ({ ...g, items: list.filter(m => categoryOf(m).group === g.key) }))
+    .filter(g => g.items.length > 0);
+}
+
+/* Source options come from the messages actually in hand rather than a fixed
+ * list — a type nothing has raised is not a filter worth offering. */
+export function sourceOptions(items) {
+  const list = Array.isArray(items) ? items : [];
+  const seen = new Map();
+  list.forEach(m => {
+    const type = m?.type || 'general';
+    if (!seen.has(type)) seen.set(type, categoryOf(m).label);
+  });
+  return [
+    { value: 'all', label: 'All sources' },
+    ...[...seen.entries()]
+      .sort((a, b) => a[1].localeCompare(b[1]))
+      .map(([value, label]) => ({ value, label })),
+  ];
+}
+
+export function filterBySource(items, source) {
+  const list = Array.isArray(items) ? items : [];
+  if (!source || source === 'all') return list;
+  return list.filter(m => (m?.type || 'general') === source);
+}
+
+export function formatWhen(iso) {
+  if (!iso) return 'Created recently';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return 'Created recently';
+  const date = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const time = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  return `${date} · ${time}`;
+}
+
+/* Who clearing it acts for. The distinction matters: on a shared wall display
+ * one person dismissing an 'anyone' message clears it for the whole household. */
+export function scopeLabel(message) {
+  return message?.ack_scope === 'per_user' ? 'Each person acknowledges' : 'For everyone';
+}
+
+export function snoozeNote(message, now = Date.now()) {
+  if (!message?.snoozed_until) return null;
+  const until = new Date(message.snoozed_until);
+  if (Number.isNaN(until.getTime()) || until.getTime() <= now) return null;
+  return `Snoozed until ${formatWhen(message.snoozed_until)}`;
+}
+
+export const SNOOZE_OPTIONS = [
+  { label: '1 hour', minutes: 60 },
+  { label: '4 hours', minutes: 240 },
+  { label: '1 day', minutes: 1440 },
+];
+
+/* The follow-up a message points at. Low-stock is the only generated type so
+ * far, and the manage page already takes `?patient=`, so the link lands on the
+ * medication list for the right patient. `medication_name` is written by the
+ * generator; messages raised before that shipped fall back to a generic label
+ * rather than rendering "Review undefined". */
+export function reviewLink(message) {
+  if (message?.type !== 'low_medication') return null;
+  const name = message?.data?.medication_name;
+  const patientId = message?.patient_id ?? message?.data?.patient_id;
+  return {
+    label: name ? `Review ${name}` : 'Review medication',
+    to: `/care/medications/manage${patientId ? `?patient=${patientId}` : ''}`,
+  };
+}
+
+/* The primary action a message allows. A message that clears itself has none —
+ * saying so is more useful than a disabled button. */
+export function primaryAction(message) {
+  if (message?.dismissible) {
+    return { key: 'dismiss', label: message?.ack_scope === 'per_user' ? 'Acknowledge' : 'Dismiss' };
+  }
+  return null;
+}

--- a/frontend/src/components/messages/messageMeta.test.js
+++ b/frontend/src/components/messages/messageMeta.test.js
@@ -1,0 +1,165 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The derivations both message surfaces share. What matters here is that an
+// unknown type still lands somewhere (the column is a free string), that the
+// source filter only offers what is actually present, and that a message with
+// no follow-up says so rather than rendering a broken link.
+import { describe, it, expect } from 'vitest';
+import {
+  severityOf, categoryOf, humanizeType, groupMessages, sourceOptions,
+  filterBySource, formatWhen, scopeLabel, snoozeNote, reviewLink, primaryAction,
+} from './messageMeta';
+
+const lowMed = (over = {}) => ({
+  id: 1, type: 'low_medication', severity: 'warning', title: 'Ojemda is running low',
+  dismissible: true, snoozable: true, ack_scope: 'anyone', patient_id: 2,
+  data: { medication_id: 9, medication_name: 'Ojemda' }, ...over,
+});
+const manual = (over = {}) => ({
+  id: 2, type: 'general', severity: 'info', title: 'Test',
+  dismissible: true, snoozable: true, ack_scope: 'anyone', ...over,
+});
+
+describe('severityOf', () => {
+  it('falls back to info for an unknown or missing severity', () => {
+    expect(severityOf({ severity: 'critical' }).label).toBe('Critical');
+    expect(severityOf({ severity: 'nonsense' }).key).toBe('info');
+    expect(severityOf(undefined).key).toBe('info');
+  });
+});
+
+describe('categoryOf', () => {
+  it('labels the known types', () => {
+    expect(categoryOf(lowMed()).label).toBe('Medication inventory');
+    expect(categoryOf(manual()).label).toBe('Manual message');
+  });
+
+  it('humanises a type nothing knows about instead of dropping it', () => {
+    const cat = categoryOf({ type: 'oxygen_tank_swap' });
+    expect(cat.label).toBe('Oxygen tank swap');
+    expect(cat.group).toBe('system');
+  });
+
+  it('treats a message with no type as a manual one', () => {
+    expect(categoryOf({}).label).toBe('Manual message');
+  });
+});
+
+describe('humanizeType', () => {
+  it('never returns an empty label', () => {
+    expect(humanizeType('')).toBe('Message');
+    expect(humanizeType(null)).toBe('Message');
+  });
+});
+
+describe('groupMessages', () => {
+  it('files generated messages under system and manual ones under other', () => {
+    const groups = groupMessages([manual(), lowMed()]);
+    expect(groups.map(g => g.key)).toEqual(['system', 'other']);
+    expect(groups[0].items).toHaveLength(1);
+    expect(groups[0].items[0].type).toBe('low_medication');
+  });
+
+  it('leaves no empty heading behind', () => {
+    expect(groupMessages([manual()]).map(g => g.key)).toEqual(['other']);
+    expect(groupMessages([])).toEqual([]);
+  });
+});
+
+describe('sourceOptions / filterBySource', () => {
+  it('offers only the sources present, plus all', () => {
+    const opts = sourceOptions([lowMed(), lowMed({ id: 3 }), manual()]);
+    // Sorted by the label a reader sees, so "Manual message" precedes
+    // "Medication inventory" even though the types sort the other way.
+    expect(opts.map(o => o.value)).toEqual(['all', 'general', 'low_medication']);
+    expect(opts[1].label).toBe('Manual message');
+  });
+
+  it('collapses to just "all" when there is nothing to filter', () => {
+    expect(sourceOptions([]).map(o => o.value)).toEqual(['all']);
+  });
+
+  it('filters by type and passes everything through for all', () => {
+    const items = [lowMed(), manual()];
+    expect(filterBySource(items, 'low_medication')).toHaveLength(1);
+    expect(filterBySource(items, 'all')).toHaveLength(2);
+    expect(filterBySource(items, undefined)).toHaveLength(2);
+  });
+});
+
+describe('formatWhen', () => {
+  it('reads as a date and a time', () => {
+    expect(formatWhen('2026-06-26T14:22:00Z')).toMatch(/^\w+ \d+ · \d+:\d\d/);
+  });
+
+  it('says the message is recent rather than showing Invalid Date', () => {
+    expect(formatWhen(null)).toBe('Created recently');
+    expect(formatWhen('not a date')).toBe('Created recently');
+  });
+});
+
+describe('scopeLabel', () => {
+  it('distinguishes clearing for everyone from acknowledging individually', () => {
+    expect(scopeLabel(manual())).toBe('For everyone');
+    expect(scopeLabel(manual({ ack_scope: 'per_user' }))).toBe('Each person acknowledges');
+  });
+});
+
+describe('snoozeNote', () => {
+  const now = Date.parse('2026-06-26T12:00:00Z');
+
+  it('reports a snooze that is still running', () => {
+    expect(snoozeNote(manual({ snoozed_until: '2026-06-26T13:00:00Z' }), now))
+      .toMatch(/^Snoozed until/);
+  });
+
+  it('says nothing about one that has lapsed', () => {
+    expect(snoozeNote(manual({ snoozed_until: '2026-06-26T11:00:00Z' }), now)).toBeNull();
+    expect(snoozeNote(manual(), now)).toBeNull();
+  });
+});
+
+describe('reviewLink', () => {
+  it('points a low-stock message at that patient in the medication list', () => {
+    expect(reviewLink(lowMed())).toEqual({
+      label: 'Review Ojemda',
+      to: '/care/medications/manage?patient=2',
+    });
+  });
+
+  it('stays generic for a message raised before the name was carried', () => {
+    const link = reviewLink(lowMed({ data: { medication_id: 9 }, patient_id: null }));
+    expect(link.label).toBe('Review medication');
+    expect(link.to).toBe('/care/medications/manage');
+  });
+
+  it('has nothing to offer for a manual message', () => {
+    expect(reviewLink(manual())).toBeNull();
+  });
+});
+
+describe('primaryAction', () => {
+  it('names the action by who it clears for', () => {
+    expect(primaryAction(manual()).label).toBe('Dismiss');
+    expect(primaryAction(manual({ ack_scope: 'per_user' })).label).toBe('Acknowledge');
+  });
+
+  it('offers nothing for a message that clears itself', () => {
+    expect(primaryAction(lowMed({ dismissible: false }))).toBeNull();
+  });
+});

--- a/frontend/src/components/messages/messages-panel.css
+++ b/frontend/src/components/messages/messages-panel.css
@@ -1,0 +1,720 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Messages, one styling for both hosts: the admin page and the dashboard's
+ * docked panel.
+ *
+ * Severity is carried by the badge and the icon. There is deliberately no
+ * coloured bar down the side of the card — the stripe is decoration standing in
+ * for a label, and the badge already says the level in words.
+ *
+ * The dashboard is dark always; admin follows the user's theme. So the palette
+ * is a local token layer that defaults to the app's own light-capable variables
+ * and is swapped to the vc tokens under dark (`:root:not(.light)`, the admin
+ * convention) or under `.force-dark` (how the live board pins itself dark
+ * regardless of theme).
+ *
+ * Rendered outside the `.tw` island, so box-sizing and the bare <button> paint
+ * are asserted; `:where()` keeps that reset at element specificity. */
+@import '../../styles/vc-tokens.css';
+
+.mx-board {
+  --mx-surface: var(--card);
+  --mx-raised: var(--secondary, var(--card));
+  --mx-line: var(--border);
+  --mx-line-strong: var(--border);
+  --mx-text: var(--foreground);
+  --mx-text-2: var(--muted-foreground);
+  --mx-text-3: var(--muted-foreground);
+  --mx-accent: #0e7490;
+  --mx-critical: #b42318;
+  --mx-warning: #b54708;
+  --mx-info: #0f6f8f;
+}
+
+:root:not(.light) .mx-board,
+.force-dark .mx-board {
+  --mx-surface: var(--vc-bg-surface);
+  --mx-raised: var(--vc-bg-raised);
+  --mx-line: var(--vc-line-hairline);
+  --mx-line-strong: var(--vc-line-strong);
+  --mx-text: var(--vc-text-primary);
+  --mx-text-2: var(--vc-text-secondary);
+  --mx-text-3: var(--vc-text-tertiary);
+  --mx-accent: var(--vc-data-live);
+  --mx-critical: var(--vc-state-alert);
+  --mx-warning: var(--vc-state-due);
+  --mx-info: var(--vc-data-live);
+}
+
+.mx-board, .mx-board * { box-sizing: border-box; }
+:where(.mx-board) button {
+  font-family: var(--vc-font-mono);
+  padding: 0;
+  border: 1px solid transparent;
+  background: none;
+  color: inherit;
+}
+
+.mx-board {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  /* Capped rather than full-bleed: on a 1920px admin page an un-capped card
+     runs the message body out to a line nobody tracks across. */
+  max-width: 1040px;
+  font-family: var(--vc-font-sans);
+  color: var(--mx-text);
+}
+
+.mx-sr {
+  position: absolute;
+  width: 1px; height: 1px;
+  margin: -1px; padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+/* ---- toolbar ---- */
+
+.mx-toolbar { display: flex; flex-direction: column; gap: 0.6rem; }
+
+.mx-tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border: 1px solid var(--mx-line);
+  border-radius: 10px;
+  background: var(--mx-surface);
+}
+.mx-tab {
+  flex: 1;
+  min-height: 36px;
+  padding: 0 0.6rem;
+  border-radius: 7px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--mx-text-3);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.mx-tab:hover { color: var(--mx-text); }
+.mx-tab.active {
+  background: var(--mx-raised);
+  border-color: var(--mx-line-strong);
+  color: var(--mx-text);
+}
+.mx-tab-count { color: var(--mx-accent); font-size: 10.5px; }
+
+.mx-toolbar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.mx-source {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex: 1 1 180px;
+  min-width: 0;
+}
+.mx-source select {
+  appearance: none;
+  width: 100%;
+  min-height: 38px;
+  padding: 0 2rem 0 0.7rem;
+  border: 1px solid var(--mx-line);
+  border-radius: 8px;
+  background: var(--mx-surface);
+  color: var(--mx-text-2);
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.mx-source select:disabled { cursor: default; opacity: 0.6; }
+.mx-source select:hover:not(:disabled) { border-color: var(--mx-accent); }
+.mx-source svg {
+  position: absolute;
+  right: 0.6rem;
+  pointer-events: none;
+  color: var(--mx-text-3);
+}
+/* The OS draws the option list, so tell it which scheme to paint. */
+:root:not(.light) .mx-board .mx-source select,
+.force-dark .mx-board .mx-source select { color-scheme: dark; }
+
+/* ---- groups ---- */
+
+.mx-group { display: flex; flex-direction: column; gap: 0.5rem; }
+.mx-group-head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mx-text-3);
+}
+.mx-group-count { color: var(--mx-accent); }
+.mx-cards { display: flex; flex-direction: column; gap: 0.6rem; }
+
+/* ---- card ---- */
+
+.mx-card {
+  border: 1px solid var(--mx-line);
+  border-radius: 10px;
+  background: var(--mx-surface);
+  overflow: hidden;
+}
+.mx-card.busy { opacity: 0.6; }
+
+.mx-card-top {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.8rem 0;
+  min-width: 0;
+}
+.mx-badge {
+  flex-shrink: 0;
+  padding: 0.15rem 0.45rem;
+  border: 1px solid;
+  border-radius: 6px;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.mx-badge.critical {
+  color: var(--mx-critical);
+  border-color: color-mix(in srgb, var(--mx-critical) 60%, transparent);
+  background: color-mix(in srgb, var(--mx-critical) 12%, transparent);
+}
+.mx-badge.warning {
+  color: var(--mx-warning);
+  border-color: color-mix(in srgb, var(--mx-warning) 60%, transparent);
+  background: color-mix(in srgb, var(--mx-warning) 12%, transparent);
+}
+.mx-badge.info {
+  color: var(--mx-info);
+  border-color: color-mix(in srgb, var(--mx-info) 55%, transparent);
+  background: color-mix(in srgb, var(--mx-info) 10%, transparent);
+}
+.mx-cat {
+  min-width: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mx-text-3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mx-card-main {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.6rem 0.8rem 0.75rem;
+}
+.mx-icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid;
+  border-radius: 10px;
+}
+.mx-icon.critical {
+  color: var(--mx-critical);
+  border-color: color-mix(in srgb, var(--mx-critical) 35%, transparent);
+  background: color-mix(in srgb, var(--mx-critical) 8%, transparent);
+}
+.mx-icon.warning {
+  color: var(--mx-warning);
+  border-color: color-mix(in srgb, var(--mx-warning) 35%, transparent);
+  background: color-mix(in srgb, var(--mx-warning) 8%, transparent);
+}
+.mx-icon.info {
+  color: var(--mx-info);
+  border-color: color-mix(in srgb, var(--mx-info) 32%, transparent);
+  background: color-mix(in srgb, var(--mx-info) 8%, transparent);
+}
+
+.mx-card-text { min-width: 0; display: flex; flex-direction: column; gap: 0.25rem; }
+.mx-title {
+  margin: 0;
+  font-family: var(--vc-font-sans);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--mx-text);
+}
+.mx-body {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--mx-text-2);
+  white-space: pre-wrap;
+}
+.mx-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 0.15rem;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--mx-text-3);
+}
+.mx-dot { color: var(--mx-line-strong); }
+.mx-snoozed {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--mx-warning);
+}
+
+/* ---- actions ---- */
+
+.mx-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.8rem;
+  border-top: 1px solid var(--mx-line);
+}
+.mx-card-actions-main {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-width: 0;
+  flex: 1;
+}
+.mx-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 34px;
+  padding: 0 0.75rem;
+  border-radius: 8px;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.mx-btn.primary {
+  border: 1px solid var(--mx-accent);
+  background: color-mix(in srgb, var(--mx-accent) 16%, transparent);
+  color: var(--mx-text);
+}
+.mx-btn.primary:hover:not(:disabled) { background: color-mix(in srgb, var(--mx-accent) 28%, transparent); }
+.mx-btn.ghost { border: 1px solid var(--mx-line-strong); color: var(--mx-text-2); }
+.mx-btn.ghost:hover:not(:disabled) { color: var(--mx-text); border-color: var(--mx-accent); }
+.mx-btn.danger {
+  border: 1px solid color-mix(in srgb, var(--mx-critical) 55%, transparent);
+  color: var(--mx-critical);
+}
+.mx-btn.danger:hover:not(:disabled) { background: color-mix(in srgb, var(--mx-critical) 12%, transparent); }
+.mx-btn.sm { min-height: 28px; padding: 0 0.55rem; font-size: 9.5px; }
+.mx-btn:disabled { opacity: 0.45; cursor: default; }
+
+.mx-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-height: 34px;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--mx-accent);
+  cursor: pointer;
+}
+.mx-link:hover { color: var(--mx-text); }
+.mx-note {
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--mx-text-3);
+}
+
+.mx-more {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  margin-left: auto;
+  border: 1px solid var(--mx-line-strong);
+  border-radius: 50%;
+  color: var(--mx-text-3);
+  cursor: pointer;
+}
+.mx-more:hover, .mx-more.open { color: var(--mx-text); border-color: var(--mx-accent); }
+
+.mx-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.6rem 0.8rem 0.7rem;
+  border-top: 1px solid var(--mx-line);
+  background: var(--mx-raised);
+}
+.mx-menu-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.mx-menu-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--mx-text-3);
+}
+.mx-menu-opts { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-left: auto; }
+
+/* ---- states ---- */
+
+.mx-empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--mx-text-3);
+}
+.mx-error {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--mx-critical) 55%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--mx-critical) 12%, transparent);
+  color: var(--mx-text);
+  font-size: 12.5px;
+}
+
+.mx-foot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding-top: 0.2rem;
+}
+.mx-foot-label {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--mx-text-3);
+}
+
+/* ---- narrow dock stop ----
+   One column of controls and a smaller icon; the actions wrap under the text
+   rather than competing with it for the same 380px line. */
+.mx-board.dense .mx-tab { font-size: 9.5px; letter-spacing: 0.08em; padding: 0 0.35rem; }
+.mx-board.dense .mx-icon { width: 34px; height: 34px; border-radius: 8px; }
+.mx-board.dense .mx-card-main { gap: 0.6rem; padding: 0.5rem 0.65rem 0.65rem; }
+.mx-board.dense .mx-card-top { padding: 0.55rem 0.65rem 0; }
+.mx-board.dense .mx-title { font-size: 13.5px; }
+.mx-board.dense .mx-body { font-size: 12px; }
+.mx-board.dense .mx-card-actions { padding: 0.5rem 0.65rem; flex-wrap: wrap; }
+.mx-board.dense .mx-btn.primary { flex: 1; }
+
+/* ---- compose sheet ----
+   Rides the capture surface's bottom sheet (.vc-sheet chrome), so it is dark
+   like every other sheet in the app rather than following the admin theme.
+   Only the form inside is defined here. */
+
+.mx-compose {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding-top: 0.7rem;
+  font-family: var(--vc-font-sans);
+  color: var(--vc-text-primary);
+}
+.mx-compose * { box-sizing: border-box; }
+.mx-compose .mx-error { color: var(--vc-text-primary); }
+
+.mx-compose-sub {
+  margin: -0.3rem 0 0;
+  font-size: 13px;
+  color: var(--vc-text-secondary);
+}
+
+.mx-field { display: flex; flex-direction: column; gap: 0.4rem; }
+.mx-field-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+/* Required is the one thing that stops a post, so it gets the accent; optional
+   recedes instead of shouting the same way. */
+.mx-req { color: var(--vc-data-live); }
+.mx-opt { color: var(--vc-text-tertiary); }
+
+.mx-input {
+  width: 100%;
+  min-height: 48px;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  background: var(--vc-bg-base);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-size: 15px;
+}
+.mx-input::placeholder { color: var(--vc-text-tertiary); }
+.mx-input:focus {
+  outline: none;
+  border-color: var(--vc-data-live);
+}
+.mx-textarea { min-height: 110px; resize: vertical; line-height: 1.45; }
+.mx-count {
+  align-self: flex-end;
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+
+/* Priority: segmented, and each level wears the colour it will have on the
+   card — urgent is the one red the palette reserves for real concern. */
+.mx-seg {
+  display: flex;
+  gap: 0.3rem;
+  padding: 0.3rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  background: var(--vc-bg-base);
+}
+.mx-seg-btn {
+  flex: 1;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: none;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.mx-seg-btn:hover { color: var(--vc-text-primary); }
+.mx-seg-btn.on.info {
+  background: color-mix(in srgb, var(--vc-data-live) 22%, transparent);
+  border-color: var(--vc-data-live);
+  color: var(--vc-text-primary);
+}
+.mx-seg-btn.on.warning {
+  background: color-mix(in srgb, var(--vc-state-due) 20%, transparent);
+  border-color: var(--vc-state-due);
+  color: var(--vc-text-primary);
+}
+.mx-seg-btn.on.critical {
+  background: color-mix(in srgb, var(--vc-state-alert) 20%, transparent);
+  border-color: var(--vc-state-alert);
+  color: var(--vc-text-primary);
+}
+
+.mx-card-block {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  padding: 0.7rem 0.8rem;
+  gap: 0.6rem;
+}
+.mx-block-head {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.mx-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--vc-line-hairline);
+}
+.mx-card-block .mx-toggle-row:first-of-type { border-top: none; padding-top: 0; }
+.mx-toggle-row.disabled { opacity: 0.5; }
+.mx-toggle-text { display: flex; flex-direction: column; gap: 0.1rem; min-width: 0; }
+.mx-toggle-label { font-size: 14.5px; color: var(--vc-text-primary); }
+.mx-toggle-hint { font-size: 12px; color: var(--vc-text-tertiary); }
+
+.mx-switch {
+  flex-shrink: 0;
+  position: relative;
+  width: 52px;
+  height: 30px;
+  margin-left: auto;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 999px;
+  background: var(--vc-bg-base);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.mx-switch.on { background: var(--vc-data-live); border-color: var(--vc-data-live); }
+.mx-switch-knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--vc-text-tertiary);
+  transition: transform 120ms ease, background 120ms ease;
+}
+.mx-switch.on .mx-switch-knob { transform: translateX(22px); background: var(--vc-text-primary); }
+.mx-switch:disabled { cursor: default; opacity: 0.5; }
+
+.mx-choices { display: flex; flex-direction: column; gap: 0.4rem; }
+.mx-choice {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 10px;
+  background: var(--vc-bg-base);
+  color: var(--vc-text-secondary);
+  text-align: left;
+  cursor: pointer;
+}
+.mx-choice.on {
+  border-color: var(--vc-data-live);
+  background: color-mix(in srgb, var(--vc-data-live) 12%, transparent);
+  color: var(--vc-data-live);
+}
+.mx-choice-text { display: flex; flex-direction: column; gap: 0.15rem; min-width: 0; flex: 1; }
+.mx-choice-label {
+  font-family: var(--vc-font-mono);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+.mx-choice-hint { font-family: var(--vc-font-sans); font-size: 12px; color: var(--vc-text-tertiary); }
+
+.mx-compose-note {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--vc-text-tertiary);
+}
+.mx-compose-note svg { flex-shrink: 0; color: var(--vc-data-live); }
+.mx-compose-note strong {
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* The action row sticks to the bottom of the sheet so Post is reachable
+   without scrolling back down a long form. */
+.mx-compose-actions {
+  position: sticky;
+  bottom: 0;
+  padding: 0.7rem 0 0;
+  margin-top: 0.2rem;
+  border-top: 1px solid var(--vc-line-hairline);
+  background: var(--vc-bg-sheet);
+}
+
+/* ---- confirm sheet ---- */
+.mx-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding-top: 0.8rem;
+  font-family: var(--vc-font-sans);
+  color: var(--vc-text-primary);
+}
+.mx-confirm p { margin: 0; font-size: 14px; color: var(--vc-text-secondary); }
+.mx-confirm strong { color: var(--vc-text-primary); }
+.vc-btn.mx-danger {
+  background: var(--vc-state-alert);
+  color: var(--vc-bg-base);
+  flex: 1.6;
+}
+.vc-btn.mx-danger:hover { border-color: transparent; }
+
+/* The lone overflow button on an archived card sits in the header row. */
+.mx-card-top .mx-more { width: 28px; height: 28px; margin-left: auto; }

--- a/frontend/src/components/messages/useMessages.js
+++ b/frontend/src/components/messages/useMessages.js
@@ -1,0 +1,117 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Fetching and acting on messages, shared by both hosts.
+//
+// The two surfaces mean different things by "active" and the API has an
+// endpoint for each, so `scope` picks:
+//   'mine' — GET /api/messages/active: what this user must deal with now. Runs
+//            the generators first, and drops messages this user has already
+//            acknowledged or snoozed. The dashboard's badge counts these.
+//   'all'  — GET /api/messages?status=active: every open message regardless of
+//            who has snoozed it. The admin registry has to show those.
+// Dismissed and resolved only exist on the paginated endpoint, so both scopes
+// use it for those tabs.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import config, { apiFetch } from '../../config';
+
+export default function useMessages({ scope = 'all', pageSize = 20, initialItems = null } = {}) {
+  const [status, setStatusRaw] = useState('active');
+  const [page, setPage] = useState(1);
+  const [items, setItems] = useState(initialItems || []);
+  const [total, setTotal] = useState(initialItems ? initialItems.length : 0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [loading, setLoading] = useState(!initialItems);
+  const [error, setError] = useState(null);
+  const [busyId, setBusyId] = useState(null);
+  // The auto-pop hands over the list it already fetched; the first fetch would
+  // only re-run the generators for the same answer. It is skipped once — every
+  // later tab change, action or refresh talks to the API normally.
+  const skipFirst = useRef(!!initialItems);
+  // Requests can land out of order — the active tab runs the generators before
+  // answering, so it is the slow one, and its late reply would otherwise wipe
+  // the list the user has already switched to. Only the newest request writes.
+  const reqId = useRef(0);
+
+  const setStatus = useCallback((next) => {
+    setStatusRaw(next);
+    setPage(1);
+  }, []);
+
+  const fetchMessages = useCallback(async () => {
+    if (skipFirst.current) { skipFirst.current = false; return; }
+    const mine = scope === 'mine' && status === 'active';
+    const id = ++reqId.current;
+    try {
+      setLoading(true);
+      setError(null);
+      const url = mine
+        ? `${config.apiUrl}/api/messages/active`
+        : `${config.apiUrl}/api/messages?status=${status}&page=${page}&page_size=${pageSize}`;
+      const res = await apiFetch(url);
+      if (!res.ok) throw new Error(`Error fetching messages: ${res.statusText}`);
+      const data = await res.json();
+      if (id !== reqId.current) return;
+      setItems(data.items || []);
+      setTotal(mine ? (data.count ?? (data.items || []).length) : (data.total || 0));
+      setTotalPages(mine ? 0 : (data.total_pages || 0));
+    } catch (err) {
+      if (id !== reqId.current) return;
+      console.error('Error fetching messages:', err);
+      setError('Failed to load messages. Please try again.');
+    } finally {
+      if (id === reqId.current) setLoading(false);
+    }
+  }, [scope, status, page, pageSize]);
+
+  useEffect(() => { fetchMessages(); }, [fetchMessages]);
+
+  const act = useCallback(async (message, path, body) => {
+    try {
+      setBusyId(message.id);
+      setError(null);
+      const res = await apiFetch(`${config.apiUrl}/api/messages/${message.id}/${path}`, {
+        method: 'POST',
+        headers: body ? { 'Content-Type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => ({}));
+        throw new Error(detail.detail || res.statusText);
+      }
+      // Drop it locally so the card goes away on the tap, then re-read: the
+      // server decides what the list is now (a per-user ack may leave the
+      // message active for everyone else, and the admin scope keeps it).
+      setItems(prev => prev.filter(m => m.id !== message.id));
+      await fetchMessages();
+    } catch (err) {
+      console.error(`Error on message ${path}:`, err);
+      setError(err.message || 'Action failed. Please try again.');
+    } finally {
+      setBusyId(null);
+    }
+  }, [fetchMessages]);
+
+  const dismiss = useCallback((message) => act(message, 'dismiss'), [act]);
+  const snooze = useCallback((message, minutes) => act(message, 'snooze', { minutes }), [act]);
+
+  return {
+    status, setStatus, page, setPage,
+    items, total, totalPages, loading, error, setError,
+    busyId, refresh: fetchMessages, dismiss, snooze,
+  };
+}

--- a/frontend/src/components/messages/useMessages.test.jsx
+++ b/frontend/src/components/messages/useMessages.test.jsx
@@ -1,0 +1,103 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Fetching messages. The case that actually bit: the dashboard's active tab
+// runs the low-stock generators before answering, so it is the slow request —
+// and its late reply used to overwrite whichever tab the user had moved on to.
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import useMessages from './useMessages';
+
+const deferred = () => {
+  let resolve;
+  const promise = new Promise(r => { resolve = r; });
+  return { promise, resolve };
+};
+
+const jsonRes = (body) => ({ ok: true, status: 200, json: async () => body });
+
+beforeEach(() => { vi.restoreAllMocks(); });
+
+describe('useMessages', () => {
+  it('asks the per-user endpoint for the dashboard and the registry for admin', async () => {
+    const fetchMock = vi.fn(async () => jsonRes({ items: [], count: 0 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderHook(() => useMessages({ scope: 'mine' }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/messages/active');
+
+    fetchMock.mockClear();
+    renderHook(() => useMessages({ scope: 'all' }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/messages?status=active');
+  });
+
+  it('ignores a slow reply for a tab the reader has already left', async () => {
+    const slow = deferred();
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes('/active')) return slow.promise;
+      return jsonRes({ items: [{ id: 7, title: 'Archived' }], total: 1, total_pages: 1 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useMessages({ scope: 'mine' }));
+    act(() => result.current.setStatus('dismissed'));
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    // The active request finally answers — with an empty list, which is the
+    // truth for *that* tab and must not clear this one.
+    await act(async () => { slow.resolve(jsonRes({ items: [], count: 0 })); });
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.status).toBe('dismissed');
+  });
+
+  it('starts from a handed-over list without re-running the generators', async () => {
+    const fetchMock = vi.fn(async () => jsonRes({ items: [], count: 0 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const seed = [{ id: 1, title: 'Already fetched' }];
+    const { result } = renderHook(() => useMessages({ scope: 'mine', initialItems: seed }));
+    expect(result.current.items).toEqual(seed);
+    expect(result.current.loading).toBe(false);
+    await new Promise(r => setTimeout(r, 20));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failure instead of showing an empty list', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500, statusText: 'Server Error' })));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result } = renderHook(() => useMessages({ scope: 'all' }));
+    await waitFor(() => expect(result.current.error).toMatch(/Failed to load/));
+  });
+
+  it('drops a dismissed message from the list and re-reads', async () => {
+    let page = [{ id: 4, title: 'Ojemda is running low' }];
+    const fetchMock = vi.fn(async (url, opts) => {
+      if (opts?.method === 'POST') { page = []; return jsonRes({ status: 'success' }); }
+      return jsonRes({ items: page, count: page.length, total: page.length, total_pages: 1 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useMessages({ scope: 'mine' }));
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    await act(async () => { await result.current.dismiss({ id: 4 }); });
+    expect(result.current.items).toHaveLength(0);
+    expect(fetchMock.mock.calls.some(([u, o]) =>
+      String(u).endsWith('/api/messages/4/dismiss') && o?.method === 'POST')).toBe(true);
+  });
+});

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -564,8 +564,9 @@ export default function Dashboard() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helper is recreated each render; effect is keyed on patient change only
   }, [selectedPatient?.id]);
 
-  // Detect Frigate integration for the current patient so we can swap the
-  // Messages icon for a live camera icon when one is configured.
+  // Detect Frigate integration for the current patient: the Live Camera action
+  // appears only when a camera is actually configured. (It used to take the
+  // Messages slot rather than add one, which hid the messages list entirely.)
   useEffect(() => {
     let cancelled = false;
     setHasCamera(false);

--- a/frontend/src/pages/admin-v2/AdminV2Messages.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Messages.jsx
@@ -15,91 +15,34 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import AdminV2Layout from './AdminV2Layout';
 import config, { apiFetch } from '../../config';
-import { PlusIcon, TrashIcon } from '../../components/Icons';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
-import { Alert } from '@/components/ui/alert';
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
-import { Field, FormRow } from '@/components/ui/field';
+import { PlusIcon } from '../../components/Icons';
+import MessagesBoard from '../../components/messages/MessagesBoard';
+import ComposeMessageSheet from '../../components/messages/ComposeMessageSheet';
+import ConfirmSheet from '../../components/messages/ConfirmSheet';
+import useMessages from '../../components/messages/useMessages';
 import './AdminV2.css';
 
-const SEVERITY_COLORS = {
-  critical: '#e53e3e',
-  warning: '#dd6b20',
-  info: '#4299e1',
-};
-
-const STATUS_TABS = [
-  { value: 'active', label: 'Active' },
-  { value: 'dismissed', label: 'Dismissed' },
-  { value: 'resolved', label: 'Resolved' },
-];
-
-const EMPTY_FORM = {
-  title: '',
-  body: '',
-  severity: 'info',
-  ack_scope: 'anyone',
-  dismissible: true,
-  snoozable: true,
-};
-
 const AdminV2Messages = () => {
-  const [messages, setMessages] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+  // 'all': the admin registry shows every open message, including ones this
+  // user has snoozed — unlike the dashboard panel, which asks what *I* owe.
+  const {
+    status, setStatus, page, setPage, items, total, totalPages,
+    loading, error, setError, busyId, refresh, dismiss, snooze,
+  } = useMessages({ scope: 'all' });
 
-  const [statusFilter, setStatusFilter] = useState('active');
-  const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(0);
-  const [total, setTotal] = useState(0);
-
-  const [showCreateModal, setShowCreateModal] = useState(false);
-  const [formData, setFormData] = useState(EMPTY_FORM);
+  const [showCompose, setShowCompose] = useState(false);
   const [formError, setFormError] = useState(null);
   const [saving, setSaving] = useState(false);
 
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [deleting, setDeleting] = useState(false);
 
-  const fetchMessages = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const url = `${config.apiUrl}/api/messages?status=${statusFilter}&page=${page}&page_size=20`;
-      const response = await apiFetch(url);
-      if (!response.ok) throw new Error('Failed to load messages');
-      const data = await response.json();
-      setMessages(data.items || []);
-      setTotalPages(data.total_pages || 0);
-      setTotal(data.total || 0);
-    } catch (err) {
-      console.error('Error fetching messages:', err);
-      setError('Failed to load messages');
-    } finally {
-      setLoading(false);
-    }
-  }, [statusFilter, page]);
-
-  useEffect(() => {
-    fetchMessages();
-  }, [fetchMessages]);
-
-  const handleCreate = async (e) => {
-    e.preventDefault();
+  const handleCreate = async (formData) => {
     setFormError(null);
     setSaving(true);
     try {
@@ -116,11 +59,9 @@ const AdminV2Messages = () => {
             : data.detail || 'Failed to create message'
         );
       }
-      setShowCreateModal(false);
-      setFormData(EMPTY_FORM);
-      setStatusFilter('active');
-      setPage(1);
-      fetchMessages();
+      setShowCompose(false);
+      setStatus('active');
+      refresh();
     } catch (err) {
       setFormError(err.message);
     } finally {
@@ -137,7 +78,7 @@ const AdminV2Messages = () => {
       });
       if (!response.ok) throw new Error('Failed to delete message');
       setDeleteTarget(null);
-      fetchMessages();
+      refresh();
     } catch (err) {
       console.error('Error deleting message:', err);
       setError('Failed to delete message');
@@ -150,215 +91,71 @@ const AdminV2Messages = () => {
   return (
     <AdminV2Layout>
       <div className="admin-v2-page">
-        {error && (
-          <div className="tw mb-4">
-            <Alert variant="destructive">{error}</Alert>
-          </div>
-        )}
-
-        <div className="admin-v2-controls-bar">
-          <div className="admin-v2-tabs">
-            {STATUS_TABS.map(tab => (
-              <button
-                key={tab.value}
-                className={`admin-v2-tab ${statusFilter === tab.value ? 'active' : ''}`}
-                onClick={() => { setStatusFilter(tab.value); setPage(1); }}
-              >
-                {tab.label}
+        {/* The list, the tabs and the source filter are the same component the
+            dashboard panel renders — one styling for messages wherever they
+            are read. The page keeps what only an admin does: creating a
+            broadcast, deleting one, and paging back through the archive. */}
+        <MessagesBoard
+          items={items}
+          loading={loading}
+          error={error}
+          status={status}
+          onStatusChange={setStatus}
+          statusCount={total}
+          busyId={busyId}
+          onDismiss={status === 'active' ? dismiss : undefined}
+          onSnooze={status === 'active' ? snooze : undefined}
+          onDelete={setDeleteTarget}
+          onReview={(message, link) => navigate(link.to)}
+          headerActions={
+            <button
+              type="button"
+              className="mx-btn primary"
+              onClick={() => { setFormError(null); setShowCompose(true); }}
+            >
+              <PlusIcon size={14} />
+              New message
+            </button>
+          }
+          footer={totalPages > 1 ? (
+            <div className="mx-foot">
+              <button type="button" className="mx-btn ghost sm" disabled={page <= 1} onClick={() => setPage(page - 1)}>
+                Previous
               </button>
-            ))}
-          </div>
-          <div className="tw">
-            <Button onClick={() => { setFormData(EMPTY_FORM); setFormError(null); setShowCreateModal(true); }}>
-              <PlusIcon size={16} />
-              New Message
-            </Button>
-          </div>
-        </div>
+              <span className="mx-foot-label">
+                Page {page} of {totalPages} · {total} total
+              </span>
+              <button type="button" className="mx-btn ghost sm" disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
+                Next
+              </button>
+            </div>
+          ) : null}
+        />
 
-        {loading ? (
-          <div style={{ textAlign: 'center', padding: 40, color: 'var(--muted-foreground)' }}>Loading messages…</div>
-        ) : messages.length === 0 ? (
-          <div className="admin-v2-empty-state-small" style={{ textAlign: 'center', padding: 40 }}>
-            No {statusFilter} messages.
-          </div>
-        ) : (
-          <div className="admin-v2-table-container">
-            <table className="admin-v2-table">
-              <thead>
-                <tr>
-                  <th>Severity</th>
-                  <th>Title</th>
-                  <th>Type</th>
-                  <th>Clearing</th>
-                  <th>Created</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {messages.map(message => (
-                  <tr key={message.id}>
-                    <td>
-                      <span style={{
-                        fontSize: 12, fontWeight: 700, letterSpacing: '0.05em',
-                        textTransform: 'uppercase',
-                        color: SEVERITY_COLORS[message.severity] || SEVERITY_COLORS.info,
-                      }}>
-                        {message.severity}
-                      </span>
-                    </td>
-                    <td>
-                      <div style={{ fontWeight: 600 }}>{message.title}</div>
-                      {message.body && (
-                        <div style={{ fontSize: 13, color: 'var(--muted-foreground)', maxWidth: 420, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          {message.body}
-                        </div>
-                      )}
-                    </td>
-                    <td>{message.type}</td>
-                    <td>{message.ack_scope === 'per_user' ? 'Each person' : 'Anyone'}</td>
-                    <td>{message.created_at ? new Date(message.created_at).toLocaleString() : '—'}</td>
-                    <td className="admin-v2-table-actions">
-                      <div className="tw">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setDeleteTarget(message)}
-                          aria-label="Delete message"
-                        >
-                          <TrashIcon size={16} />
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+        {/* Compose and confirm both ride the app's bottom sheet, the same one
+            the capture surface uses — a form to fill in on a phone. */}
+        <ComposeMessageSheet
+          open={showCompose}
+          onClose={() => { setShowCompose(false); setFormError(null); }}
+          onSubmit={handleCreate}
+          saving={saving}
+          error={formError}
+        />
 
-        {totalPages > 1 && (
-          <div className="tw" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 12, marginTop: 16 }}>
-            <Button variant="secondary" size="sm" disabled={page <= 1} onClick={() => setPage(page - 1)}>
-              Previous
-            </Button>
-            <span style={{ color: 'var(--muted-foreground)', fontSize: 14 }}>
-              Page {page} of {totalPages} ({total} total)
-            </span>
-            <Button variant="secondary" size="sm" disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
-              Next
-            </Button>
-          </div>
-        )}
+        <ConfirmSheet
+          open={!!deleteTarget}
+          title="Delete message"
+          confirmLabel="Delete permanently"
+          busy={deleting}
+          onClose={() => setDeleteTarget(null)}
+          onConfirm={handleDelete}
+        >
+          <p>
+            Permanently delete <strong>“{deleteTarget?.title}”</strong>? Nobody will see it
+            again, and any acknowledgement history goes with it.
+          </p>
+        </ConfirmSheet>
 
-        {/* Create modal */}
-        <Dialog open={showCreateModal} onOpenChange={(open) => !open && setShowCreateModal(false)}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>New Message</DialogTitle>
-            </DialogHeader>
-            <form onSubmit={handleCreate}>
-              <div className="flex flex-col gap-4">
-                {formError && <Alert variant="destructive">{formError}</Alert>}
-
-                <Field label="Title" required htmlFor="msg-title">
-                  <Input
-                    id="msg-title"
-                    value={formData.title}
-                    onChange={e => setFormData({ ...formData, title: e.target.value })}
-                    required
-                    maxLength={255}
-                    placeholder="e.g., Doctor appointment moved to Friday"
-                  />
-                </Field>
-
-                <Field label="Details" htmlFor="msg-body">
-                  <Textarea
-                    id="msg-body"
-                    value={formData.body}
-                    onChange={e => setFormData({ ...formData, body: e.target.value })}
-                    rows={3}
-                    placeholder="Optional additional details"
-                  />
-                </Field>
-
-                <FormRow>
-                  <Field label="Severity">
-                    <Select
-                      value={formData.severity}
-                      onValueChange={(v) => setFormData({ ...formData, severity: v })}
-                    >
-                      <SelectTrigger><SelectValue /></SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="info">Info</SelectItem>
-                        <SelectItem value="warning">Warning</SelectItem>
-                        <SelectItem value="critical">Critical</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </Field>
-                  <Field label="Who can clear it">
-                    <Select
-                      value={formData.ack_scope}
-                      onValueChange={(v) => setFormData({ ...formData, ack_scope: v })}
-                    >
-                      <SelectTrigger><SelectValue /></SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="anyone">Anyone clears it for everyone</SelectItem>
-                        <SelectItem value="per_user">Each person must acknowledge</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </Field>
-                </FormRow>
-
-                <div className="flex items-center gap-6">
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id="msg-dismissible"
-                      checked={formData.dismissible}
-                      onCheckedChange={(v) => setFormData({ ...formData, dismissible: !!v })}
-                    />
-                    <Label htmlFor="msg-dismissible" className="cursor-pointer">Can be cleared</Label>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id="msg-snoozable"
-                      checked={formData.snoozable}
-                      onCheckedChange={(v) => setFormData({ ...formData, snoozable: !!v })}
-                    />
-                    <Label htmlFor="msg-snoozable" className="cursor-pointer">Can be snoozed</Label>
-                  </div>
-                </div>
-              </div>
-              <DialogFooter>
-                <Button type="button" variant="secondary" onClick={() => setShowCreateModal(false)}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={saving || !formData.title.trim()}>
-                  {saving ? 'Creating…' : 'Create Message'}
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-
-        {/* Delete confirmation */}
-        <Dialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Delete Message</DialogTitle>
-            </DialogHeader>
-            <p>
-              Permanently delete “{deleteTarget?.title}”? Users will no longer see it,
-              and any acknowledgement history is removed.
-            </p>
-            <DialogFooter>
-              <Button variant="secondary" onClick={() => setDeleteTarget(null)}>Cancel</Button>
-              <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
-                {deleting ? 'Deleting…' : 'Delete'}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
       </div>
     </AdminV2Layout>
   );


### PR DESCRIPTION
## Nav

`Messages` was the *else* branch of the camera check in `topBarActions.jsx` — configuring a Frigate camera **replaced** it, so the whole messages section vanished from the board with nothing to say so. Messages is now always present; Live Camera is the one conditional action and appears only when a camera is configured for the patient (that detection was already correct, it just wasn't additive).

## Messages, one styling for both hosts

`components/messages/` is rendered by the admin page **and** the dashboard's docked panel:

| File | Role |
|---|---|
| `messageMeta.js` | pure — severity/category labels, grouping, source options, follow-up link, status tabs |
| `MessageCard.jsx` | one card |
| `MessagesBoard.jsx` | tabs + source filter + grouped cards + states |
| `useMessages.js` | fetching and acting |
| `ComposeMessageSheet.jsx` / `ConfirmSheet.jsx` | the bottom sheets |
| `messages-panel.css` | the styling |

**No coloured bar down the side.** Severity is carried by the badge and the icon instead — a stripe is decoration standing in for a label the badge already spells out. (The same motif is still on the alerts cards, the schedule rows and the admin table — happy to sweep those in a follow-up; this PR only rebuilt messages.)

Other behaviour worth flagging:

- Cards group into **system messages** (anything a generator raised) and **other** (manual broadcasts). An unknown `type` is humanised rather than dropped — the column is a free string.
- The source filter renders only when there is more than one source in hand, and falls back to "all" if the one you picked resolves away.
- A card offers only what the message allows: no Dismiss on a non-dismissible message, plus a line saying it clears when the condition does. Archived cards carry no action row at all.
- **Backend:** the low-stock generator now writes `medication_name` into `data`, so "Review Ojemda" can name the medication without parsing the title prose back apart. The link lands on `/care/medications/manage?patient=N`.

## Compose

The new-message dialog was the last shadcn slab in this flow. It is now the app's bottom sheet — the same chrome the capture surface uses — following your mockup: title (required), optional message, priority segmented, follow-up toggles, and who clearing it acts for. Delete confirmation moved to the same sheet.

Two deliberate deviations from the mockup:

- **No audience picker.** The API has no audience — every message goes to everyone on the account. A picker would promise targeting that doesn't exist. The "when someone clears it" row is the real distinction and it's kept.
- **Priority has three stops, not two.** `NORMAL / IMPORTANT / URGENT` → `info / warning / critical`; dropping to two would have quietly removed the critical level the API already supports. Each stop wears the colour it will have on the card.

The character counter counts down from the column's real 255 limit, and only once it's within 40.

## Theming

The dashboard panel is dark always; admin follows the user's theme. So the palette is a local token layer defaulting to the app's own light-capable variables, swapped to the vc tokens under `:root:not(.light)` and `.force-dark`. Verified in light theme — cards resolve to the light card/foreground values, not vc hex.

## Fixed along the way

The active tab hits `/api/messages/active`, which runs the low-stock generators **before** answering — so it's the slow request, and its late reply could overwrite whichever tab the reader had already switched to (I hit exactly this: 3 dismissed messages rendering as "no dismissed messages"). Requests now carry a token and only the newest one writes. Regression test in `useMessages.test.jsx`.

## Verification

- Playwright, dark, cookie login: admin at **390px** and **1440px**, dashboard panel at the **narrow** and **expanded** dock stops and at **390px**. No horizontal overflow anywhere; every card's left border equals its right border (the stripe check is also a unit test).
- Round trip on real data: compose → post (lands as `warning` under Other) → dismiss (leaves Active) → delete from the Dismissed tab.
- Light theme: `.mx-card` background `rgb(246,248,250)`, title `rgb(31,35,40)`.
- Gates: `npm run lint` 0, `npx vite build` clean, **606** frontend tests (+52 new), backend `scripts/run_tests.sh` green.

## Not in this pass

- A badge on the Messages nav action. It would need its own poll, and `/active` runs the generators on every call — say the word and I'll add it on a slower cadence than the 60s due-counts loop.
- Compose from the dashboard panel (it exists on the admin page only, as before).
- The side-bar sweep across the other panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011u7gjNWppXao35QPLtBBQe