### PR TITLE
Scope shipments to an account

### DIFF
--- a/backend/alembic/versions/046_shipment_account_scope.py
+++ b/backend/alembic/versions/046_shipment_account_scope.py
@@ -1,0 +1,77 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Backfill dme_shipments.account_id so shipments can be scoped to an account
+
+Revision ID: 046_shipment_account_scope
+Revises: 045_nutrition_intake_tube_feed
+Create Date: 2026-08-19
+
+The column has existed since the accounts work, but nothing ever wrote it:
+create_shipment took no account_id, so every row in every install carries
+NULL. Now that the queries filter on it, the existing rows have to be given
+the account they always belonged to, or they would vanish from the UI.
+
+A shipment's account is not ambiguous -- patient_id is NOT NULL and a patient
+carries the account -- so the backfill reads it from there rather than
+guessing. Documents denormalize the same value and are corrected from their
+shipment for the same reason.
+
+Rows whose patient has no account (a single-tenant install, where the whole
+accounts column is NULL) stay NULL, which is what the query layer expects:
+a request with no account applies no filter.
+"""
+from typing import Sequence, Union
+from alembic import op
+
+
+revision: str = '046_shipment_account_scope'
+down_revision: Union[str, None] = '045_nutrition_intake_tube_feed'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Take the account from the patient the shipment is for.
+    op.execute("""
+        UPDATE dme_shipments AS s
+           SET account_id = p.account_id
+          FROM patients AS p
+         WHERE p.id = s.patient_id
+           AND s.account_id IS NULL
+           AND p.account_id IS NOT NULL
+    """)
+
+    # Documents copy the shipment's account at upload time, so any attached to
+    # a shipment created before this migration carry the same NULL.
+    op.execute("""
+        UPDATE dme_shipment_documents AS d
+           SET account_id = s.account_id
+          FROM dme_shipments AS s
+         WHERE s.id = d.shipment_id
+           AND d.account_id IS NULL
+           AND s.account_id IS NOT NULL
+    """)
+
+    # No index is created here: ix_dme_shipments_account_id already exists
+    # from 001_initial_schema, which indexed the column the module then never
+    # populated.
+
+
+def downgrade() -> None:
+    # Data-only migration. The backfilled values are deliberately left in
+    # place: they are the correct account for each row, and clearing them
+    # would re-open the gap this migration exists to close.
+    pass

--- a/backend/crud/dme_shipments.py
+++ b/backend/crud/dme_shipments.py
@@ -20,12 +20,59 @@ import logging
 from datetime import datetime
 from typing import Optional, List
 from sqlalchemy.orm import Session
-from sqlalchemy import and_
+from sqlalchemy import and_, or_
 from schemas.dme_shipment import DMEShipment, DMEShipmentItem, DMEReceiptItem, DMEShipmentAlert, DMEShipmentDocument
 from schemas.equipment import Equipment
 import document_store
 
 logger = logging.getLogger('crud')
+
+
+# --- Account scoping ---
+#
+# A shipment belongs to a patient, and a patient belongs to an account, so
+# unlike equipment there is no such thing as a shared shipment: the filter is
+# equality, not "mine or global". Requests without an account (a single-tenant
+# install, where every patient's account_id is NULL too) skip the filter, which
+# is the convention the rest of the CRUD layer already follows.
+#
+# Everything reachable by id — items, receipts, alerts, documents — is reached
+# through its shipment, so scoping the shipment lookup is what closes the
+# boundary. Callers that hold only an item or alert id must resolve the parent
+# shipment through these helpers rather than querying the child table directly.
+
+def _scope_to_account(query, account_id: Optional[int]):
+    """Restrict a DMEShipment query to one account."""
+    if account_id is None:
+        return query
+    return query.filter(DMEShipment.account_id == account_id)
+
+
+def _owned_shipment(db: Session, shipment_id: int, account_id: Optional[int]) -> Optional[DMEShipment]:
+    """The shipment, or None if it does not exist or belongs to another account."""
+    query = db.query(DMEShipment).filter(DMEShipment.id == shipment_id)
+    return _scope_to_account(query, account_id).first()
+
+
+def _owned_item(
+    db: Session,
+    item_id: int,
+    shipment_id: Optional[int] = None,
+    account_id: Optional[int] = None,
+) -> Optional[DMEShipmentItem]:
+    """An item, confirmed to sit on the named shipment and inside the account.
+
+    The item routes take both ids in the path but only ever used the item's,
+    so a caller could edit, delete or receive against a line belonging to a
+    different shipment — and a different account — by naming one of their own.
+    """
+    query = db.query(DMEShipmentItem).filter(DMEShipmentItem.id == item_id)
+    if shipment_id is not None:
+        query = query.filter(DMEShipmentItem.shipment_id == shipment_id)
+    if account_id is not None:
+        query = query.join(DMEShipment, DMEShipmentItem.shipment_id == DMEShipment.id) \
+                     .filter(DMEShipment.account_id == account_id)
+    return query.first()
 
 
 # --- Shipment CRUD ---
@@ -47,11 +94,13 @@ def create_shipment(
     created_by: Optional[int] = None,
     is_template: bool = False,
     template_source_id: Optional[int] = None,
-    status: str = 'draft'
+    status: str = 'draft',
+    account_id: Optional[int] = None
 ) -> Optional[DMEShipment]:
     """Create a new DME shipment"""
     try:
         shipment = DMEShipment(
+            account_id=account_id,
             patient_id=patient_id,
             supplier_id=supplier_id,
             po_number=po_number,
@@ -82,10 +131,10 @@ def create_shipment(
         return None
 
 
-def get_shipment(db: Session, shipment_id: int) -> Optional[dict]:
+def get_shipment(db: Session, shipment_id: int, account_id: Optional[int] = None) -> Optional[dict]:
     """Get a shipment with all related data"""
     try:
-        shipment = db.query(DMEShipment).filter(DMEShipment.id == shipment_id).first()
+        shipment = _owned_shipment(db, shipment_id, account_id)
         if not shipment:
             return None
         
@@ -103,11 +152,12 @@ def list_shipments(
     is_backorder: Optional[bool] = None,
     is_template: Optional[bool] = None,
     skip: int = 0,
-    limit: int = 50
+    limit: int = 50,
+    account_id: Optional[int] = None
 ) -> List[dict]:
     """List shipments with optional filters"""
     try:
-        query = db.query(DMEShipment)
+        query = _scope_to_account(db.query(DMEShipment), account_id)
 
         if patient_id is not None:
             query = query.filter(DMEShipment.patient_id == patient_id)
@@ -132,11 +182,12 @@ def list_shipments(
 def update_shipment(
     db: Session,
     shipment_id: int,
+    account_id: Optional[int] = None,
     **kwargs
 ) -> bool:
     """Update shipment fields"""
     try:
-        shipment = db.query(DMEShipment).filter(DMEShipment.id == shipment_id).first()
+        shipment = _owned_shipment(db, shipment_id, account_id)
         if not shipment:
             return False
         
@@ -160,10 +211,10 @@ def update_shipment(
         return False
 
 
-def delete_shipment(db: Session, shipment_id: int) -> bool:
+def delete_shipment(db: Session, shipment_id: int, account_id: Optional[int] = None) -> bool:
     """Delete a shipment and all related items (and packing-slip blobs)"""
     try:
-        shipment = db.query(DMEShipment).filter(DMEShipment.id == shipment_id).first()
+        shipment = _owned_shipment(db, shipment_id, account_id)
         if not shipment:
             return False
 
@@ -200,10 +251,15 @@ def add_shipment_item(
     unit_description: Optional[str] = None,
     unit_price: Optional[float] = None,
     lot_number: Optional[str] = None,
-    notes: Optional[str] = None
+    notes: Optional[str] = None,
+    account_id: Optional[int] = None
 ) -> Optional[DMEShipmentItem]:
     """Add an item to a shipment"""
     try:
+        if account_id is not None and not _owned_shipment(db, shipment_id, account_id):
+            logger.error(f"Shipment {shipment_id} not found in account {account_id}")
+            return None
+
         item = DMEShipmentItem(
             shipment_id=shipment_id,
             equipment_id=equipment_id,
@@ -240,10 +296,16 @@ def add_shipment_item(
         return None
 
 
-def update_shipment_item(db: Session, item_id: int, **kwargs) -> bool:
+def update_shipment_item(
+    db: Session,
+    item_id: int,
+    shipment_id: Optional[int] = None,
+    account_id: Optional[int] = None,
+    **kwargs
+) -> bool:
     """Update a shipment item"""
     try:
-        item = db.query(DMEShipmentItem).filter(DMEShipmentItem.id == item_id).first()
+        item = _owned_item(db, item_id, shipment_id, account_id)
         if not item:
             return False
         
@@ -266,10 +328,15 @@ def update_shipment_item(db: Session, item_id: int, **kwargs) -> bool:
         return False
 
 
-def delete_shipment_item(db: Session, item_id: int) -> bool:
+def delete_shipment_item(
+    db: Session,
+    item_id: int,
+    shipment_id: Optional[int] = None,
+    account_id: Optional[int] = None,
+) -> bool:
     """Delete a shipment item"""
     try:
-        item = db.query(DMEShipmentItem).filter(DMEShipmentItem.id == item_id).first()
+        item = _owned_item(db, item_id, shipment_id, account_id)
         if not item:
             return False
         
@@ -293,17 +360,18 @@ def receive_item(
     condition: str = 'good',
     discrepancy_notes: Optional[str] = None,
     lot_number: Optional[str] = None,
-    expiration_date: Optional[datetime] = None
+    expiration_date: Optional[datetime] = None,
+    shipment_id: Optional[int] = None,
+    account_id: Optional[int] = None
 ) -> Optional[DMEReceiptItem]:
     """
     Record receipt of an item. Updates equipment quantity immediately.
     Can be called multiple times for partial receiving across sessions.
     """
     try:
-        # Get the shipment item
-        shipment_item = db.query(DMEShipmentItem).filter(
-            DMEShipmentItem.id == shipment_item_id
-        ).first()
+        # Receiving writes to inventory, so the line has to be confirmed as
+        # part of the shipment named in the request, in this account.
+        shipment_item = _owned_item(db, shipment_item_id, shipment_id, account_id)
         if not shipment_item:
             logger.error(f"Shipment item {shipment_item_id} not found")
             return None
@@ -357,9 +425,18 @@ def receive_item(
         return None
 
 
-def get_item_receipts(db: Session, shipment_item_id: int) -> List[dict]:
+def get_item_receipts(
+    db: Session,
+    shipment_item_id: int,
+    shipment_id: Optional[int] = None,
+    account_id: Optional[int] = None,
+) -> List[dict]:
     """Get all receipts for a shipment item"""
     try:
+        if (shipment_id is not None or account_id is not None) and \
+                not _owned_item(db, shipment_item_id, shipment_id, account_id):
+            return []
+
         receipts = db.query(DMEReceiptItem).filter(
             DMEReceiptItem.shipment_item_id == shipment_item_id
         ).order_by(DMEReceiptItem.received_at).all()
@@ -370,13 +447,23 @@ def get_item_receipts(db: Session, shipment_item_id: int) -> List[dict]:
         return []
 
 
-def get_total_received(db: Session, shipment_item_id: int) -> dict:
+def get_total_received(
+    db: Session,
+    shipment_item_id: int,
+    shipment_id: Optional[int] = None,
+    account_id: Optional[int] = None,
+) -> dict:
     """Get total quantities received for a shipment item by condition"""
+    empty = {'good': 0, 'damaged': 0, 'wrong_item': 0, 'short': 0, 'extra': 0, 'total': 0}
     try:
+        if (shipment_id is not None or account_id is not None) and \
+                not _owned_item(db, shipment_item_id, shipment_id, account_id):
+            return empty
+
         receipts = db.query(DMEReceiptItem).filter(
             DMEReceiptItem.shipment_item_id == shipment_item_id
         ).all()
-        
+
         totals = {'good': 0, 'damaged': 0, 'wrong_item': 0, 'short': 0, 'extra': 0}
         for r in receipts:
             if r.condition in totals:
@@ -394,7 +481,8 @@ def get_total_received(db: Session, shipment_item_id: int) -> dict:
 def finalize_shipment(
     db: Session,
     shipment_id: int,
-    finalized_by: Optional[int] = None
+    finalized_by: Optional[int] = None,
+    account_id: Optional[int] = None
 ) -> dict:
     """
     Finalize a shipment:
@@ -403,7 +491,7 @@ def finalize_shipment(
     - Update shipment status to 'complete' or 'partial'
     """
     try:
-        shipment = db.query(DMEShipment).filter(DMEShipment.id == shipment_id).first()
+        shipment = _owned_shipment(db, shipment_id, account_id)
         if not shipment:
             return {'success': False, 'error': 'Shipment not found'}
         
@@ -479,7 +567,8 @@ def finalize_shipment(
                 is_backorder=True,
                 parent_shipment_id=shipment_id,
                 notes=f"Backorder items from shipment #{shipment_id}",
-                created_by=finalized_by
+                created_by=finalized_by,
+                account_id=shipment.account_id
             )
             
             if backorder_shipment:
@@ -547,31 +636,23 @@ def _create_alert(
         return None
 
 
-def get_shipment_alerts(db: Session, shipment_id: int) -> List[dict]:
+def get_shipment_alerts(
+    db: Session,
+    shipment_id: int,
+    account_id: Optional[int] = None,
+) -> List[dict]:
     """Get all alerts for a shipment"""
     try:
+        if account_id is not None and not _owned_shipment(db, shipment_id, account_id):
+            return []
+
         alerts = db.query(DMEShipmentAlert).filter(
             DMEShipmentAlert.shipment_id == shipment_id
         ).order_by(DMEShipmentAlert.created_at).all()
-        
+
         return [_alert_to_dict(a) for a in alerts]
     except Exception as e:
         logger.error(f"Error fetching alerts for shipment {shipment_id}: {e}")
-        return []
-
-
-def get_unresolved_alerts(db: Session, patient_id: Optional[int] = None) -> List[dict]:
-    """Get all unresolved alerts, optionally filtered by patient"""
-    try:
-        query = db.query(DMEShipmentAlert).filter(DMEShipmentAlert.resolved == False)
-        
-        if patient_id is not None:
-            query = query.join(DMEShipment).filter(DMEShipment.patient_id == patient_id)
-        
-        alerts = query.order_by(DMEShipmentAlert.created_at.desc()).all()
-        return [_alert_to_dict(a) for a in alerts]
-    except Exception as e:
-        logger.error(f"Error fetching unresolved alerts: {e}")
         return []
 
 
@@ -579,21 +660,27 @@ def get_alerts(
     db: Session,
     patient_id: Optional[int] = None,
     alert_type: Optional[str] = None,
-    resolved: Optional[bool] = None
+    resolved: Optional[bool] = None,
+    account_id: Optional[int] = None
 ) -> List[dict]:
     """Get alerts with filters"""
     try:
         query = db.query(DMEShipmentAlert)
-        
+
         if resolved is not None:
             query = query.filter(DMEShipmentAlert.resolved == resolved)
-        
+
         if alert_type:
             query = query.filter(DMEShipmentAlert.alert_type == alert_type)
-        
-        if patient_id is not None:
-            query = query.join(DMEShipment).filter(DMEShipment.patient_id == patient_id)
-        
+
+        # One join carries both scopes — joining DMEShipment twice would raise.
+        if patient_id is not None or account_id is not None:
+            query = query.join(DMEShipment, DMEShipmentAlert.shipment_id == DMEShipment.id)
+            if patient_id is not None:
+                query = query.filter(DMEShipment.patient_id == patient_id)
+            if account_id is not None:
+                query = query.filter(DMEShipment.account_id == account_id)
+
         alerts = query.order_by(DMEShipmentAlert.created_at.desc()).all()
         return [_alert_to_dict(a) for a in alerts]
     except Exception as e:
@@ -605,14 +692,20 @@ def resolve_alert(
     db: Session,
     alert_id: int,
     resolved_by: Optional[int] = None,
-    resolution_notes: Optional[str] = None
+    resolution_notes: Optional[str] = None,
+    account_id: Optional[int] = None
 ) -> bool:
     """Mark an alert as resolved"""
     try:
-        alert = db.query(DMEShipmentAlert).filter(DMEShipmentAlert.id == alert_id).first()
+        query = db.query(DMEShipmentAlert).filter(DMEShipmentAlert.id == alert_id)
+        if account_id is not None:
+            query = query.join(
+                DMEShipment, DMEShipmentAlert.shipment_id == DMEShipment.id
+            ).filter(DMEShipment.account_id == account_id)
+        alert = query.first()
         if not alert:
             return False
-        
+
         alert.resolved = True
         alert.resolved_at = datetime.utcnow()
         alert.resolved_by = resolved_by
@@ -630,27 +723,31 @@ def resolve_alert(
 def create_followup_order(
     db: Session,
     alert_ids: List[int],
-    created_by: Optional[int] = None
+    created_by: Optional[int] = None,
+    account_id: Optional[int] = None
 ) -> Optional[dict]:
     """
     Create a follow-up order from one or more alerts.
     Groups alerts by original shipment's supplier/patient.
     """
     try:
-        alerts = db.query(DMEShipmentAlert).filter(
+        alert_query = db.query(DMEShipmentAlert).filter(
             DMEShipmentAlert.id.in_(alert_ids),
             DMEShipmentAlert.resolved == False
-        ).all()
-        
+        )
+        if account_id is not None:
+            alert_query = alert_query.join(
+                DMEShipment, DMEShipmentAlert.shipment_id == DMEShipment.id
+            ).filter(DMEShipment.account_id == account_id)
+        alerts = alert_query.all()
+
         if not alerts:
             return {'success': False, 'error': 'No valid unresolved alerts found'}
-        
+
         # Get original shipment info
         first_alert = alerts[0]
-        original_shipment = db.query(DMEShipment).filter(
-            DMEShipment.id == first_alert.shipment_id
-        ).first()
-        
+        original_shipment = _owned_shipment(db, first_alert.shipment_id, account_id)
+
         if not original_shipment:
             return {'success': False, 'error': 'Original shipment not found'}
         
@@ -660,7 +757,8 @@ def create_followup_order(
             patient_id=original_shipment.patient_id,
             supplier_id=original_shipment.supplier_id,
             notes=f"Follow-up order for alerts from shipment #{original_shipment.id}",
-            created_by=created_by
+            created_by=created_by,
+            account_id=original_shipment.account_id
         )
         
         if not followup:
@@ -718,14 +816,18 @@ def create_followup_order(
         return {'success': False, 'error': str(e)}
 
 
-def get_pending_backorders(db: Session, patient_id: Optional[int] = None) -> List[dict]:
+def get_pending_backorders(
+    db: Session,
+    patient_id: Optional[int] = None,
+    account_id: Optional[int] = None,
+) -> List[dict]:
     """Get all pending backorder shipments"""
     try:
-        query = db.query(DMEShipment).filter(
+        query = _scope_to_account(db.query(DMEShipment), account_id).filter(
             DMEShipment.is_backorder == True,
             DMEShipment.status.in_(['ordered', 'shipped'])
         )
-        
+
         if patient_id is not None:
             query = query.filter(DMEShipment.patient_id == patient_id)
         
@@ -742,7 +844,8 @@ def create_delivery_from_template(
     db: Session,
     template_id: int,
     expected_delivery: Optional[datetime] = None,
-    created_by: Optional[int] = None
+    created_by: Optional[int] = None,
+    account_id: Optional[int] = None
 ) -> Optional[dict]:
     """
     Create a delivery from a standing-order template ("the usual monthly order").
@@ -750,9 +853,12 @@ def create_delivery_from_template(
     the expectation is everything arrives as usual; reconcile adjusts from there.
     """
     try:
-        template = db.query(DMEShipment).filter(
-            DMEShipment.id == template_id,
-            DMEShipment.is_template == True
+        template = _scope_to_account(
+            db.query(DMEShipment).filter(
+                DMEShipment.id == template_id,
+                DMEShipment.is_template == True
+            ),
+            account_id,
         ).first()
         if not template:
             return {'success': False, 'error': 'Standing order not found'}
@@ -767,7 +873,8 @@ def create_delivery_from_template(
             notes=None,
             created_by=created_by,
             template_source_id=template_id,
-            status='ordered'
+            status='ordered',
+            account_id=template.account_id
         )
         if not delivery:
             return {'success': False, 'error': 'Failed to create delivery'}
@@ -804,7 +911,8 @@ def reconcile_shipment(
     mode: str = 'same_as_usual',
     items: Optional[List[dict]] = None,
     confirmed_delivery_date: Optional[datetime] = None,
-    user_id: Optional[int] = None
+    user_id: Optional[int] = None,
+    account_id: Optional[int] = None
 ) -> dict:
     """
     Confirm a delivery in one call, collapsing receive + finalize:
@@ -816,7 +924,7 @@ def reconcile_shipment(
     backorder shipment, status partial/complete.
     """
     try:
-        shipment = db.query(DMEShipment).filter(DMEShipment.id == shipment_id).first()
+        shipment = _owned_shipment(db, shipment_id, account_id)
         if not shipment:
             return {'success': False, 'error': 'Shipment not found'}
         if shipment.is_template:
@@ -873,9 +981,9 @@ def reconcile_shipment(
             shipment.actual_delivery = confirmed_delivery_date
         db.commit()
 
-        result = finalize_shipment(db, shipment_id, finalized_by=user_id)
+        result = finalize_shipment(db, shipment_id, finalized_by=user_id, account_id=account_id)
         if result.get('success'):
-            result['alerts'] = get_shipment_alerts(db, shipment_id)
+            result['alerts'] = get_shipment_alerts(db, shipment_id, account_id=account_id)
         return result
     except Exception as e:
         logger.error(f"Error reconciling shipment {shipment_id}: {e}")
@@ -892,11 +1000,12 @@ def add_shipment_document(
     content_type: str,
     title: Optional[str] = None,
     page_number: Optional[int] = None,
-    uploaded_by: Optional[int] = None
+    uploaded_by: Optional[int] = None,
+    account_id: Optional[int] = None
 ) -> Optional[dict]:
     """Store a packing-slip image/PDF blob and attach its metadata row."""
     try:
-        shipment = db.query(DMEShipment).filter(DMEShipment.id == shipment_id).first()
+        shipment = _owned_shipment(db, shipment_id, account_id)
         if not shipment:
             return None
 
@@ -928,9 +1037,16 @@ def add_shipment_document(
         return None
 
 
-def list_shipment_documents(db: Session, shipment_id: int) -> List[dict]:
+def list_shipment_documents(
+    db: Session,
+    shipment_id: int,
+    account_id: Optional[int] = None,
+) -> List[dict]:
     """List document metadata for a shipment (ordered by page)"""
     try:
+        if account_id is not None and not _owned_shipment(db, shipment_id, account_id):
+            return []
+
         docs = db.query(DMEShipmentDocument).filter(
             DMEShipmentDocument.shipment_id == shipment_id
         ).order_by(DMEShipmentDocument.page_number.nullslast(), DMEShipmentDocument.id).all()
@@ -940,18 +1056,30 @@ def list_shipment_documents(db: Session, shipment_id: int) -> List[dict]:
         return []
 
 
-def get_shipment_document(db: Session, shipment_id: int, document_id: int) -> Optional[DMEShipmentDocument]:
-    """Fetch a single document row (scoped to the shipment)"""
+def get_shipment_document(
+    db: Session,
+    shipment_id: int,
+    document_id: int,
+    account_id: Optional[int] = None,
+) -> Optional[DMEShipmentDocument]:
+    """Fetch a single document row (scoped to the shipment, and to the account)"""
+    if account_id is not None and not _owned_shipment(db, shipment_id, account_id):
+        return None
     return db.query(DMEShipmentDocument).filter(
         DMEShipmentDocument.id == document_id,
         DMEShipmentDocument.shipment_id == shipment_id
     ).first()
 
 
-def delete_shipment_document(db: Session, shipment_id: int, document_id: int) -> bool:
+def delete_shipment_document(
+    db: Session,
+    shipment_id: int,
+    document_id: int,
+    account_id: Optional[int] = None,
+) -> bool:
     """Delete a document row and its blob"""
     try:
-        doc = get_shipment_document(db, shipment_id, document_id)
+        doc = get_shipment_document(db, shipment_id, document_id, account_id)
         if not doc:
             return False
         if doc.file_path:
@@ -968,16 +1096,28 @@ def delete_shipment_document(db: Session, shipment_id: int, document_id: int) ->
 
 # --- Inventory summary ---
 
-def get_inventory_summary(db: Session, patient_id: Optional[int] = None) -> List[dict]:
+def get_inventory_summary(
+    db: Session,
+    patient_id: Optional[int] = None,
+    account_id: Optional[int] = None,
+) -> List[dict]:
     """
     Per-equipment on-hand view: quantity vs par_level / reorder_point with a
     derived status (ok | low | reorder). Reconciled deliveries keep this live
     via receive_item()'s Equipment.quantity updates.
+
+    This reads the equipment table, so it scopes the way the equipment module
+    does — an account's own rows plus the shared ones with no account — rather
+    than the strict equality the shipment tables use. Filtering these strictly
+    would hide shared supplies that the equipment page itself lists.
     """
     try:
         query = db.query(Equipment)
         if patient_id is not None:
             query = query.filter(Equipment.patient_id == patient_id)
+        if account_id is not None:
+            query = query.filter(or_(Equipment.account_id == account_id,
+                                     Equipment.account_id.is_(None)))
         rows = query.order_by(Equipment.name).all()
 
         result = []

--- a/backend/routes/dme_shipments.py
+++ b/backend/routes/dme_shipments.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
 from db import get_db
-from dependencies import get_current_user, require_permission
+from dependencies import get_current_user, get_optional_account_id, require_permission
 from models.users import User
 from crud import dme_shipments as crud
 
@@ -155,6 +155,7 @@ def parse_datetime(dt_str: Optional[str]) -> Optional[datetime]:
 async def create_shipment(
     data: ShipmentCreate,
     db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
     current_user: User = Depends(get_current_user)
 ):
     """Create a new DME shipment"""
@@ -172,7 +173,8 @@ async def create_shipment(
             warehouse_loc=data.warehouse_loc,
             notes=data.notes,
             created_by=current_user.id,
-            is_template=data.is_template
+            is_template=data.is_template,
+            account_id=account_id
         )
         
         if shipment:
@@ -192,7 +194,8 @@ async def list_shipments(
     is_template: Optional[bool] = None,
     skip: int = 0,
     limit: int = 50,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """List shipments with optional filters"""
     try:
@@ -204,7 +207,8 @@ async def list_shipments(
             is_backorder=is_backorder,
             is_template=is_template,
             skip=skip,
-            limit=limit
+            limit=limit,
+            account_id=account_id
         )
         return {"shipments": shipments}
     except Exception as e:
@@ -215,11 +219,12 @@ async def list_shipments(
 @router.get("/backorders", dependencies=[Depends(require_permission("shipments.read"))])
 async def get_pending_backorders(
     patient_id: Optional[int] = None,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Get all pending backorder shipments"""
     try:
-        backorders = crud.get_pending_backorders(db, patient_id=patient_id)
+        backorders = crud.get_pending_backorders(db, patient_id=patient_id, account_id=account_id)
         return {"backorders": backorders}
     except Exception as e:
         logger.error(f"Error fetching backorders: {e}")
@@ -231,7 +236,8 @@ async def get_alerts(
     patient_id: Optional[int] = None,
     alert_type: Optional[str] = None,
     resolved: Optional[str] = None,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Get shipment alerts with optional filters"""
     try:
@@ -239,7 +245,8 @@ async def get_alerts(
             db, 
             patient_id=patient_id,
             alert_type=alert_type,
-            resolved=resolved == 'true' if resolved else None
+            resolved=resolved == 'true' if resolved else None,
+            account_id=account_id
         )
         return {"alerts": alerts, "count": len(alerts)}
     except Exception as e:
@@ -250,11 +257,12 @@ async def get_alerts(
 @router.get("/inventory", dependencies=[Depends(require_permission("shipments.read"))])
 async def get_inventory(
     patient_id: Optional[int] = None,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Supplies-on-hand summary: per-equipment quantity vs par/reorder levels"""
     try:
-        items = crud.get_inventory_summary(db, patient_id=patient_id)
+        items = crud.get_inventory_summary(db, patient_id=patient_id, account_id=account_id)
         return {
             "inventory": items,
             "counts": {
@@ -271,11 +279,12 @@ async def get_inventory(
 @router.get("/{shipment_id}", dependencies=[Depends(require_permission("shipments.read"))])
 async def get_shipment(
     shipment_id: int,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Get a specific shipment with all items and receipts"""
     try:
-        shipment = crud.get_shipment(db, shipment_id)
+        shipment = crud.get_shipment(db, shipment_id, account_id=account_id)
         if not shipment:
             raise HTTPException(status_code=404, detail="Shipment not found")
         return shipment
@@ -290,7 +299,8 @@ async def get_shipment(
 async def update_shipment(
     shipment_id: int,
     data: ShipmentUpdate,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Update a shipment"""
     try:
@@ -301,7 +311,7 @@ async def update_shipment(
             if field in update_data and update_data[field]:
                 update_data[field] = parse_datetime(update_data[field])
         
-        success = crud.update_shipment(db, shipment_id, **update_data)
+        success = crud.update_shipment(db, shipment_id, account_id=account_id, **update_data)
         return {"success": success}
     except Exception as e:
         logger.error(f"Error updating shipment {shipment_id}: {e}")
@@ -312,7 +322,8 @@ async def update_shipment(
 async def patch_shipment(
     shipment_id: int,
     data: ShipmentUpdate,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Partially update a shipment (e.g., change status)"""
     try:
@@ -323,7 +334,7 @@ async def patch_shipment(
             if field in update_data and update_data[field]:
                 update_data[field] = parse_datetime(update_data[field])
         
-        success = crud.update_shipment(db, shipment_id, **update_data)
+        success = crud.update_shipment(db, shipment_id, account_id=account_id, **update_data)
         if success:
             return {"success": True}
         else:
@@ -338,7 +349,8 @@ async def patch_shipment(
 @router.delete("/{shipment_id}", dependencies=[Depends(require_permission("shipments.delete"))])
 async def delete_shipment(
     shipment_id: int,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """
     Delete a shipment. Guarded: once anything has been received (receipts
@@ -362,7 +374,7 @@ async def delete_shipment(
         )
 
     try:
-        success = crud.delete_shipment(db, shipment_id)
+        success = crud.delete_shipment(db, shipment_id, account_id=account_id)
         return {"success": success}
     except Exception as e:
         logger.error(f"Error deleting shipment {shipment_id}: {e}")
@@ -372,12 +384,13 @@ async def delete_shipment(
 @router.post("/{shipment_id}/copy", dependencies=[Depends(require_permission("shipments.create"))])
 async def copy_shipment(
     shipment_id: int,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Copy a shipment with all items as a new draft"""
     try:
         # Get the original shipment
-        original = crud.get_shipment(db, shipment_id)
+        original = crud.get_shipment(db, shipment_id, account_id=account_id)
         if not original:
             raise HTTPException(status_code=404, detail="Shipment not found")
         
@@ -392,6 +405,7 @@ async def copy_shipment(
             expected_delivery=None,
             tracking_number=None,
             ship_method=original.get('ship_method'),
+            account_id=account_id,
             warehouse_loc=original.get('warehouse_loc'),
             notes=f"Copied from shipment #{shipment_id}"
         )
@@ -415,7 +429,8 @@ async def copy_shipment(
                 unit_description=item.get('unit_description'),
                 unit_price=item.get('unit_price'),
                 lot_number=None,  # Clear lot number
-                notes=item.get('notes')
+                notes=item.get('notes'),
+                account_id=account_id
             )
         
         logger.info(f"Copied shipment {shipment_id} to new shipment {new_shipment.id}")
@@ -435,13 +450,15 @@ async def copy_shipment(
 async def add_shipment_item(
     shipment_id: int,
     data: ShipmentItemCreate,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Add an item to a shipment"""
     try:
         item = crud.add_shipment_item(
             db,
             shipment_id=shipment_id,
+            account_id=account_id,
             **data.model_dump()
         )
         
@@ -457,7 +474,8 @@ async def add_shipment_item(
 async def add_shipment_items_bulk(
     shipment_id: int,
     items: List[ShipmentItemCreate],
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """
     Add many items in one call — used by the invoice/packing-slip scanner to
@@ -470,7 +488,7 @@ async def add_shipment_items_bulk(
     created = []
     errors = []
     for entry in items:
-        item = crud.add_shipment_item(db, shipment_id=shipment_id, **entry.model_dump())
+        item = crud.add_shipment_item(db, shipment_id=shipment_id, account_id=account_id, **entry.model_dump())
         if item:
             created.append(item.id)
         else:
@@ -489,12 +507,13 @@ async def update_shipment_item(
     shipment_id: int,
     item_id: int,
     data: ShipmentItemUpdate,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Update a shipment item"""
     try:
         update_data = data.model_dump(exclude_unset=True)
-        success = crud.update_shipment_item(db, item_id, **update_data)
+        success = crud.update_shipment_item(db, item_id, shipment_id=shipment_id, account_id=account_id, **update_data)
         return {"success": success}
     except Exception as e:
         logger.error(f"Error updating item {item_id}: {e}")
@@ -505,11 +524,12 @@ async def update_shipment_item(
 async def delete_shipment_item(
     shipment_id: int,
     item_id: int,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Delete a shipment item"""
     try:
-        success = crud.delete_shipment_item(db, item_id)
+        success = crud.delete_shipment_item(db, item_id, shipment_id=shipment_id, account_id=account_id)
         return {"success": success}
     except Exception as e:
         logger.error(f"Error deleting item {item_id}: {e}")
@@ -523,6 +543,7 @@ async def receive_items(
     shipment_id: int,
     items: List[ReceiveItem],
     db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
     current_user: User = Depends(get_current_user)
 ):
     """
@@ -540,7 +561,9 @@ async def receive_items(
                 condition=item_data.condition,
                 discrepancy_notes=item_data.discrepancy_notes,
                 lot_number=item_data.lot_number,
-                expiration_date=parse_datetime(item_data.expiration_date)
+                expiration_date=parse_datetime(item_data.expiration_date),
+                shipment_id=shipment_id,
+                account_id=account_id
             )
             
             if receipt:
@@ -561,12 +584,13 @@ async def receive_items(
 async def get_item_receipts(
     shipment_id: int,
     item_id: int,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Get all receipts for a specific item"""
     try:
-        receipts = crud.get_item_receipts(db, item_id)
-        totals = crud.get_total_received(db, item_id)
+        receipts = crud.get_item_receipts(db, item_id, shipment_id=shipment_id, account_id=account_id)
+        totals = crud.get_total_received(db, item_id, shipment_id=shipment_id, account_id=account_id)
         return {
             "receipts": receipts,
             "totals": totals
@@ -582,6 +606,7 @@ async def get_item_receipts(
 async def finalize_shipment(
     shipment_id: int,
     db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
     current_user: User = Depends(get_current_user)
 ):
     """
@@ -591,7 +616,7 @@ async def finalize_shipment(
     - Update status to complete or partial
     """
     try:
-        result = crud.finalize_shipment(db, shipment_id, finalized_by=current_user.id)
+        result = crud.finalize_shipment(db, shipment_id, finalized_by=current_user.id, account_id=account_id)
         return result
     except Exception as e:
         logger.error(f"Error finalizing shipment {shipment_id}: {e}")
@@ -603,11 +628,12 @@ async def finalize_shipment(
 @router.get("/{shipment_id}/alerts", dependencies=[Depends(require_permission("shipments.read"))])
 async def get_shipment_alerts(
     shipment_id: int,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Get all alerts for a shipment"""
     try:
-        alerts = crud.get_shipment_alerts(db, shipment_id)
+        alerts = crud.get_shipment_alerts(db, shipment_id, account_id=account_id)
         return {"alerts": alerts}
     except Exception as e:
         logger.error(f"Error fetching alerts for shipment {shipment_id}: {e}")
@@ -619,6 +645,7 @@ async def resolve_alert(
     alert_id: int,
     data: ResolveAlert,
     db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
     current_user: User = Depends(get_current_user)
 ):
     """Mark an alert as resolved"""
@@ -627,7 +654,8 @@ async def resolve_alert(
             db,
             alert_id,
             resolved_by=current_user.id,
-            resolution_notes=data.resolution_notes
+            resolution_notes=data.resolution_notes,
+            account_id=account_id
         )
         return {"success": success}
     except Exception as e:
@@ -639,6 +667,7 @@ async def resolve_alert(
 async def create_followup_order(
     data: CreateFollowupOrder,
     db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
     current_user: User = Depends(get_current_user)
 ):
     """Create a follow-up order from one or more unresolved alerts"""
@@ -646,7 +675,8 @@ async def create_followup_order(
         result = crud.create_followup_order(
             db,
             alert_ids=data.alert_ids,
-            created_by=current_user.id
+            created_by=current_user.id,
+            account_id=account_id
         )
         return result
     except Exception as e:
@@ -661,6 +691,7 @@ async def create_delivery(
     template_id: int,
     data: CreateDelivery = Body(default=CreateDelivery()),
     db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
     current_user: User = Depends(get_current_user)
 ):
     """Create a delivery from a standing-order template ("the usual order")"""
@@ -669,7 +700,8 @@ async def create_delivery(
             db,
             template_id=template_id,
             expected_delivery=parse_datetime(data.expected_delivery),
-            created_by=current_user.id
+            created_by=current_user.id,
+            account_id=account_id
         )
         return result
     except Exception as e:
@@ -684,6 +716,7 @@ async def reconcile_shipment(
     shipment_id: int,
     data: ReconcileRequest,
     db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
     current_user: User = Depends(get_current_user)
 ):
     """
@@ -707,7 +740,8 @@ async def reconcile_shipment(
             mode=data.mode,
             items=items,
             confirmed_delivery_date=parse_datetime(data.confirmed_delivery_date),
-            user_id=current_user.id
+            user_id=current_user.id,
+            account_id=account_id
         )
         return result
     except Exception as e:
@@ -729,6 +763,7 @@ async def upload_shipment_document(
     page_number: Optional[int] = Form(None),
     title: Optional[str] = Form(None),
     db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
     current_user: User = Depends(get_current_user)
 ):
     """Attach a packing-slip image/PDF to a shipment (repeat for multi-page slips)"""
@@ -747,7 +782,8 @@ async def upload_shipment_document(
         content_type=content_type,
         title=title or file.filename,
         page_number=page_number,
-        uploaded_by=current_user.id
+        uploaded_by=current_user.id,
+        account_id=account_id
     )
     if not doc:
         raise HTTPException(status_code=404, detail="Shipment not found")
@@ -757,20 +793,22 @@ async def upload_shipment_document(
 @router.get("/{shipment_id}/documents", dependencies=[Depends(require_permission("shipments.read"))])
 async def list_shipment_documents(
     shipment_id: int,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """List packing-slip documents attached to a shipment"""
-    return {"documents": crud.list_shipment_documents(db, shipment_id)}
+    return {"documents": crud.list_shipment_documents(db, shipment_id, account_id=account_id)}
 
 
 @router.get("/{shipment_id}/documents/{document_id}/raw", dependencies=[Depends(require_permission("shipments.read"))])
 async def get_shipment_document_raw(
     shipment_id: int,
     document_id: int,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Serve the stored packing-slip blob for inline viewing"""
-    doc = crud.get_shipment_document(db, shipment_id, document_id)
+    doc = crud.get_shipment_document(db, shipment_id, document_id, account_id=account_id)
     if not doc or not doc.file_path:
         raise HTTPException(status_code=404, detail="Document not found")
     return FileResponse(doc.file_path, media_type=doc.content_type or "application/octet-stream")
@@ -780,10 +818,11 @@ async def get_shipment_document_raw(
 async def delete_shipment_document(
     shipment_id: int,
     document_id: int,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id)
 ):
     """Delete a packing-slip document (blob + metadata)"""
-    success = crud.delete_shipment_document(db, shipment_id, document_id)
+    success = crud.delete_shipment_document(db, shipment_id, document_id, account_id=account_id)
     if not success:
         raise HTTPException(status_code=404, detail="Document not found")
     return {"success": True}

--- a/backend/tests/test_dme_shipments_account_scope.py
+++ b/backend/tests/test_dme_shipments_account_scope.py
@@ -1,0 +1,266 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Shipments are scoped to an account.
+
+Every endpoint here was reachable across accounts: nothing set account_id on
+create and no query filtered on it, so holding shipments.read was enough to
+read, and shipments.receive enough to write into, any other account's data.
+
+The item routes are covered separately because they take both a shipment id
+and an item id but only ever used the item's — so naming your own shipment
+alongside someone else's line was enough to reach it.
+"""
+import pytest
+
+
+# --- A second account, with its own user, client and patient -----------------
+
+@pytest.fixture
+def other_account(db_session):
+    from models.users import Account
+    import bcrypt
+    acc = Account(
+        name="Other Family", slug="other-family",
+        password_hash=bcrypt.hashpw(b"otherpass", bcrypt.gensalt()).decode(),
+        timezone="America/New_York", is_default=False,
+    )
+    db_session.add(acc)
+    db_session.commit()
+    db_session.refresh(acc)
+    return acc
+
+
+@pytest.fixture
+def other_user(db_session, other_account):
+    from crud.users import create_user, get_role_by_name
+    role = get_role_by_name(db_session, "system_admin")
+    user = create_user(
+        db_session, username="other_admin", password="otherpass",
+        full_name="Other Admin", is_system_admin=True,
+        role_ids=[role.id] if role else None, force_password_reset=False,
+    )
+    user.account_id = other_account.id
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def other_client(client, other_user, other_account):
+    """A fully-privileged client belonging to a different account.
+
+    System admin on purpose: the boundary must hold on account identity, not
+    on permissions, so the strongest role is the honest thing to test with.
+    """
+    from routes.auth import create_access_token
+    from starlette.testclient import TestClient
+    token = create_access_token(user=other_user, account=other_account, auth_level="full")
+    fresh = TestClient(client.app)
+    fresh.headers.update({"Authorization": f"Bearer {token}"})
+    return fresh
+
+
+@pytest.fixture
+def other_patient(db_session, other_account):
+    from crud.patients import create_patient
+    p = create_patient(db_session, {
+        "first_name": "Other", "last_name": "Patient",
+        "account_id": other_account.id, "is_active": True,
+    })
+    db_session.commit()
+    return p
+
+
+def _make_shipment(cl, patient, **over):
+    payload = {"patient_id": patient.id, "po_number": "PO-SCOPE"}
+    payload.update(over)
+    resp = cl.post("/api/shipments", json=payload)
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+def _add_item(cl, sid, **over):
+    payload = {"item_description": "Tubing", "qty_ordered": 5, "qty_shipped": 5}
+    payload.update(over)
+    resp = cl.post(f"/api/shipments/{sid}/items", json=payload)
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+# --- The account is recorded on create ---------------------------------------
+
+def test_create_records_the_account(admin_client, patient, db_session, account):
+    sid = _make_shipment(admin_client, patient)
+    from schemas.dme_shipment import DMEShipment
+    row = db_session.query(DMEShipment).filter(DMEShipment.id == sid).first()
+    assert row.account_id == account.id
+
+
+# --- Reads -------------------------------------------------------------------
+
+def test_list_excludes_other_accounts(admin_client, other_client, patient, other_patient):
+    mine = _make_shipment(admin_client, patient)
+    theirs = _make_shipment(other_client, other_patient)
+
+    ids = [s["id"] for s in admin_client.get("/api/shipments").json()["shipments"]]
+    assert mine in ids
+    assert theirs not in ids
+
+
+def test_get_by_id_across_accounts_is_404(admin_client, other_client, other_patient):
+    theirs = _make_shipment(other_client, other_patient)
+    assert admin_client.get(f"/api/shipments/{theirs}").status_code == 404
+
+
+def test_alerts_exclude_other_accounts(admin_client, other_client, other_patient):
+    theirs = _make_shipment(other_client, other_patient)
+    item = _add_item(other_client, theirs)
+    # Receive nothing, then finalize: that shortfall raises a 'short' alert.
+    other_client.post(f"/api/shipments/{theirs}/receive",
+                      json=[{"shipment_item_id": item, "qty_received": 0}])
+    other_client.post(f"/api/shipments/{theirs}/finalize")
+
+    theirs_alerts = other_client.get("/api/shipments/alerts").json()["alerts"]
+    assert theirs_alerts, "the other account should see its own alert"
+
+    mine = admin_client.get("/api/shipments/alerts").json()["alerts"]
+    assert all(a["shipment_id"] != theirs for a in mine)
+
+
+def test_shipment_alerts_by_id_across_accounts_is_empty(admin_client, other_client, other_patient):
+    theirs = _make_shipment(other_client, other_patient)
+    assert admin_client.get(f"/api/shipments/{theirs}/alerts").json()["alerts"] == []
+
+
+def test_documents_across_accounts_are_hidden(admin_client, other_client, other_patient):
+    theirs = _make_shipment(other_client, other_patient)
+    other_client.post(
+        f"/api/shipments/{theirs}/documents",
+        files={"file": ("slip.png", b"\x89PNG\r\n\x1a\n" + b"0" * 32, "image/png")},
+    )
+    assert other_client.get(f"/api/shipments/{theirs}/documents").json()["documents"]
+    assert admin_client.get(f"/api/shipments/{theirs}/documents").json()["documents"] == []
+
+
+# --- Writes ------------------------------------------------------------------
+
+def test_update_across_accounts_does_not_apply(admin_client, other_client, other_patient, db_session):
+    theirs = _make_shipment(other_client, other_patient)
+    admin_client.patch(f"/api/shipments/{theirs}", json={"tracking_number": "STOLEN"})
+
+    from schemas.dme_shipment import DMEShipment
+    db_session.expire_all()
+    row = db_session.query(DMEShipment).filter(DMEShipment.id == theirs).first()
+    assert row.tracking_number != "STOLEN"
+
+
+def test_delete_across_accounts_does_not_apply(admin_client, other_client, other_patient, db_session):
+    theirs = _make_shipment(other_client, other_patient)
+    admin_client.delete(f"/api/shipments/{theirs}")
+
+    from schemas.dme_shipment import DMEShipment
+    db_session.expire_all()
+    assert db_session.query(DMEShipment).filter(DMEShipment.id == theirs).first() is not None
+
+
+def test_add_item_across_accounts_does_not_apply(admin_client, other_client, other_patient):
+    theirs = _make_shipment(other_client, other_patient)
+    resp = admin_client.post(f"/api/shipments/{theirs}/items",
+                             json={"item_description": "Injected", "qty_ordered": 1})
+    assert resp.json().get("success") is not True
+    assert other_client.get(f"/api/shipments/{theirs}").json()["items"] == []
+
+
+def test_finalize_across_accounts_does_not_apply(admin_client, other_client, other_patient):
+    theirs = _make_shipment(other_client, other_patient)
+    resp = admin_client.post(f"/api/shipments/{theirs}/finalize")
+    assert resp.json().get("success") is not True
+    assert other_client.get(f"/api/shipments/{theirs}").json()["finalized_at"] is None
+
+
+# --- Item routes: the shipment id in the path is now enforced ----------------
+
+def test_item_update_cannot_reach_another_shipments_line(
+    admin_client, other_client, patient, other_patient
+):
+    """The classic shape: name a shipment you own, an item you do not."""
+    theirs = _make_shipment(other_client, other_patient)
+    their_item = _add_item(other_client, theirs)
+    mine = _make_shipment(admin_client, patient)
+
+    admin_client.put(f"/api/shipments/{mine}/items/{their_item}",
+                     json={"item_description": "Rewritten"})
+
+    items = other_client.get(f"/api/shipments/{theirs}").json()["items"]
+    assert items[0]["item_description"] == "Tubing"
+
+
+def test_item_delete_cannot_reach_another_shipments_line(
+    admin_client, other_client, patient, other_patient
+):
+    theirs = _make_shipment(other_client, other_patient)
+    their_item = _add_item(other_client, theirs)
+    mine = _make_shipment(admin_client, patient)
+
+    admin_client.delete(f"/api/shipments/{mine}/items/{their_item}")
+    assert len(other_client.get(f"/api/shipments/{theirs}").json()["items"]) == 1
+
+
+def test_receive_cannot_reach_another_shipments_line(
+    admin_client, other_client, patient, other_patient
+):
+    """Receiving writes to inventory, so this one moved stock, not just rows."""
+    theirs = _make_shipment(other_client, other_patient)
+    their_item = _add_item(other_client, theirs)
+    mine = _make_shipment(admin_client, patient)
+
+    resp = admin_client.post(f"/api/shipments/{mine}/receive",
+                             json=[{"shipment_item_id": their_item, "qty_received": 5}])
+    assert all(r["success"] is False for r in resp.json()["results"])
+
+    items = other_client.get(f"/api/shipments/{theirs}").json()["items"]
+    assert items[0]["qty_received"] == 0
+
+
+def test_receipts_cannot_be_read_through_another_shipment(
+    admin_client, other_client, patient, other_patient
+):
+    theirs = _make_shipment(other_client, other_patient)
+    their_item = _add_item(other_client, theirs)
+    other_client.post(f"/api/shipments/{theirs}/receive",
+                      json=[{"shipment_item_id": their_item, "qty_received": 5}])
+    mine = _make_shipment(admin_client, patient)
+
+    body = admin_client.get(f"/api/shipments/{mine}/items/{their_item}/receipts").json()
+    assert body["receipts"] == []
+    assert body["totals"]["total"] == 0
+
+
+# --- Same-account behaviour is unchanged -------------------------------------
+
+def test_own_items_still_work_through_their_own_shipment(admin_client, patient):
+    sid = _make_shipment(admin_client, patient)
+    item = _add_item(admin_client, sid)
+
+    assert admin_client.put(f"/api/shipments/{sid}/items/{item}",
+                            json={"item_description": "Renamed"}).json()["success"] is True
+    resp = admin_client.post(f"/api/shipments/{sid}/receive",
+                             json=[{"shipment_item_id": item, "qty_received": 5}])
+    assert resp.json()["results"][0]["success"] is True
+
+    items = admin_client.get(f"/api/shipments/{sid}").json()["items"]
+    assert items[0]["item_description"] == "Renamed"
+    assert items[0]["qty_received"] == 5

--- a/backend/tests/test_dme_shipments_account_scope.py
+++ b/backend/tests/test_dme_shipments_account_scope.py
@@ -142,6 +142,13 @@ def test_alerts_exclude_other_accounts(admin_client, other_client, other_patient
 
 def test_shipment_alerts_by_id_across_accounts_is_empty(admin_client, other_client, other_patient):
     theirs = _make_shipment(other_client, other_patient)
+    item = _add_item(other_client, theirs)
+    # Give the shipment a real alert first, or an empty list proves nothing.
+    other_client.post(f"/api/shipments/{theirs}/receive",
+                      json=[{"shipment_item_id": item, "qty_received": 0}])
+    other_client.post(f"/api/shipments/{theirs}/finalize")
+    assert other_client.get(f"/api/shipments/{theirs}/alerts").json()["alerts"]
+
     assert admin_client.get(f"/api/shipments/{theirs}/alerts").json()["alerts"] == []
 
 


### PR DESCRIPTION
Shipments had no tenant boundary. `dme_shipments.account_id` has existed since accounts landed and is indexed, but nothing ever wrote it — `create_shipment` took no `account_id`, so every row in every install carries NULL — and no query in the module filtered on it.

All 26 endpoints have been permission-gated the whole time. What was missing sat behind the permission check: holding `shipments.read` was enough to read **any** account's shipments, items, alerts and packing slips by id, and `shipments.receive` enough to write into them.

Found while scoping the Deliveries UI rebuild; sent separately so it can be reviewed on its own rather than inside a large UI diff.

## The widest one

`GET /api/shipments/inventory` queries the equipment table with only a patient filter, while the equipment module filters the same table by account (`crud/equipment.py:281-282`). Same table, two rules — so the shipments route returned every account's supplies.

It keeps **equipment's** rule (`account_id == me OR account_id IS NULL`) rather than the shipment one, because equipment genuinely has shared rows and filtering it strictly would hide supplies the equipment page itself lists. The shipment tables use strict equality: a shipment belongs to a patient and a patient belongs to an account, so there is no such thing as a shared shipment.

## The item routes had to be fixed for the boundary to hold

`PUT`/`DELETE /{shipment_id}/items/{item_id}`, the receipts read, and `POST /{shipment_id}/receive` all take a shipment id **and** an item id in the path, but only ever used the item's. Naming a shipment you own alongside a line you don't was enough to edit, delete, or receive against it — and receiving adds to `Equipment.quantity`, so that path wrote to another account's inventory. Membership is now checked against the shipment named in the path. (`reconcile` already got this right; it was the one place that filtered on both.)

## Derived shipments inherit their origin

The backorder `finalize` creates, the follow-up order from alerts, a delivery off a standing order, and a copy all take the account of the shipment they came from rather than the caller's.

## Migration 046

Backfills existing rows from their patient — unambiguous, since `patient_id` is `NOT NULL` and the patient carries the account. Documents denormalize the same value and are corrected from their shipment. Rows whose patient has no account (a single-tenant install) stay NULL, which is what the query layer expects: a request with no account applies no filter.

It creates no index — `001_initial_schema:922` already indexed the column the module then never populated. `downgrade` is a no-op on purpose: the backfilled values are correct, and clearing them would re-open the gap.

## Also

`get_unresolved_alerts` is deleted rather than scoped — nothing referenced it, and leaving it would have left a second unscoped path into the alerts table.

## Notes for review

- **This is a live behaviour change for any multi-account install**: a user can no longer see or touch another account's shipments. Single-tenant installs are unaffected (no account on the request → no filter, the existing convention).
- System admins are scoped too. That matches how equipment already behaves; the boundary is account identity, not permission level.
- Patient-level authorization is still absent — any user with `shipments.read` can read any patient *within their own account*. Out of scope here; worth its own pass.

## Verification

Backend **646 pass**, 1 skipped (631 baseline + 15 new).

The new tests were checked against the unfixed code: **14 of the 15 fail without this change**, and the 15th is the same-account control that must pass either way. One of them (`alerts` by id) initially passed for the wrong reason — it asserted an empty list on a shipment with no alerts — and is fixed in the second commit to create a real alert first.

Migration verified separately: `upgrade → downgrade → upgrade` round-trips clean, and the backfill was run against a hand-built legacy row (shipment + document with NULL account) and populated both from the patient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
