### PR TITLE
Shipments rebuilt in the vc aesthetic

### DIFF
--- a/frontend/src/components/shipment/ReceiveReview.jsx
+++ b/frontend/src/components/shipment/ReceiveReview.jsx
@@ -1,0 +1,145 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Checking a delivery in: what arrived, and what is still coming.
+//
+// Seeded either from a packing-slip scan or from the order itself. Lines the
+// scan could not match by item number are shown separately, because guessing
+// silently is how a box of the wrong thing gets counted as the right thing --
+// each one is a decision (add it, count it toward a line we have, ignore it)
+// rather than something applied on the user's behalf.
+const CONDITIONS = [
+  { value: 'good', label: 'Good' },
+  { value: 'damaged', label: 'Damaged' },
+  { value: 'wrong_item', label: 'Wrong item' },
+];
+
+export default function ReceiveReview({
+  items = [],
+  extras = null,
+  shipmentItems = [],
+  saving,
+  onChangeItem,
+  onChangeExtra,
+  onRemoveExtra,
+  onCancel,
+  onSave,
+}) {
+  const num = (value) => (Number.isFinite(parseInt(value, 10)) ? parseInt(value, 10) : 0);
+  const totalArrived = items.reduce((sum, r) => sum + num(r.qty_received), 0);
+  const totalLater = items.reduce((sum, r) => sum + num(r.qty_backordered), 0);
+
+  return (
+    <div className="rr">
+      {extras && extras.length > 0 && (
+        <section className="rr-extras">
+          <h3 className="rr-sub">New on this slip ({extras.length})</h3>
+          <p className="sd-hint">
+            These lines did not match anything on the order by item number.
+          </p>
+          {extras.map((e) => (
+            <div key={e.key} className="rr-extra">
+              <input className="em-input" value={e.item_description}
+                     aria-label={`Description for scanned line ${e.item_number || e.key}`}
+                     onChange={(ev) => onChangeExtra(e.key, { item_description: ev.target.value })} />
+              <div className="rr-extra-row">
+                <label className="rr-mini">
+                  <span>Item #</span>
+                  <input className="em-input" value={e.item_number}
+                         onChange={(ev) => onChangeExtra(e.key, { item_number: ev.target.value })} />
+                </label>
+                <label className="rr-mini">
+                  <span>Arrived</span>
+                  <input className="em-input" type="number" min="0" value={e.qty_shipped}
+                         onChange={(ev) => onChangeExtra(e.key, { qty_shipped: ev.target.value })} />
+                </label>
+                <label className="rr-mini">
+                  <span>What to do</span>
+                  <select className="em-input" value={e.action}
+                          onChange={(ev) => onChangeExtra(e.key, { action: ev.target.value })}>
+                    <option value="new">Add as a new line</option>
+                    {shipmentItems.map((item) => (
+                      <option key={item.id} value={String(item.id)}>
+                        Count toward {item.item_description || item.item_number || `item ${item.id}`}
+                      </option>
+                    ))}
+                    <option value="skip">Ignore this line</option>
+                  </select>
+                </label>
+                <button type="button" className="sh-btn ghost"
+                        onClick={() => onRemoveExtra(e.key)}>Remove</button>
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      <h3 className="rr-sub">Check the numbers</h3>
+      <div className="rr-rows">
+        {items.map((r) => (
+          <div key={r.shipment_item_id} className="rr-row">
+            <div className="rr-row-head">
+              <span className="rr-label">{r.label}</span>
+              {r.matched && (
+                <span className="rr-tag">
+                  {r.matched === 'barcode' ? 'Scanned' : 'Read from slip'}
+                </span>
+              )}
+            </div>
+            <div className="rr-fields">
+              <label className="rr-mini">
+                <span>Ordered</span>
+                <input className="em-input" value={r.qty_ordered ?? 0} readOnly tabIndex={-1} />
+              </label>
+              <label className="rr-mini">
+                <span>Arrived</span>
+                <input className="em-input" type="number" min="0" value={r.qty_received}
+                       onChange={(e) => onChangeItem(r.shipment_item_id, 'qty_received', e.target.value)} />
+              </label>
+              <label className="rr-mini">
+                <span>Coming later</span>
+                <input className="em-input" type="number" min="0" value={r.qty_backordered}
+                       onChange={(e) => onChangeItem(r.shipment_item_id, 'qty_backordered', e.target.value)} />
+              </label>
+              <label className="rr-mini">
+                <span>Condition</span>
+                <select className="em-input" value={r.condition || 'good'}
+                        onChange={(e) => onChangeItem(r.shipment_item_id, 'condition', e.target.value)}>
+                  {CONDITIONS.map((c) => (
+                    <option key={c.value} value={c.value}>{c.label}</option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="sd-foot">
+        <span className="sd-foot-count">
+          {totalArrived} arrived{totalLater > 0 ? ` · ${totalLater} to follow` : ''}
+        </span>
+        <div className="sd-actions">
+          <button type="button" className="sh-btn ghost" onClick={onCancel}>Cancel</button>
+          <button type="button" className="sh-btn primary" disabled={saving} onClick={onSave}>
+            {saving ? 'Saving…' : 'Record this delivery'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shipment/ShipmentCard.jsx
+++ b/frontend/src/components/shipment/ShipmentCard.jsx
@@ -1,0 +1,131 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// One shipment on the Deliveries list, from the mockup:
+//
+//   #78711852                              (SHIPPED)
+//   PEDIATRIC HOME SERVICE
+//   EXPECTED     TRACKING        ITEMS
+//   AUG 21       1Z84…392        14
+//   ●───────●───────◉───────○
+//   BUILT   ORDERED  SHIPPED  RECEIVED
+//   TRACK PACKAGE                         ›
+//
+// The three facts under the heading change with where the shipment is, since
+// a draft has no tracking to show and a finished one has no date to wait for.
+import { useEffect, useRef, useState } from 'react';
+import { MoreVerticalIcon, ChevronRightIcon } from '../Icons';
+import { statusInfo, stepStates, needsAttention } from '../../lib/shipmentStatus';
+import './shipment-card.css';
+
+/** The progress rail. Decorative — the status pill already states the state. */
+function StepRail({ shipment }) {
+  const steps = stepStates(shipment);
+  return (
+    <div className="sc-rail" aria-hidden="true">
+      {steps.map((step, i) => (
+        <div key={step.label} className={`sc-step is-${step.state}`}>
+          {i > 0 && <span className="sc-rail-line" />}
+          <span className="sc-rail-node" />
+          <span className="sc-step-label">{step.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function ShipmentCard({
+  shipment,
+  supplierName,
+  details = [],   // [{ label, value }] — three at most, the mockup's grid
+  action,         // { label, onClick } — the footer row
+  menu = [],      // [{ label, onClick, danger? }]
+  showRail = true,
+  onOpen,
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+  const info = statusInfo(shipment.status);
+  const attention = needsAttention(shipment);
+
+  useEffect(() => {
+    if (!menuOpen) return undefined;
+    const close = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) setMenuOpen(false);
+    };
+    document.addEventListener('pointerdown', close);
+    return () => document.removeEventListener('pointerdown', close);
+  }, [menuOpen]);
+
+  const heading = shipment.order_number || shipment.po_number || `#${shipment.id}`;
+
+  return (
+    <article className={`sc-card tone-${info.tone} ${attention ? 'needs-attention' : ''}`}>
+      <header className="sc-head">
+        <div className="sc-head-text">
+          <button type="button" className="sc-title" onClick={onOpen}>
+            {heading}
+          </button>
+          {supplierName && <p className="sc-supplier">{supplierName}</p>}
+        </div>
+        <div className="sc-head-right">
+          <span className={`sc-status tone-${info.tone}`}>{info.label}</span>
+          {menu.length > 0 && (
+            <div className="sc-menu-wrap" ref={menuRef}>
+              <button type="button" className="sc-kebab" aria-label={`Actions for ${heading}`}
+                      aria-haspopup="menu" aria-expanded={menuOpen}
+                      onClick={() => setMenuOpen((v) => !v)}>
+                <MoreVerticalIcon size={18} />
+              </button>
+              {menuOpen && (
+                <div className="sc-menu" role="menu">
+                  {menu.map((item) => (
+                    <button key={item.label} type="button" role="menuitem"
+                            className={`sc-menu-item ${item.danger ? 'danger' : ''}`}
+                            onClick={() => { setMenuOpen(false); item.onClick(); }}>
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </header>
+
+      {details.length > 0 && (
+        <dl className="sc-details">
+          {details.map((d) => (
+            <div key={d.label} className="sc-detail">
+              <dt>{d.label}</dt>
+              <dd>{d.value ?? '—'}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      {showRail && <StepRail shipment={shipment} />}
+
+      {action && (
+        <button type="button" className="sc-action" onClick={action.onClick}>
+          <span>{action.label}</span>
+          <ChevronRightIcon size={16} />
+        </button>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/components/shipment/ShipmentCard.test.jsx
+++ b/frontend/src/components/shipment/ShipmentCard.test.jsx
@@ -1,0 +1,123 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ShipmentCard from './ShipmentCard';
+import ShipmentItemCard from './ShipmentItemCard';
+
+const shipment = { id: 7, order_number: '78711852', status: 'shipped', item_count: 14 };
+
+describe('ShipmentCard', () => {
+  it('shows the status the server reported, not a guess', () => {
+    render(<ShipmentCard shipment={{ ...shipment, status: 'receiving' }} />);
+    expect(screen.getByText('Receiving')).toBeInTheDocument();
+  });
+
+  it('renders complete as Received, which is what the user calls it', () => {
+    // "Received" is also the rail's last step, so assert on the status pill.
+    const { container } = render(<ShipmentCard shipment={{ ...shipment, status: 'complete' }} />);
+    expect(container.querySelector('.sc-status').textContent).toBe('Received');
+  });
+
+  it('falls back to the id when there is no order or PO number', () => {
+    render(<ShipmentCard shipment={{ id: 42, status: 'draft' }} />);
+    expect(screen.getByRole('button', { name: '#42' })).toBeInTheDocument();
+  });
+
+  it('renders an em dash for a detail with no value', () => {
+    // A blank cell reads as a loading failure; the dash says "not set".
+    render(<ShipmentCard shipment={shipment}
+                         details={[{ label: 'Tracking', value: null }]} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('flags a partial delivery as needing attention', () => {
+    const { container } = render(<ShipmentCard shipment={{ ...shipment, status: 'partial' }} />);
+    expect(container.querySelector('.needs-attention')).toBeTruthy();
+  });
+
+  it('flags unresolved alerts even when the delivery completed', () => {
+    const { container } = render(
+      <ShipmentCard shipment={{ ...shipment, status: 'complete', unresolved_alert_count: 1 }} />,
+    );
+    expect(container.querySelector('.needs-attention')).toBeTruthy();
+  });
+
+  it('opens from the heading and from the footer action', () => {
+    const onOpen = vi.fn();
+    const action = { label: 'Track package', onClick: vi.fn() };
+    render(<ShipmentCard shipment={shipment} onOpen={onOpen} action={action} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '78711852' }));
+    expect(onOpen).toHaveBeenCalled();
+    fireEvent.click(screen.getByText('Track package'));
+    expect(action.onClick).toHaveBeenCalled();
+  });
+
+  it('hides the kebab when there is nothing in it', () => {
+    render(<ShipmentCard shipment={shipment} menu={[]} />);
+    expect(screen.queryByLabelText(/Actions for/)).not.toBeInTheDocument();
+  });
+});
+
+describe('ShipmentItemCard', () => {
+  const item = {
+    id: 1, item_description: 'Trach suction catheter', item_number: '14FR-100',
+    qty_ordered: 30, qty_received: 0, receipts: [],
+  };
+
+  it('distinguishes nothing-recorded from a recorded zero', () => {
+    render(<ShipmentItemCard index={1} item={item} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+
+    render(<ShipmentItemCard index={1}
+                             item={{ ...item, qty_received: 0, receipts: [{ id: 9 }] }} />);
+    expect(screen.getAllByText('0').length).toBeGreaterThan(0);
+  });
+
+  it('offers the stepper only while the list is editable', () => {
+    const { rerender } = render(<ShipmentItemCard index={1} item={item} />);
+    expect(screen.queryByLabelText(/One more/)).not.toBeInTheDocument();
+
+    rerender(<ShipmentItemCard index={1} item={item} editableQty onQtyChange={vi.fn()} />);
+    expect(screen.getByLabelText(/One more/)).toBeInTheDocument();
+  });
+
+  it('steps the quantity up and down', () => {
+    const onQtyChange = vi.fn();
+    render(<ShipmentItemCard index={1} item={item} editableQty onQtyChange={onQtyChange} />);
+
+    fireEvent.click(screen.getByLabelText(/One more/));
+    expect(onQtyChange).toHaveBeenCalledWith(31);
+    fireEvent.click(screen.getByLabelText(/One fewer/));
+    expect(onQtyChange).toHaveBeenCalledWith(29);
+  });
+
+  it('never steps below zero', () => {
+    const onQtyChange = vi.fn();
+    render(<ShipmentItemCard index={1} item={{ ...item, qty_ordered: 0 }}
+                             editableQty onQtyChange={onQtyChange} />);
+    expect(screen.getByLabelText(/One fewer/)).toBeDisabled();
+  });
+
+  it('shows what is still to follow', () => {
+    render(<ShipmentItemCard index={1} item={{ ...item, qty_backordered: 6 }} />);
+    expect(screen.getByText('To follow')).toBeInTheDocument();
+    expect(screen.getByText('6')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/shipment/ShipmentDetailsModal.jsx
+++ b/frontend/src/components/shipment/ShipmentDetailsModal.jsx
@@ -1,0 +1,146 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The shipment's own details — supplier, the two reference numbers, dates,
+// tracking. One form for both creating a shipment and the detail page's
+// "Edit details", which previously were separate: a dialog on the list page
+// and five inline blur-to-save inputs on the detail page, so the same field
+// validated differently depending on where you typed it.
+import { useEffect, useState } from 'react';
+import EntityModal, { EmField, EmRow, EmSelect } from '../vc/EntityModal';
+
+const EMPTY = {
+  supplier_id: '',
+  po_number: '',
+  order_number: '',
+  ship_date: '',
+  expected_delivery: '',
+  tracking_number: '',
+  ship_method: '',
+  notes: '',
+};
+
+/** ISO timestamp -> the yyyy-mm-dd a date input wants. */
+const asDateValue = (value) => (value ? String(value).slice(0, 10) : '');
+
+const fromShipment = (shipment) => (shipment ? {
+  supplier_id: shipment.supplier_id ? String(shipment.supplier_id) : '',
+  po_number: shipment.po_number || '',
+  order_number: shipment.order_number || '',
+  ship_date: asDateValue(shipment.ship_date),
+  expected_delivery: asDateValue(shipment.expected_delivery),
+  tracking_number: shipment.tracking_number || '',
+  ship_method: shipment.ship_method || '',
+  notes: shipment.notes || '',
+} : { ...EMPTY });
+
+export default function ShipmentDetailsModal({
+  open, onOpenChange, shipment = null, suppliers = [], saving, onSave,
+}) {
+  const [form, setForm] = useState(EMPTY);
+  const [error, setError] = useState(null);
+  const editing = Boolean(shipment);
+
+  useEffect(() => {
+    if (!open) return;
+    setForm(fromShipment(shipment));
+    setError(null);
+  }, [open, shipment]);
+
+  const set = (field) => (event) => setForm((f) => ({ ...f, [field]: event.target.value }));
+
+  const submit = async (event) => {
+    event.preventDefault();
+    setError(null);
+    // Blank means "no value", not the empty string — the API stores what it
+    // is given, and "" would read as a PO number that is present but empty.
+    const payload = Object.fromEntries(
+      Object.entries(form).map(([k, v]) => [k, v === '' ? null : v]),
+    );
+    payload.supplier_id = form.supplier_id ? parseInt(form.supplier_id, 10) : null;
+    try {
+      await onSave(payload);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <EntityModal open={open} onOpenChange={onOpenChange}
+                 title={editing ? 'Edit details' : 'New shipment'} wide>
+      <form className="em-form" onSubmit={submit}>
+        {error && <div className="em-error">{error}</div>}
+
+        <EmField label="Supplier" htmlFor="sd-supplier">
+          <EmSelect id="sd-supplier" value={form.supplier_id} onChange={set('supplier_id')}>
+            <option value="">No supplier</option>
+            {suppliers.map((s) => (
+              <option key={s.id} value={String(s.id)}>{s.name}</option>
+            ))}
+          </EmSelect>
+        </EmField>
+
+        <EmRow>
+          <EmField label="PO number" optional htmlFor="sd-po">
+            <input id="sd-po" className="em-input" value={form.po_number}
+                   onChange={set('po_number')} placeholder="e.g. 55811" />
+          </EmField>
+          <EmField label="Order number" optional htmlFor="sd-order">
+            <input id="sd-order" className="em-input" value={form.order_number}
+                   onChange={set('order_number')} placeholder="e.g. 1099274055" />
+          </EmField>
+        </EmRow>
+
+        <EmRow>
+          <EmField label="Ship date" optional htmlFor="sd-shipped">
+            <input id="sd-shipped" type="date" className="em-input"
+                   value={form.ship_date} onChange={set('ship_date')} />
+          </EmField>
+          <EmField label="Expected delivery" optional htmlFor="sd-expected">
+            <input id="sd-expected" type="date" className="em-input"
+                   value={form.expected_delivery} onChange={set('expected_delivery')} />
+          </EmField>
+        </EmRow>
+
+        <EmRow>
+          <EmField label="Tracking number" optional htmlFor="sd-tracking">
+            <input id="sd-tracking" className="em-input" value={form.tracking_number}
+                   onChange={set('tracking_number')} />
+          </EmField>
+          <EmField label="Ship method" optional htmlFor="sd-method">
+            <input id="sd-method" className="em-input" value={form.ship_method}
+                   onChange={set('ship_method')} placeholder="e.g. FedEx Ground" />
+          </EmField>
+        </EmRow>
+
+        <EmField label="Notes" optional htmlFor="sd-notes">
+          <textarea id="sd-notes" className="em-input" rows={2}
+                    value={form.notes} onChange={set('notes')} />
+        </EmField>
+
+        <div className="em-footer">
+          <button type="button" className="em-cancel" onClick={() => onOpenChange(false)}>
+            Cancel
+          </button>
+          <button type="submit" className="em-submit" disabled={saving}>
+            {saving ? 'Saving…' : (editing ? 'Save details' : 'Create shipment')}
+          </button>
+        </div>
+      </form>
+    </EntityModal>
+  );
+}

--- a/frontend/src/components/shipment/ShipmentItemCard.jsx
+++ b/frontend/src/components/shipment/ShipmentItemCard.jsx
@@ -1,0 +1,143 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// One line on a shipment, from the mockup:
+//
+//   [1]  TRACH SUCTION CATHETER            ⋮
+//        SKU 14FR-100                 [−] 30 [+]
+//        CATEGORY AIRWAY
+//        ─────────────────────
+//        EXPECTED   RECEIVED
+//        30         —
+//
+// The stepper edits the ordered quantity while the list is still being built.
+// Once the shipment is placed the number stops being editable, because by
+// then it is a claim about what the supplier sent rather than what we asked
+// for -- that correction belongs to the receive step.
+import { useEffect, useRef, useState } from 'react';
+import { MoreVerticalIcon, PlusIcon, MinusIcon } from '../Icons';
+import './shipment-card.css';
+
+export default function ShipmentItemCard({
+  index,
+  item,
+  editableQty = false,
+  onQtyChange,
+  menu = [],
+  onOpen,
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    if (!menuOpen) return undefined;
+    const close = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) setMenuOpen(false);
+    };
+    document.addEventListener('pointerdown', close);
+    return () => document.removeEventListener('pointerdown', close);
+  }, [menuOpen]);
+
+  const name = item.item_description || item.equipment_name || item.item_number || `Item ${item.id}`;
+  const ordered = item.qty_ordered ?? 0;
+  const received = item.qty_received ?? 0;
+  const hasReceipts = (item.receipts || []).length > 0;
+
+  const step = (delta) => onQtyChange?.(Math.max(0, ordered + delta));
+
+  return (
+    <article className="si-card">
+      <span className="si-index" aria-hidden="true">{index}</span>
+
+      <div className="si-body">
+        <div className="si-head">
+          <button type="button" className="si-name" onClick={onOpen} disabled={!onOpen}>
+            {name}
+          </button>
+          {menu.length > 0 && (
+            <div className="si-menu-wrap" ref={menuRef}>
+              <button type="button" className="si-kebab" aria-label={`Actions for ${name}`}
+                      aria-haspopup="menu" aria-expanded={menuOpen}
+                      onClick={() => setMenuOpen((v) => !v)}>
+                <MoreVerticalIcon size={16} />
+              </button>
+              {menuOpen && (
+                <div className="si-menu" role="menu">
+                  {menu.map((entry) => (
+                    <button key={entry.label} type="button" role="menuitem"
+                            className={`si-menu-item ${entry.danger ? 'danger' : ''}`}
+                            onClick={() => { setMenuOpen(false); entry.onClick(); }}>
+                      {entry.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <dl className="si-meta">
+          {item.item_number && (
+            <div><dt>SKU</dt><dd>{item.item_number}</dd></div>
+          )}
+          {item.manufacturer_name && (
+            <div><dt>Maker</dt><dd>{item.manufacturer_name}</dd></div>
+          )}
+          {item.unit_of_measure && (
+            <div><dt>Unit</dt><dd>{item.unit_of_measure}</dd></div>
+          )}
+        </dl>
+
+        <div className="si-numbers">
+          <div className="si-number">
+            <span className="si-number-label">Expected</span>
+            <span className="si-number-value">{ordered}</span>
+          </div>
+          <div className="si-number">
+            <span className="si-number-label">Received</span>
+            {/* An em dash means "nothing recorded yet", which is not the same
+                claim as a recorded zero. */}
+            <span className={`si-number-value ${received ? 'is-in' : ''}`}>
+              {hasReceipts ? received : '—'}
+            </span>
+          </div>
+          {item.qty_backordered > 0 && (
+            <div className="si-number">
+              <span className="si-number-label">To follow</span>
+              <span className="si-number-value is-due">{item.qty_backordered}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {editableQty && (
+        <div className="si-stepper">
+          <button type="button" onClick={() => step(-1)} disabled={ordered <= 0}
+                  aria-label={`One fewer ${name}`}>
+            <MinusIcon size={15} />
+          </button>
+          <input type="number" min="0" value={ordered}
+                 aria-label={`Quantity of ${name}`}
+                 onChange={(e) => onQtyChange?.(Math.max(0, parseInt(e.target.value, 10) || 0))} />
+          <button type="button" onClick={() => step(1)} aria-label={`One more ${name}`}>
+            <PlusIcon size={15} />
+          </button>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/components/shipment/ShipmentItemSheet.jsx
+++ b/frontend/src/components/shipment/ShipmentItemSheet.jsx
@@ -1,0 +1,178 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Add or edit one line on a shipment.
+//
+// Linking the line to one of our supplies fills the identifying fields from
+// it, so the same catheter is not typed three different ways across three
+// months of deliveries.
+import { useEffect, useState } from 'react';
+import EntityModal, { EmField, EmRow, EmSelect } from '../vc/EntityModal';
+
+const EMPTY = {
+  equipment_id: '',
+  item_number: '',
+  item_description: '',
+  manufacturer_name: '',
+  qty_ordered: 1,
+  qty_shipped: 0,
+  qty_backordered: 0,
+  unit_of_measure: '',
+  unit_description: '',
+};
+
+const fromItem = (item) => (item ? {
+  equipment_id: item.equipment_id ? String(item.equipment_id) : '',
+  item_number: item.item_number || '',
+  item_description: item.item_description || '',
+  manufacturer_name: item.manufacturer_name || '',
+  qty_ordered: item.qty_ordered ?? 0,
+  qty_shipped: item.qty_shipped ?? 0,
+  qty_backordered: item.qty_backordered ?? 0,
+  unit_of_measure: item.unit_of_measure || '',
+  unit_description: item.unit_description || '',
+} : { ...EMPTY });
+
+export default function ShipmentItemSheet({
+  open, onOpenChange, item = null, equipment = [], onSave,
+}) {
+  const [form, setForm] = useState(EMPTY);
+  const [error, setError] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const editing = Boolean(item);
+
+  useEffect(() => {
+    if (!open) return;
+    setForm(fromItem(item));
+    setError(null);
+  }, [open, item]);
+
+  const set = (field) => (event) => setForm((f) => ({ ...f, [field]: event.target.value }));
+
+  // Picking a supply carries its identifiers across; typing over them
+  // afterwards is still allowed, since a supplier can relabel the same thing.
+  const pickEquipment = (event) => {
+    const value = event.target.value;
+    const eq = equipment.find((e) => String(e.id) === value);
+    setForm((f) => ({
+      ...f,
+      equipment_id: value,
+      ...(eq ? {
+        item_number: eq.item_number || f.item_number,
+        item_description: f.item_description || eq.name || '',
+        manufacturer_name: eq.default_manufacturer || f.manufacturer_name,
+        unit_of_measure: eq.unit_of_measure || f.unit_of_measure,
+        unit_description: eq.unit_description || f.unit_description,
+      } : {}),
+    }));
+  };
+
+  const canSave = String(form.item_description || '').trim() || form.equipment_id;
+
+  const submit = async (event) => {
+    event.preventDefault();
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave({
+        equipment_id: form.equipment_id ? parseInt(form.equipment_id, 10) : null,
+        item_number: form.item_number.trim() || null,
+        item_description: form.item_description.trim() || null,
+        manufacturer_name: form.manufacturer_name.trim() || null,
+        qty_ordered: parseInt(form.qty_ordered, 10) || 0,
+        qty_shipped: parseInt(form.qty_shipped, 10) || 0,
+        qty_backordered: parseInt(form.qty_backordered, 10) || 0,
+        unit_of_measure: form.unit_of_measure.trim() || null,
+        unit_description: form.unit_description.trim() || null,
+      });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <EntityModal open={open} onOpenChange={onOpenChange}
+                 title={editing ? 'Edit item' : 'Add item'} wide>
+      <form className="em-form" onSubmit={submit}>
+        {error && <div className="em-error">{error}</div>}
+
+        <EmField label="Our supply" optional htmlFor="si-equipment">
+          <EmSelect id="si-equipment" value={form.equipment_id} onChange={pickEquipment}>
+            <option value="">Not linked</option>
+            {equipment.map((e) => (
+              <option key={e.id} value={String(e.id)}>{e.name}</option>
+            ))}
+          </EmSelect>
+        </EmField>
+
+        <EmField label="Description" required htmlFor="si-desc">
+          <input id="si-desc" className="em-input" value={form.item_description}
+                 onChange={set('item_description')} placeholder="What the supplier calls it" />
+        </EmField>
+
+        <EmRow>
+          <EmField label="Item number" optional htmlFor="si-number">
+            <input id="si-number" className="em-input" value={form.item_number}
+                   onChange={set('item_number')} />
+          </EmField>
+          <EmField label="Manufacturer" optional htmlFor="si-maker">
+            <input id="si-maker" className="em-input" value={form.manufacturer_name}
+                   onChange={set('manufacturer_name')} />
+          </EmField>
+        </EmRow>
+
+        <EmRow>
+          <EmField label="Ordered" htmlFor="si-ordered">
+            <input id="si-ordered" className="em-input" type="number" min="0"
+                   value={form.qty_ordered} onChange={set('qty_ordered')} />
+          </EmField>
+          <EmField label="Shipped" optional htmlFor="si-shipped">
+            <input id="si-shipped" className="em-input" type="number" min="0"
+                   value={form.qty_shipped} onChange={set('qty_shipped')} />
+          </EmField>
+          <EmField label="To follow" optional htmlFor="si-bo">
+            <input id="si-bo" className="em-input" type="number" min="0"
+                   value={form.qty_backordered} onChange={set('qty_backordered')} />
+          </EmField>
+        </EmRow>
+
+        <EmRow>
+          <EmField label="Unit" optional htmlFor="si-uom">
+            <input id="si-uom" className="em-input" value={form.unit_of_measure}
+                   onChange={set('unit_of_measure')} placeholder="EA, BX, PK…" />
+          </EmField>
+          <EmField label="Unit description" optional htmlFor="si-udesc">
+            <input id="si-udesc" className="em-input" value={form.unit_description}
+                   onChange={set('unit_description')} placeholder="e.g. BX = 100 EA" />
+          </EmField>
+        </EmRow>
+
+        <div className="em-footer">
+          <button type="button" className="em-cancel" onClick={() => onOpenChange(false)}>
+            Cancel
+          </button>
+          <button type="submit" className="em-submit" disabled={!canSave || saving}>
+            {saving ? 'Saving…' : (editing ? 'Save item' : 'Add item')}
+          </button>
+        </div>
+      </form>
+    </EntityModal>
+  );
+}

--- a/frontend/src/components/shipment/shipment-card.css
+++ b/frontend/src/components/shipment/shipment-card.css
@@ -294,3 +294,197 @@
   outline: 2px solid var(--vc-data-live);
   outline-offset: -2px;
 }
+
+/* --- item card (shipment detail) --- */
+
+:root:not(.light) .si-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 9px;
+}
+
+:root:not(.light) .si-index {
+  display: grid;
+  place-content: center;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 6px;
+  font-family: var(--vc-font-mono);
+  font-size: 0.75rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .si-body { flex: 1; min-width: 0; }
+
+:root:not(.light) .si-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+:root:not(.light) .si-name {
+  flex: 1;
+  padding: 0;
+  background: none;
+  border: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: left;
+  color: var(--vc-text-primary);
+  cursor: pointer;
+}
+:root:not(.light) .si-name:disabled { cursor: default; }
+:root:not(.light) .si-name:not(:disabled):hover { color: var(--vc-data-live); }
+
+:root:not(.light) .si-kebab {
+  display: grid;
+  place-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: 6px;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+:root:not(.light) .si-kebab:hover {
+  background: color-mix(in srgb, var(--vc-text-primary) 8%, transparent);
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .si-menu-wrap { position: relative; }
+
+:root:not(.light) .si-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 20;
+  min-width: 170px;
+  padding: 4px;
+  background: var(--vc-bg-raised);
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+:root:not(.light) .si-menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 10px;
+  background: none;
+  border: 0;
+  border-radius: 5px;
+  font-size: 0.85rem;
+  text-align: left;
+  color: var(--vc-text-primary);
+  cursor: pointer;
+}
+:root:not(.light) .si-menu-item:hover {
+  background: color-mix(in srgb, var(--vc-text-primary) 8%, transparent);
+}
+:root:not(.light) .si-menu-item.danger { color: var(--vc-state-alert); }
+
+:root:not(.light) .si-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  margin: 4px 0 0;
+}
+:root:not(.light) .si-meta > div { display: flex; gap: 6px; align-items: baseline; }
+:root:not(.light) .si-meta dt {
+  font-size: 0.62rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .si-meta dd {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.78rem;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .si-numbers {
+  display: flex;
+  gap: 22px;
+  margin-top: 9px;
+  padding-top: 9px;
+  border-top: 1px solid var(--vc-line-hairline);
+}
+
+:root:not(.light) .si-number { display: flex; flex-direction: column; gap: 2px; }
+
+:root:not(.light) .si-number-label {
+  font-size: 0.6rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .si-number-value {
+  font-family: var(--vc-font-mono);
+  font-size: 0.92rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .si-number-value.is-in { color: var(--vc-state-complete); }
+:root:not(.light) .si-number-value.is-due { color: var(--vc-state-due); }
+
+/* --- quantity stepper --- */
+
+:root:not(.light) .si-stepper {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+:root:not(.light) .si-stepper button {
+  display: grid;
+  place-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--vc-data-live);
+  border-radius: 7px;
+  color: var(--vc-data-live);
+  cursor: pointer;
+}
+:root:not(.light) .si-stepper button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--vc-data-live) 15%, transparent);
+}
+:root:not(.light) .si-stepper button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+:root:not(.light) .si-stepper input {
+  width: 46px;
+  padding: 6px 2px;
+  background: none;
+  border: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 1.15rem;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  color: var(--vc-text-primary);
+  -moz-appearance: textfield;
+}
+:root:not(.light) .si-stepper input::-webkit-outer-spin-button,
+:root:not(.light) .si-stepper input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+:root:not(.light) .si-stepper input:focus {
+  outline: 2px solid var(--vc-data-live);
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/frontend/src/components/shipment/shipment-card.css
+++ b/frontend/src/components/shipment/shipment-card.css
@@ -1,0 +1,296 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Shipment cards and the shipments list chrome. Dark-only, like the rest of
+ * the vc skin — the pages scope themselves to :root:not(.light). */
+
+:root:not(.light) .sc-card {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  padding: 14px 16px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+:root:not(.light) .sc-card.needs-attention {
+  border-color: color-mix(in srgb, var(--vc-state-due) 45%, transparent);
+}
+
+/* --- head --- */
+
+:root:not(.light) .sc-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+:root:not(.light) .sc-head-text { flex: 1; min-width: 0; }
+
+:root:not(.light) .sc-title {
+  background: none;
+  border: 0;
+  padding: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--vc-data-live);
+  cursor: pointer;
+  text-align: left;
+  word-break: break-all;
+}
+
+:root:not(.light) .sc-card.tone-due .sc-title { color: var(--vc-state-due); }
+:root:not(.light) .sc-card.tone-complete .sc-title { color: var(--vc-state-complete); }
+:root:not(.light) .sc-card.tone-idle .sc-title { color: var(--vc-text-secondary); }
+
+:root:not(.light) .sc-title:hover { text-decoration: underline; }
+:root:not(.light) .sc-title:focus-visible {
+  outline: 2px solid var(--vc-data-live);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+:root:not(.light) .sc-supplier {
+  margin: 2px 0 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .sc-head-right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+:root:not(.light) .sc-status {
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+/* Filled for states that are moving or done; outlined for a draft, which is
+ * a state the user still owns rather than one the supplier reports. */
+:root:not(.light) .sc-status.tone-accent {
+  background: var(--vc-data-live);
+  color: var(--vc-bg-base);
+}
+:root:not(.light) .sc-status.tone-complete {
+  background: var(--vc-state-complete);
+  color: var(--vc-bg-base);
+}
+:root:not(.light) .sc-status.tone-due {
+  background: transparent;
+  color: var(--vc-state-due);
+  border: 1px solid var(--vc-state-due);
+}
+:root:not(.light) .sc-status.tone-idle {
+  background: transparent;
+  color: var(--vc-text-tertiary);
+  border: 1px solid var(--vc-line-strong);
+}
+
+/* --- kebab --- */
+
+:root:not(.light) .sc-menu-wrap { position: relative; }
+
+:root:not(.light) .sc-kebab {
+  display: grid;
+  place-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: 6px;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+:root:not(.light) .sc-kebab:hover {
+  background: color-mix(in srgb, var(--vc-text-primary) 8%, transparent);
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .sc-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 20;
+  min-width: 180px;
+  padding: 4px;
+  background: var(--vc-bg-raised);
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+:root:not(.light) .sc-menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 10px;
+  background: none;
+  border: 0;
+  border-radius: 5px;
+  font-size: 0.85rem;
+  text-align: left;
+  color: var(--vc-text-primary);
+  cursor: pointer;
+}
+:root:not(.light) .sc-menu-item:hover {
+  background: color-mix(in srgb, var(--vc-text-primary) 8%, transparent);
+}
+:root:not(.light) .sc-menu-item.danger { color: var(--vc-state-alert); }
+
+/* --- detail grid --- */
+
+:root:not(.light) .sc-details {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin: 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--vc-line-hairline);
+}
+
+:root:not(.light) .sc-detail dt {
+  font-size: 0.64rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .sc-detail dd {
+  margin: 3px 0 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.9rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--vc-text-primary);
+  overflow-wrap: anywhere;
+}
+
+/* The last column reads right-aligned in the mockup, which keeps the numbers
+ * off the card edge without a second grid. */
+:root:not(.light) .sc-detail:last-child { text-align: right; }
+
+/* --- progress rail --- */
+
+:root:not(.light) .sc-rail {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  padding-top: 12px;
+  border-top: 1px solid var(--vc-line-hairline);
+}
+
+:root:not(.light) .sc-step {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+:root:not(.light) .sc-rail-node {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--vc-state-idle);
+  background: var(--vc-bg-surface);
+}
+
+:root:not(.light) .sc-step.is-done .sc-rail-node {
+  border-color: var(--vc-data-live);
+  background: var(--vc-data-live);
+}
+
+/* The current step reads as a ring, so "here" is distinguishable from
+ * "finished" without relying on the fill colour alone. */
+:root:not(.light) .sc-step.is-current .sc-rail-node {
+  border-color: var(--vc-data-live);
+  background: var(--vc-bg-surface);
+  box-shadow: inset 0 0 0 2px var(--vc-data-live);
+}
+
+:root:not(.light) .sc-rail-line {
+  position: absolute;
+  top: 5px;
+  right: 50%;
+  width: 100%;
+  height: 2px;
+  background: var(--vc-state-idle);
+}
+
+:root:not(.light) .sc-step.is-done .sc-rail-line,
+:root:not(.light) .sc-step.is-current .sc-rail-line {
+  background: var(--vc-data-live);
+}
+
+:root:not(.light) .sc-step-label {
+  font-size: 0.6rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  text-align: center;
+}
+
+:root:not(.light) .sc-step.is-done .sc-step-label,
+:root:not(.light) .sc-step.is-current .sc-step-label {
+  color: var(--vc-text-primary);
+}
+
+/* --- footer action --- */
+
+:root:not(.light) .sc-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: calc(100% + 32px);
+  margin: 0 -16px;
+  padding: 12px 16px;
+  background: none;
+  border: 0;
+  border-top: 1px solid var(--vc-line-hairline);
+  font-family: var(--vc-font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-data-live);
+  cursor: pointer;
+}
+
+:root:not(.light) .sc-card.tone-due .sc-action { color: var(--vc-state-due); }
+:root:not(.light) .sc-card.tone-complete .sc-action { color: var(--vc-state-complete); }
+
+:root:not(.light) .sc-action:hover {
+  background: color-mix(in srgb, var(--vc-text-primary) 5%, transparent);
+}
+:root:not(.light) .sc-action:focus-visible {
+  outline: 2px solid var(--vc-data-live);
+  outline-offset: -2px;
+}

--- a/frontend/src/lib/shipmentStatus.js
+++ b/frontend/src/lib/shipmentStatus.js
@@ -1,0 +1,138 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// What a shipment's status means, in one place.
+//
+// The label, the tone and the position on the progress rail were each written
+// out separately on the list page and the detail page, so a status could read
+// one way in the table and another on the page it linked to.
+//
+// The vocabulary here is the one the server actually writes, which is not the
+// one the old UI displayed:
+//
+//   draft      create_shipment's default — the list is still being built
+//   ordered    create_delivery_from_template, or the UI marking a draft placed
+//   shipped    add_shipment_item sets this when a line ships from an 'ordered'
+//   receiving  the first receipt lands
+//   complete   finalize, no discrepancies
+//   partial    finalize, with discrepancies
+//
+// 'verified' appears in a model comment and in the old UI's badge map, but no
+// backend path sets it, so it is not a state a shipment can be found in and is
+// deliberately absent here. There is no 'delivered' or 'received' either —
+// arrival is 'receiving' until finalize decides complete vs partial.
+
+/** The rail drawn on a shipment card, in order. */
+export const SHIPMENT_STEPS = ['Built', 'Ordered', 'Shipped', 'Received'];
+
+// step: how far along the rail this status sits.
+// done: the step is finished rather than in progress.
+const STATUS = {
+  draft: {
+    label: 'Draft', tone: 'due', step: 0, done: false,
+    open: true, blurb: 'Still being built',
+  },
+  ordered: {
+    label: 'Ordered', tone: 'accent', step: 1, done: true,
+    open: true, blurb: 'Placed with the supplier',
+  },
+  shipped: {
+    label: 'Shipped', tone: 'accent', step: 2, done: true,
+    open: true, blurb: 'On its way',
+  },
+  receiving: {
+    label: 'Receiving', tone: 'accent', step: 3, done: false,
+    open: true, blurb: 'Arrived, being checked in',
+  },
+  complete: {
+    label: 'Received', tone: 'complete', step: 3, done: true,
+    open: false, blurb: 'Everything arrived',
+  },
+  partial: {
+    label: 'Partial', tone: 'due', step: 3, done: true,
+    open: false, blurb: 'Arrived with discrepancies',
+  },
+};
+
+// A status the server has never been known to write still has to render as
+// something rather than crash the row.
+const UNKNOWN = {
+  label: 'Unknown', tone: 'idle', step: 0, done: false, open: true, blurb: '',
+};
+
+export function statusInfo(status) {
+  return STATUS[status] || { ...UNKNOWN, label: status || 'Unknown' };
+}
+
+export const statusLabel = (status) => statusInfo(status).label;
+export const statusTone = (status) => statusInfo(status).tone;
+
+/** Statuses offered as filters, in lifecycle order. */
+export const STATUS_FILTERS = ['draft', 'ordered', 'shipped', 'receiving', 'complete', 'partial'];
+
+/** A shipment still moving through the lifecycle (vs one that has landed). */
+export const isOpen = (shipment) => statusInfo(shipment?.status).open;
+
+/** Finalized, whatever the outcome — the record is closed and stops accepting receipts. */
+export const isFinalized = (shipment) => Boolean(shipment?.finalized_at);
+
+/**
+ * The rail state for one shipment: each step marked done / current / todo.
+ *
+ * A finalized shipment fills the rail regardless of how far the status got,
+ * because finalize is the end of the road even when it lands on 'partial'.
+ */
+export function stepStates(shipment) {
+  const { step, done } = statusInfo(shipment?.status);
+  const finalized = isFinalized(shipment);
+  return SHIPMENT_STEPS.map((label, index) => {
+    if (finalized || index < step || (index === step && done)) return { label, state: 'done' };
+    if (index === step) return { label, state: 'current' };
+    return { label, state: 'todo' };
+  });
+}
+
+/**
+ * Whether this shipment wants someone's attention.
+ *
+ * Two independent reasons, both from the server's own record rather than a
+ * rule invented here: it finalized with discrepancies, or it has alerts
+ * nobody has resolved.
+ */
+export function needsAttention(shipment) {
+  if (!shipment) return false;
+  if (shipment.status === 'partial') return true;
+  return (shipment.unresolved_alert_count || 0) > 0;
+}
+
+/**
+ * Where the three tabs of the detail wizard sit for a given status.
+ * Build the list, confirm it was placed and is travelling, then receive it.
+ */
+export const DETAIL_STEPS = [
+  { key: 'build', label: 'Build list' },
+  { key: 'shipping', label: 'Shipping' },
+  { key: 'receive', label: 'Receive' },
+];
+
+export function detailStep(shipment) {
+  const status = shipment?.status;
+  if (isFinalized(shipment)) return 'receive';
+  if (status === 'draft') return 'build';
+  if (status === 'receiving') return 'receive';
+  return 'shipping';
+}

--- a/frontend/src/lib/shipmentStatus.test.js
+++ b/frontend/src/lib/shipmentStatus.test.js
@@ -1,0 +1,142 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  SHIPMENT_STEPS, STATUS_FILTERS, statusInfo, statusLabel, statusTone,
+  isOpen, isFinalized, stepStates, needsAttention, detailStep,
+} from './shipmentStatus';
+
+describe('statusInfo', () => {
+  it('covers every status the backend writes', () => {
+    // create default, template delivery, item ship, first receipt, finalize x2
+    ['draft', 'ordered', 'shipped', 'receiving', 'complete', 'partial'].forEach((s) => {
+      expect(statusInfo(s).label).not.toBe('Unknown');
+    });
+  });
+
+  it('has no entry for verified, which nothing sets', () => {
+    // The old badge maps listed it; no backend path produces it.
+    expect(statusInfo('verified').label).toBe('verified');
+    expect(statusInfo('verified').tone).toBe('idle');
+  });
+
+  it('renders an unrecognised status rather than throwing', () => {
+    expect(statusLabel(undefined)).toBe('Unknown');
+    expect(statusTone('banana')).toBe('idle');
+    expect(statusLabel('banana')).toBe('banana');
+  });
+
+  it('separates arrival from completion', () => {
+    expect(statusLabel('receiving')).toBe('Receiving');
+    expect(statusLabel('complete')).toBe('Received');
+    expect(statusTone('complete')).toBe('complete');
+    expect(statusTone('partial')).toBe('due');
+    expect(statusTone('draft')).toBe('due');
+  });
+});
+
+describe('isOpen', () => {
+  it('counts anything before finalize as open', () => {
+    ['draft', 'ordered', 'shipped', 'receiving'].forEach((status) => {
+      expect(isOpen({ status })).toBe(true);
+    });
+  });
+
+  it('counts both finalize outcomes as closed', () => {
+    expect(isOpen({ status: 'complete' })).toBe(false);
+    expect(isOpen({ status: 'partial' })).toBe(false);
+  });
+});
+
+describe('isFinalized', () => {
+  it('reads the timestamp, not the status', () => {
+    expect(isFinalized({ status: 'complete', finalized_at: '2026-08-19T00:00:00Z' })).toBe(true);
+    expect(isFinalized({ status: 'complete', finalized_at: null })).toBe(false);
+    expect(isFinalized(null)).toBe(false);
+  });
+});
+
+describe('stepStates', () => {
+  const labels = (s) => stepStates(s).map((x) => x.state);
+
+  it('puts a draft on the first step, still in progress', () => {
+    expect(labels({ status: 'draft' })).toEqual(['current', 'todo', 'todo', 'todo']);
+  });
+
+  it('advances with the lifecycle', () => {
+    expect(labels({ status: 'ordered' })).toEqual(['done', 'done', 'todo', 'todo']);
+    expect(labels({ status: 'shipped' })).toEqual(['done', 'done', 'done', 'todo']);
+  });
+
+  it('marks receiving as arrived but not finished', () => {
+    expect(labels({ status: 'receiving' })).toEqual(['done', 'done', 'done', 'current']);
+  });
+
+  it('fills the rail once finalized, including a partial', () => {
+    expect(labels({ status: 'complete' })).toEqual(['done', 'done', 'done', 'done']);
+    expect(labels({ status: 'partial' })).toEqual(['done', 'done', 'done', 'done']);
+  });
+
+  it('fills the rail for a finalized shipment whose status never advanced', () => {
+    // finalize can be reached from a status the rail would otherwise show as early
+    expect(labels({ status: 'draft', finalized_at: '2026-08-19T00:00:00Z' }))
+      .toEqual(['done', 'done', 'done', 'done']);
+  });
+
+  it('returns one entry per named step', () => {
+    expect(stepStates({ status: 'draft' }).map((s) => s.label)).toEqual(SHIPMENT_STEPS);
+  });
+});
+
+describe('needsAttention', () => {
+  it('flags a partial delivery', () => {
+    expect(needsAttention({ status: 'partial' })).toBe(true);
+  });
+
+  it('flags unresolved alerts on an otherwise fine shipment', () => {
+    expect(needsAttention({ status: 'complete', unresolved_alert_count: 2 })).toBe(true);
+  });
+
+  it('leaves a clean shipment alone', () => {
+    expect(needsAttention({ status: 'complete', unresolved_alert_count: 0 })).toBe(false);
+    expect(needsAttention({ status: 'draft' })).toBe(false);
+    expect(needsAttention(null)).toBe(false);
+  });
+});
+
+describe('detailStep', () => {
+  it('opens a draft on the list it still needs', () => {
+    expect(detailStep({ status: 'draft' })).toBe('build');
+  });
+
+  it('opens an in-flight shipment on shipping', () => {
+    expect(detailStep({ status: 'ordered' })).toBe('shipping');
+    expect(detailStep({ status: 'shipped' })).toBe('shipping');
+  });
+
+  it('opens an arriving or finished shipment on receive', () => {
+    expect(detailStep({ status: 'receiving' })).toBe('receive');
+    expect(detailStep({ status: 'complete', finalized_at: '2026-08-19T00:00:00Z' })).toBe('receive');
+  });
+});
+
+describe('STATUS_FILTERS', () => {
+  it('offers exactly the statuses the server can produce', () => {
+    expect(STATUS_FILTERS).toEqual(['draft', 'ordered', 'shipped', 'receiving', 'complete', 'partial']);
+  });
+});

--- a/frontend/src/pages/admin-v2/AdminV2ShipmentAlerts.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2ShipmentAlerts.jsx
@@ -15,78 +15,58 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect } from 'react';
+// What a delivery got wrong: short counts, damage, the wrong item, and what
+// the supplier still owes. Each one is either resolved or turned into a
+// follow-up order.
+//
+// The follow-up used to navigate to `result.shipment_id`, a key the endpoint
+// does not return -- it returns followup_shipment_id -- so a successful
+// follow-up landed on /shipments/undefined. Its supplier picker was inert
+// too: the request model takes alert_ids and nothing else, so the chosen
+// supplier was dropped on the floor. The follow-up inherits the supplier of
+// the shipment the alerts came from, which is what it always did.
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import AdminV2Layout from './AdminV2Layout';
-import config from '../../config';
 import { useAuth } from '../../contexts/AuthContext';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
-import {
-  AlertIcon,
-  CheckIcon,
-  PlusIcon
-} from '../../components/Icons';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Alert } from '@/components/ui/alert';
-import { Field } from '@/components/ui/field';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
+import { AlertIcon, CheckIcon, PackageIcon } from '../../components/Icons';
+import ChipGroup from '../../components/vc/ChipGroup';
+import { shipmentService } from '../../services/shipments';
 import './AdminV2.css';
+import './components/shipments-page.css';
 
-const ALERT_TYPE_OPTIONS = [
-  { value: '', label: 'All Types' },
+const ALERT_TYPES = [
+  { value: '', label: 'All' },
   { value: 'short', label: 'Short' },
-  { value: 'wrong_item', label: 'Wrong Item' },
+  { value: 'wrong_item', label: 'Wrong item' },
   { value: 'damaged', label: 'Damaged' },
   { value: 'extra', label: 'Extra' },
   { value: 'backorder', label: 'Backorder' },
 ];
 
+const TYPE_LABEL = Object.fromEntries(ALERT_TYPES.map((t) => [t.value, t.label]));
+
+const shortDate = (value) => (value ? new Date(value).toLocaleDateString() : '—');
+
 const AdminV2ShipmentAlerts = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { user } = useAuth();
-  const { 
-    patients, 
-    selectedPatient: contextPatient, 
-    selectPatient: setContextPatient,
-    loadingPatients 
+  const {
+    patients, selectedPatient: contextPatient,
+    selectPatient: setContextPatient, loadingPatients,
   } = useAdminPatient();
-  
   const selectedPatient = contextPatient;
 
-  // Alerts data
   const [alerts, setAlerts] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  
-  // Filters
+
   const [typeFilter, setTypeFilter] = useState('');
-  const [resolvedFilter, setResolvedFilter] = useState('false'); // Default to unresolved
-  
-  // Selection for follow-up order
-  const [selectedAlerts, setSelectedAlerts] = useState([]);
-  
-  // Follow-up modal
-  const [showFollowUpModal, setShowFollowUpModal] = useState(false);
-  const [creatingFollowUp, setCreatingFollowUp] = useState(false);
-  
-  // Suppliers
-  const [suppliers, setSuppliers] = useState([]);
-  const [selectedSupplierId, setSelectedSupplierId] = useState('');
+  const [showResolved, setShowResolved] = useState(false);
+  const [selected, setSelected] = useState([]);
+  const [creating, setCreating] = useState(false);
 
   const hasPermission = (permission) => {
     if (!user) return false;
@@ -94,19 +74,18 @@ const AdminV2ShipmentAlerts = () => {
     return user.permissions?.includes(permission) || false;
   };
 
-  // Set patient from URL
+  const canUpdate = hasPermission('shipments.update');
+  const canCreate = hasPermission('shipments.create');
+
   useEffect(() => {
     const patientId = searchParams.get('patient');
     if (patientId && patients.length > 0) {
-      const patient = patients.find(p => p.id === parseInt(patientId));
-      if (patient && patient.id !== contextPatient?.id) {
-        setContextPatient(patient);
-      }
+      const patient = patients.find((p) => p.id === parseInt(patientId, 10));
+      if (patient && patient.id !== contextPatient?.id) setContextPatient(patient);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way URL→context sync; adding contextPatient would re-run on selection change and revert it to the stale URL param
-  }, [searchParams, patients]);
+  }, [searchParams, patients, loadingPatients]);
 
-  // Update URL when patient changes
   useEffect(() => {
     if (contextPatient && searchParams.get('patient') !== String(contextPatient.id)) {
       setSearchParams({ patient: contextPatient.id });
@@ -114,394 +93,180 @@ const AdminV2ShipmentAlerts = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way context→URL sync; runs only when the selection changes
   }, [contextPatient]);
 
-  // Fetch data
-  useEffect(() => {
-    if (selectedPatient) {
-      fetchAlerts();
-      fetchSuppliers();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helper is recreated each render; effect is keyed on patient change only
-  }, [selectedPatient, typeFilter, resolvedFilter]);
-
-  const fetchAlerts = async () => {
+  const fetchAlerts = useCallback(async () => {
     if (!selectedPatient) return;
-    
+    setLoading(true);
+    setError(null);
     try {
-      setLoading(true);
-      setError(null);
-      
-      const params = new URLSearchParams();
-      params.append('patient_id', selectedPatient.id.toString());
-      if (typeFilter) params.append('alert_type', typeFilter);
-      if (resolvedFilter) params.append('resolved', resolvedFilter);
-      
-      const response = await fetch(`${config.apiUrl}/api/shipments/alerts?${params.toString()}`, {
-        credentials: 'include'
+      const data = await shipmentService.listAlerts({
+        patient_id: selectedPatient.id,
+        alert_type: typeFilter || undefined,
+        // The endpoint reads this as the string 'true'; anything else means
+        // unresolved, so send it only when we actually want resolved ones.
+        resolved: showResolved ? 'true' : undefined,
       });
-      
-      if (response.ok) {
-        const data = await response.json();
-        setAlerts(data.alerts || []);
-        setSelectedAlerts([]);
-      } else {
-        setError('Failed to load alerts');
-      }
+      setAlerts(data.alerts || []);
+      setSelected([]);
     } catch (err) {
-      setError('Error connecting to server');
-      console.error(err);
+      setError(err.message);
     } finally {
       setLoading(false);
     }
-  };
+  }, [selectedPatient, typeFilter, showResolved]);
 
-  const fetchSuppliers = async () => {
+  useEffect(() => { fetchAlerts(); }, [fetchAlerts]);
+
+  const visible = useMemo(
+    () => (showResolved ? alerts : alerts.filter((a) => !a.resolved)),
+    [alerts, showResolved],
+  );
+  const selectable = visible.filter((a) => !a.resolved);
+
+  const toggle = (alertId) => setSelected((prev) => (
+    prev.includes(alertId) ? prev.filter((x) => x !== alertId) : [...prev, alertId]
+  ));
+
+  const toggleAll = () => setSelected(
+    selected.length === selectable.length ? [] : selectable.map((a) => a.id),
+  );
+
+  const resolve = async (alertId) => {
     try {
-      const response = await fetch(`${config.apiUrl}/api/businesses?type=dme`, {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setSuppliers(data.businesses || data || []);
-      }
+      await shipmentService.resolveAlert(alertId);
+      fetchAlerts();
     } catch (err) {
-      console.error('Error fetching suppliers:', err);
+      setError(err.message);
     }
   };
 
-  const handleToggleSelect = (alertId) => {
-    setSelectedAlerts(prev => 
-      prev.includes(alertId) 
-        ? prev.filter(id => id !== alertId)
-        : [...prev, alertId]
-    );
-  };
-
-  const handleSelectAll = () => {
-    const unresolvedIds = alerts.filter(a => !a.resolved).map(a => a.id);
-    if (selectedAlerts.length === unresolvedIds.length) {
-      setSelectedAlerts([]);
-    } else {
-      setSelectedAlerts(unresolvedIds);
-    }
-  };
-
-  const handleCreateFollowUp = async () => {
-    if (selectedAlerts.length === 0) {
-      alert('Please select at least one alert');
-      return;
-    }
-    
-    setCreatingFollowUp(true);
-    
+  const createFollowup = async () => {
+    if (selected.length === 0) return;
+    setCreating(true);
+    setError(null);
     try {
-      const payload = {
-        alert_ids: selectedAlerts,
-        supplier_id: selectedSupplierId ? parseInt(selectedSupplierId) : null
-      };
-      
-      const response = await fetch(`${config.apiUrl}/api/shipments/alerts/create-followup`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(payload)
-      });
-      
-      if (response.ok) {
-        const result = await response.json();
-        setShowFollowUpModal(false);
-        
-        // Navigate to the new shipment
-        navigate(`/care/equipment/shipments/${result.shipment_id}?patient=${selectedPatient.id}`);
+      const result = await shipmentService.createFollowupOrder(selected);
+      if (result.success && result.followup_shipment_id) {
+        navigate(
+          `/care/equipment/shipments/${result.followup_shipment_id}?patient=${selectedPatient.id}`,
+        );
       } else {
-        const errData = await response.json();
-        alert(errData.error || 'Failed to create follow-up order');
+        setError(result.error || 'Failed to create the follow-up order');
       }
     } catch (err) {
-      console.error('Error creating follow-up:', err);
-      alert('Error connecting to server');
+      setError(err.message);
     } finally {
-      setCreatingFollowUp(false);
+      setCreating(false);
     }
   };
-
-  const handleResolveAlert = async (alertId) => {
-    try {
-      const response = await fetch(`${config.apiUrl}/api/shipments/alerts/${alertId}/resolve`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ resolution_notes: '' })
-      });
-      
-      if (response.ok) {
-        fetchAlerts();
-      } else {
-        const errData = await response.json();
-        alert(errData.error || 'Failed to resolve alert');
-      }
-    } catch (err) {
-      console.error('Error resolving alert:', err);
-    }
-  };
-
-  const formatDate = (dateString) => {
-    if (!dateString) return '-';
-    return new Date(dateString).toLocaleDateString();
-  };
-
-  const getAlertTypeBadgeClass = (type) => {
-    switch (type) {
-      case 'short': return 'admin-v2-badge-warning';
-      case 'wrong_item': return 'admin-v2-badge-danger';
-      case 'damaged': return 'admin-v2-badge-danger';
-      case 'extra': return 'admin-v2-badge-info';
-      case 'backorder': return 'admin-v2-badge-warning';
-      default: return 'admin-v2-badge-secondary';
-    }
-  };
-
-  // Same mapping as getAlertTypeBadgeClass, for the shadcn <Badge> in the dialog.
-  const getAlertTypeBadgeVariant = (type) => {
-    switch (type) {
-      case 'short': return 'warning';
-      case 'wrong_item': return 'danger';
-      case 'damaged': return 'danger';
-      case 'extra': return 'info';
-      case 'backorder': return 'warning';
-      default: return 'secondary';
-    }
-  };
-
-  // Stats
-  const unresolvedCount = alerts.filter(a => !a.resolved).length;
 
   if (loadingPatients) {
+    return <AdminV2Layout><div className="admin-v2-loading">Loading patients…</div></AdminV2Layout>;
+  }
+  if (!selectedPatient) {
     return (
       <AdminV2Layout>
-        <div className="admin-v2-loading">Loading patients...</div>
+        <div className="admin-v2-loading">Select a patient from the sidebar</div>
       </AdminV2Layout>
     );
   }
 
+  const unresolved = alerts.filter((a) => !a.resolved).length;
+
   return (
     <AdminV2Layout>
-      <div className="admin-v2-page">
-        {selectedPatient ? (
-          <>
-            {/* Stats Row */}
-            <div className="admin-v2-summary-stats admin-v2-alerts-summary">
-              <div className="admin-v2-stat-card">
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(248, 81, 73, 0.15)' }}>
-                  <AlertIcon size={20} />
-                </div>
-                <div className="admin-v2-stat-info">
-                  <h4>{unresolvedCount}</h4>
-                  <p>Unresolved Alerts</p>
-                </div>
-              </div>
-              <div className="admin-v2-stat-card">
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(46, 160, 67, 0.15)' }}>
-                  <CheckIcon size={20} />
-                </div>
-                <div className="admin-v2-stat-info">
-                  <h4>{alerts.filter(a => a.resolved).length}</h4>
-                  <p>Resolved</p>
-                </div>
-              </div>
-            </div>
+      <div className="admin-v2-page sh-page">
+        {error && <div className="sh-error" role="alert">{error}</div>}
 
-            {/* Filter Bar */}
-            <div className="history-filter-bar">
-              <div className="history-filter-row">
-                <div className="history-filter-group">
-                  <label>Alert Type</label>
-                  <select
-                    value={typeFilter}
-                    onChange={e => setTypeFilter(e.target.value)}
-                    className="history-filter-select"
-                  >
-                    {ALERT_TYPE_OPTIONS.map(opt => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </select>
-                </div>
-                
-                <div className="history-filter-group">
-                  <label>Status</label>
-                  <select
-                    value={resolvedFilter}
-                    onChange={e => setResolvedFilter(e.target.value)}
-                    className="history-filter-select"
-                  >
-                    <option value="">All</option>
-                    <option value="false">Unresolved</option>
-                    <option value="true">Resolved</option>
-                  </select>
-                </div>
-                
-                {hasPermission('equipment.create') && selectedAlerts.length > 0 && (
-                  <div className="tw" style={{ marginLeft: 'auto' }}>
-                    <Button onClick={() => setShowFollowUpModal(true)}>
-                      <PlusIcon size={16} /> Create Follow-Up Order ({selectedAlerts.length})
-                    </Button>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Alerts Table */}
-            {loading ? (
-              <div className="admin-v2-loading">Loading alerts...</div>
-            ) : error ? (
-              <div className="tw"><Alert variant="destructive">{error}</Alert></div>
-            ) : alerts.length === 0 ? (
-              <div className="admin-v2-empty-state">
-                <CheckIcon size={48} />
-                <h3>No Alerts</h3>
-                <p className="admin-v2-text-muted">All shipments are looking good!</p>
-              </div>
-            ) : (
-              <div className="admin-v2-table-container admin-v2-table-cards-wrap">
-                <table className="admin-v2-table admin-v2-table-cards">
-                  <thead>
-                    <tr>
-                      <th style={{ width: '40px' }}>
-                        <input
-                          type="checkbox"
-                          checked={selectedAlerts.length === alerts.filter(a => !a.resolved).length && selectedAlerts.length > 0}
-                          onChange={handleSelectAll}
-                        />
-                      </th>
-                      <th>Type</th>
-                      <th>Item</th>
-                      <th>Shipment</th>
-                      <th style={{ textAlign: 'center' }}>Expected</th>
-                      <th style={{ textAlign: 'center' }}>Actual</th>
-                      <th>Created</th>
-                      <th>Status</th>
-                      <th></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {alerts.map(alert => (
-                      <tr key={alert.id} className={alert.resolved ? 'admin-v2-row-muted' : ''}>
-                        <td data-label="Select" className="admin-v2-cell-select">
-                          {!alert.resolved && (
-                            <input
-                              type="checkbox"
-                              checked={selectedAlerts.includes(alert.id)}
-                              onChange={() => handleToggleSelect(alert.id)}
-                            />
-                          )}
-                        </td>
-                        <td data-label="Type">
-                          <span className={`admin-v2-badge ${getAlertTypeBadgeClass(alert.alert_type)}`}>
-                            {alert.alert_type?.replace('_', ' ')}
-                          </span>
-                        </td>
-                        <td className="admin-v2-cell-name">
-                          <strong>{alert.item_number || '-'}</strong>
-                          {alert.equipment_name && (
-                            <div className="admin-v2-text-muted">{alert.equipment_name}</div>
-                          )}
-                        </td>
-                        <td data-label="Shipment">
-                          <a
-                            href="#"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              navigate(`/care/equipment/shipments/${alert.shipment_id}?patient=${selectedPatient.id}`);
-                            }}
-                          >
-                            #{alert.shipment_id}
-                          </a>
-                          {alert.po_number && <div className="admin-v2-text-muted">PO: {alert.po_number}</div>}
-                        </td>
-                        <td data-label="Expected" style={{ textAlign: 'center' }}>{alert.expected_qty}</td>
-                        <td data-label="Actual" style={{ textAlign: 'center' }}>{alert.actual_qty}</td>
-                        <td data-label="Created">{formatDate(alert.created_at)}</td>
-                        <td data-label="Status">
-                          {alert.resolved ? (
-                            <span className="admin-v2-badge admin-v2-badge-success">Resolved</span>
-                          ) : (
-                            <span className="admin-v2-badge admin-v2-badge-warning">Open</span>
-                          )}
-                        </td>
-                        <td className="admin-v2-cell-actions">
-                          {!alert.resolved && hasPermission('equipment.update') && (
-                            <button
-                              className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-ghost"
-                              onClick={() => handleResolveAlert(alert.id)}
-                              title="Mark as resolved"
-                            >
-                              <CheckIcon size={14} />
-                            </button>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+        <div className="sh-head">
+          <h1 className="sh-title">Delivery problems</h1>
+          <div className="sh-head-actions">
+            <button type="button" className={`sh-btn ${showResolved ? 'active' : ''}`}
+                    aria-pressed={showResolved}
+                    onClick={() => setShowResolved((v) => !v)}>
+              {showResolved ? 'Hide resolved' : 'Show resolved'}
+            </button>
+            {canCreate && selected.length > 0 && (
+              <button type="button" className="sh-btn primary" disabled={creating}
+                      onClick={createFollowup}>
+                <PackageIcon size={16} />
+                {creating ? 'Creating…' : `Order the difference (${selected.length})`}
+              </button>
             )}
-          </>
+          </div>
+        </div>
+
+        <ChipGroup options={ALERT_TYPES} value={typeFilter} onChange={setTypeFilter}
+                   label="Problem" scroll />
+
+        {loading ? (
+          <div className="admin-v2-loading">Loading…</div>
+        ) : visible.length === 0 ? (
+          <div className="sh-empty">
+            <CheckIcon size={26} />
+            <p>{unresolved === 0 && !showResolved
+              ? 'Nothing outstanding — every delivery reconciled.'
+              : 'Nothing matches that.'}</p>
+          </div>
         ) : (
-          <div className="admin-v2-loading">Select a patient from the sidebar</div>
-        )}
+          <>
+            {canCreate && selectable.length > 0 && (
+              <label className="sa-selectall">
+                <input type="checkbox"
+                       checked={selected.length === selectable.length && selectable.length > 0}
+                       onChange={toggleAll} />
+                <span>Select all {selectable.length} outstanding</span>
+              </label>
+            )}
 
-        {/* Follow-Up Order Dialog */}
-        <Dialog open={showFollowUpModal} onOpenChange={(o) => { if (!o) setShowFollowUpModal(false); }}>
-          <DialogContent className="sm:max-w-[560px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>Create Follow-Up Order</DialogTitle>
-            </DialogHeader>
-            <div className="flex flex-col gap-4">
-              <p className="text-sm text-foreground">Create a new order for {selectedAlerts.length} alert(s)?</p>
+            <div className="sh-list">
+              {visible.map((a) => (
+                <article key={a.id} className={`sa-card ${a.resolved ? 'is-resolved' : ''}`}>
+                  <div className="sa-head">
+                    {canCreate && !a.resolved && (
+                      <input type="checkbox" aria-label={`Select ${TYPE_LABEL[a.alert_type] || a.alert_type} alert`}
+                             checked={selected.includes(a.id)} onChange={() => toggle(a.id)} />
+                    )}
+                    <AlertIcon size={16} />
+                    <span className="sa-type">{TYPE_LABEL[a.alert_type] || a.alert_type}</span>
+                    {a.resolved
+                      ? <span className="sa-tag resolved">Resolved</span>
+                      : <span className="sa-tag open">Outstanding</span>}
+                  </div>
 
-              <Field label="Supplier (optional)">
-                <Select
-                  value={selectedSupplierId || '__none__'}
-                  onValueChange={(v) => setSelectedSupplierId(v === '__none__' ? '' : v)}
-                >
-                  <SelectTrigger><SelectValue placeholder="-- Select Supplier --" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__none__">-- Select Supplier --</SelectItem>
-                    {suppliers.map(s => (
-                      <SelectItem key={s.id} value={String(s.id)}>{s.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </Field>
+                  {a.notes && <p className="sa-notes">{a.notes}</p>}
 
-              <div className="flex flex-col gap-2">
-                <h4 className="text-sm font-semibold text-foreground">Selected Items:</h4>
-                <ul className="flex flex-col gap-1.5">
-                  {alerts
-                    .filter(a => selectedAlerts.includes(a.id))
-                    .map(a => (
-                      <li key={a.id} className="flex items-center gap-2 text-sm text-foreground">
-                        <Badge variant={getAlertTypeBadgeVariant(a.alert_type)}>
-                          {a.alert_type}
-                        </Badge>
-                        <span>
-                          {a.item_number || a.equipment_name || 'Item'} — Qty: {Math.abs(a.expected_qty - a.actual_qty)}
-                        </span>
-                      </li>
-                    ))
-                  }
-                </ul>
-              </div>
+                  <dl className="sa-facts">
+                    <div><dt>Expected</dt><dd>{a.expected_qty ?? '—'}</dd></div>
+                    <div><dt>Actual</dt><dd>{a.actual_qty ?? '—'}</dd></div>
+                    <div><dt>Raised</dt><dd>{shortDate(a.created_at)}</dd></div>
+                  </dl>
+
+                  <div className="sa-actions">
+                    <button type="button" className="sh-btn ghost"
+                            onClick={() => navigate(
+                              `/care/equipment/shipments/${a.shipment_id}?patient=${selectedPatient.id}`,
+                            )}>
+                      Open the delivery
+                    </button>
+                    {a.followup_shipment_id && (
+                      <button type="button" className="sh-btn ghost"
+                              onClick={() => navigate(
+                                `/care/equipment/shipments/${a.followup_shipment_id}?patient=${selectedPatient.id}`,
+                              )}>
+                        Open the follow-up
+                      </button>
+                    )}
+                    {canUpdate && !a.resolved && (
+                      <button type="button" className="sh-btn" onClick={() => resolve(a.id)}>
+                        <CheckIcon size={15} /> Mark resolved
+                      </button>
+                    )}
+                  </div>
+                </article>
+              ))}
             </div>
-            <DialogFooter>
-              <Button type="button" variant="secondary" onClick={() => setShowFollowUpModal(false)}>
-                Cancel
-              </Button>
-              <Button onClick={handleCreateFollowUp} disabled={creatingFollowUp}>
-                {creatingFollowUp ? 'Creating...' : 'Create Order'}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+          </>
+        )}
       </div>
     </AdminV2Layout>
   );

--- a/frontend/src/pages/admin-v2/AdminV2ShipmentDetail.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2ShipmentDetail.jsx
@@ -15,159 +15,166 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect, useRef } from 'react';
+// One shipment, as the three things you do to it in order: build the list,
+// say it was placed, receive what turned up.
+//
+// The page was a single flat scroll of twelve conditional sections with a
+// whole second workflow hidden behind an "Advanced options" disclosure. That
+// one is gone. It hand-rolled receive + status PATCH + finalize alongside the
+// reconcile call that does all three server-side, and its receipts never
+// landed: both of its handlers POSTed a single object to /receive, which
+// takes a list, so every receipt 422'd while the code went on to PATCH the
+// shipment to 'complete'. A delivery run through it read as fully received
+// with no receipt rows and no inventory movement.
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import AdminV2Layout from './AdminV2Layout';
-import config from '../../config';
 import { useAuth } from '../../contexts/AuthContext';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
 import {
-  PlusIcon,
-  EquipmentIcon,
-  CheckIcon,
-  AlertIcon,
-  ChevronLeftIcon,
-  CameraIcon,
-  PackageIcon,
-  FileTextIcon,
-  ChevronRightIcon,
-  ChevronDownIcon,
-  XIcon,
-  EditIcon,
-  TrashIcon,
-  BarcodeIcon
+  BackArrowIcon, PackageIcon, FileTextIcon, PlusIcon, EditIcon,
+  MoreVerticalIcon, BarcodeIcon, CheckCircleIcon, AlertIcon,
 } from '../../components/Icons';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Alert } from '@/components/ui/alert';
-import { Field, FormRow } from '@/components/ui/field';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
+import ShipmentItemCard from '../../components/shipment/ShipmentItemCard';
+import ShipmentDetailsModal from '../../components/shipment/ShipmentDetailsModal';
+import ShipmentItemSheet from '../../components/shipment/ShipmentItemSheet';
+import ReceiveReview from '../../components/shipment/ReceiveReview';
 import { shipmentService } from '../../services/shipments';
+import { businessService } from '../../services/businesses';
+import { equipmentService } from '../../services/equipment';
 import { sessionGet, sessionSet, sessionClear } from '../../lib/sessionState';
 import PackingSlipCapture from './components/PackingSlipCapture';
 import CsvItemImport from './components/CsvItemImport';
 import ScannerChoiceDialog from './components/ScannerChoiceDialog';
 import ExternalScanDialog from './components/ExternalScanDialog';
 import { parseSlipBarcode } from '../../lib/slipScanner';
+import {
+  DETAIL_STEPS, detailStep, statusInfo, stepStates, isFinalized,
+} from '../../lib/shipmentStatus';
 import './AdminV2.css';
+import './components/shipments-page.css';
 
-const CONDITION_OPTIONS = [
-  { value: 'good', label: 'Good' },
-  { value: 'damaged', label: 'Damaged' },
-  { value: 'wrong_item', label: 'Wrong Item' },
-  { value: 'short', label: 'Short (Missing)' },
-  { value: 'extra', label: 'Extra (Unexpected)' },
-];
-
-// Mini labeled field for compact side-by-side quantity inputs (module scope
-// so re-renders don't remount inputs and steal focus mid-typing).
-const QtyField = ({ label, children }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
-    <span
-      className="admin-v2-text-muted"
-      style={{ fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.5px', whiteSpace: 'nowrap' }}
-    >
-      {label}
-    </span>
-    {children}
-  </div>
-);
+const longDate = (value) => (value ? new Date(value).toLocaleDateString(undefined, {
+  month: 'short', day: 'numeric', year: 'numeric',
+}) : null);
 
 const AdminV2ShipmentDetail = () => {
   const { id } = useParams();
-  const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const { user } = useAuth();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const {
-    patients,
-    selectedPatient: contextPatient,
-    selectPatient: setContextPatient
+    patients, selectedPatient: contextPatient, selectPatient: setContextPatient,
   } = useAdminPatient();
-  
   const selectedPatient = contextPatient;
 
-  // Shipment data
   const [shipment, setShipment] = useState(null);
+  const [equipment, setEquipment] = useState([]);
+  const [suppliers, setSuppliers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  
-  // Equipment list for adding items
-  const [equipment, setEquipment] = useState([]);
-  
-  // Add/Edit Item Modal (editingItemId null = adding)
-  const EMPTY_ITEM_FORM = {
-    equipment_id: '',
-    item_number: '',
-    item_description: '',
-    manufacturer_name: '',
-    qty_ordered: 1,
-    qty_shipped: 0,
-    qty_backordered: 0,
-    flagged_missing: false,
-    unit_of_measure: '',
-    unit_description: ''
-  };
-  const [showAddItemModal, setShowAddItemModal] = useState(false);
-  const [editingItemId, setEditingItemId] = useState(null);
-  const [itemFormData, setItemFormData] = useState(EMPTY_ITEM_FORM);
-  const [itemFormError, setItemFormError] = useState(null);
-  const [savingItem, setSavingItem] = useState(false);
-  
-  // Receiving state - one entry per item
-  const [receiveData, setReceiveData] = useState({});
-  const [savingReceive, setSavingReceive] = useState(false);
-  
-  // Receiving mode - edit all items at once
-  const [receivingMode, setReceivingMode] = useState(false);
-  const [itemEdits, setItemEdits] = useState({});
-  const [savingItems, setSavingItems] = useState(false);
-  
-  // Draft editing state
-  const [draftEdits, setDraftEdits] = useState({});
-  
-  // Finalize state
-  const [finalizing, setFinalizing] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const [step, setStep] = useState(null);   // null until the shipment loads
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [itemSheet, setItemSheet] = useState({ open: false, editing: null });
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
 
   // Delivery-confirm flow (the common path: box arrived -> confirm)
   const [confirming, setConfirming] = useState(false);
   const [confirmResult, setConfirmResult] = useState(null);
-  const [showCapture, setShowCapture] = useState(false);
-  const [reviewItems, setReviewItems] = useState(null); // editable grid after a scan / "adjust"
+  const [reviewItems, setReviewItems] = useState(null);
   // Scanned lines that didn't match an item by number: suggestions the user
   // maps (add as new / attach to an item / skip). Monthly orders arrive as
   // 5-6 separate slips, so unmatched lines are normal, not noise.
   const [scanExtras, setScanExtras] = useState(null);
-  const [showAdvanced, setShowAdvanced] = useState(false);
-  const [creatingDelivery, setCreatingDelivery] = useState(false);
 
   // Invoice import: scan an invoice to ADD line items instead of typing them
+  const [showCapture, setShowCapture] = useState(false);
   const [captureMode, setCaptureMode] = useState('confirm'); // 'confirm' | 'import'
-  const [newItemDrafts, setNewItemDrafts] = useState(null);  // editable rows pending bulk save
+  const [newItemDrafts, setNewItemDrafts] = useState(null);
   const [savingBulk, setSavingBulk] = useState(false);
   const [showCsvImport, setShowCsvImport] = useState(false);
-  const [importChooserOpen, setImportChooserOpen] = useState(false); // camera-vs-external before an import scan
-  const [showExternalImport, setShowExternalImport] = useState(false); // wedge-scan invoice line barcodes
+  const [importChooserOpen, setImportChooserOpen] = useState(false);
+  const [showExternalImport, setShowExternalImport] = useState(false);
+  const [creatingDelivery, setCreatingDelivery] = useState(false);
+
+  const hasPermission = (permission) => {
+    if (!user) return false;
+    if (user.is_system_admin) return true;
+    return user.permissions?.includes(permission) || false;
+  };
+
+  // The endpoints require shipments.*; the old page asked for equipment.*.
+  const canUpdate = hasPermission('shipments.update');
+  const canDelete = hasPermission('shipments.delete');
+  const canReceive = hasPermission('shipments.receive');
+  const canCreate = hasPermission('shipments.create');
 
   // --- Import-session persistence -------------------------------------------
   // Mobile browsers discard background tabs (hopping to Photos mid-import),
   // reloading the SPA and wiping React state. Checkpoint the in-progress
   // import to sessionStorage and restore it once the shipment loads.
   const sessionRestoredRef = useRef(false);
-  const importSessionKeys = () => [`drafts:${id}`, `review:${id}`, `extras:${id}`, `capture:${id}`, `scan:${id}`];
+  const importSessionKeys = useCallback(
+    () => [`drafts:${id}`, `review:${id}`, `extras:${id}`, `capture:${id}`, `scan:${id}`],
+    [id],
+  );
+
+  useEffect(() => {
+    const patientId = searchParams.get('patient');
+    if (patientId && patients.length > 0) {
+      const patient = patients.find((p) => p.id === parseInt(patientId, 10));
+      if (patient && patient.id !== contextPatient?.id) setContextPatient(patient);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way URL→context sync; adding contextPatient would re-run on selection change and revert it to the stale URL param
+  }, [searchParams, patients]);
+
+  useEffect(() => {
+    if (contextPatient && searchParams.get('patient') !== String(contextPatient.id)) {
+      setSearchParams({ patient: contextPatient.id }, { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way context→URL sync; runs only when the selection changes
+  }, [contextPatient]);
+
+  const fetchShipment = useCallback(async () => {
+    setLoading(true);
+    try {
+      setShipment(await shipmentService.getShipment(id));
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => { fetchShipment(); }, [fetchShipment]);
+
+  useEffect(() => {
+    let cancelled = false;
+    businessService.listDmeSuppliers()
+      .then((list) => { if (!cancelled) setSuppliers(list); })
+      .catch(() => { /* the supplier's name is a nicety, not the page */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedPatient) return undefined;
+    let cancelled = false;
+    equipmentService.list(selectedPatient.id)
+      .then((data) => {
+        if (!cancelled) setEquipment(data.equipment || data || []);
+      })
+      .catch(() => { /* linking a line to a supply is optional */ });
+    return () => { cancelled = true; };
+  }, [selectedPatient]);
+
+  // The wizard opens where the shipment actually is, then follows the user.
+  useEffect(() => {
+    if (shipment && step === null) setStep(detailStep(shipment));
+  }, [shipment, step]);
 
   useEffect(() => {
     if (!shipment || sessionRestoredRef.current) return;
@@ -187,8 +194,7 @@ const AdminV2ShipmentDetail = () => {
       setCaptureMode(capture.mode || 'confirm');
       setShowCapture(true);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shipment]);
+  }, [shipment, id, importSessionKeys]);
 
   useEffect(() => {
     if (sessionRestoredRef.current) sessionSet(`drafts:${id}`, newItemDrafts);
@@ -205,412 +211,109 @@ const AdminV2ShipmentDetail = () => {
     }
   }, [id, showCapture, captureMode]);
 
-  const hasPermission = (permission) => {
-    if (!user) return false;
-    if (user.is_system_admin) return true;
-    return user.permissions?.includes(permission) || false;
-  };
-
-  // Set patient context from URL
   useEffect(() => {
-    const patientId = searchParams.get('patient');
-    if (patientId && patients.length > 0) {
-      const patient = patients.find(p => p.id === parseInt(patientId));
-      if (patient && patient.id !== contextPatient?.id) {
-        setContextPatient(patient);
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way URL→context sync; adding contextPatient would re-run on selection change and revert it to the stale URL param
-  }, [searchParams, patients]);
+    if (!menuOpen) return undefined;
+    const close = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) setMenuOpen(false);
+    };
+    document.addEventListener('pointerdown', close);
+    return () => document.removeEventListener('pointerdown', close);
+  }, [menuOpen]);
 
-  // Fetch shipment details
-  useEffect(() => {
-    if (id) {
-      fetchShipment();
-      fetchEquipment();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helpers are recreated each render; effect is keyed on shipment id change only
-  }, [id]);
+  // --- Shipment-level actions ---
 
-  const fetchShipment = async () => {
+  const saveDetails = async (payload) => {
+    setBusy(true);
     try {
-      setLoading(true);
-      const response = await fetch(`${config.apiUrl}/api/shipments/${id}`, {
-        credentials: 'include'
-      });
-      
-      if (response.ok) {
-        const data = await response.json();
-        setShipment(data);
-        
-        // Initialize receive data for items not yet fully received
-        const initialReceiveData = {};
-        (data.items || []).forEach(item => {
-          const totalReceived = (item.receipts || []).reduce((sum, r) => sum + r.qty_received, 0);
-          const remaining = item.qty_shipped - totalReceived;
-          if (remaining > 0) {
-            initialReceiveData[item.id] = {
-              qty_received: remaining,
-              condition: 'good',
-              lot_number: '',
-              expiration_date: '',
-              discrepancy_notes: ''
-            };
-          }
-        });
-        setReceiveData(initialReceiveData);
-      } else {
-        setError('Shipment not found');
-      }
-    } catch (err) {
-      setError('Error loading shipment');
-      console.error(err);
+      await shipmentService.patchShipment(id, payload);
+      setDetailsOpen(false);
+      await fetchShipment();
     } finally {
-      setLoading(false);
+      setBusy(false);
     }
   };
 
-  const fetchEquipment = async () => {
-    if (!selectedPatient) return;
+  const markOrdered = async () => {
+    setBusy(true);
     try {
-      const response = await fetch(`${config.apiUrl}/api/equipment?patient_id=${selectedPatient.id}`, {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setEquipment(data.equipment || data || []);
-      }
+      await shipmentService.patchShipment(id, { status: 'ordered' });
+      await fetchShipment();
+      setStep('shipping');
     } catch (err) {
-      console.error('Error fetching equipment:', err);
-    }
-  };
-
-  // Update equipment when patient context is set
-  useEffect(() => {
-    if (selectedPatient) {
-      fetchEquipment();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helper is recreated each render; effect is keyed on patient change only
-  }, [selectedPatient]);
-
-  const handleAddItem = async (e) => {
-    e.preventDefault();
-    setSavingItem(true);
-    setItemFormError(null);
-
-    try {
-      const payload = {
-        ...itemFormData,
-        equipment_id: itemFormData.equipment_id ? parseInt(itemFormData.equipment_id) : null,
-        qty_ordered: parseInt(itemFormData.qty_ordered) || 0,
-        qty_shipped: parseInt(itemFormData.qty_shipped) || 0,
-        qty_backordered: parseInt(itemFormData.qty_backordered) || 0,
-        flagged_missing: !!itemFormData.flagged_missing
-      };
-
-      if (editingItemId) {
-        await shipmentService.updateItem(id, editingItemId, payload);
-      } else {
-        const response = await fetch(`${config.apiUrl}/api/shipments/${id}/items`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify(payload)
-        });
-        if (!response.ok) {
-          const errData = await response.json();
-          throw new Error(errData.error || 'Failed to add item');
-        }
-      }
-
-      closeItemModal();
-      fetchShipment();
-    } catch (err) {
-      setItemFormError(err.message || 'Error connecting to server');
+      setError(err.message);
     } finally {
-      setSavingItem(false);
+      setBusy(false);
     }
   };
 
-  const closeItemModal = () => {
-    setShowAddItemModal(false);
-    setEditingItemId(null);
-    setItemFormData(EMPTY_ITEM_FORM);
-    setItemFormError(null);
+  const handleDeleteShipment = async () => {
+    const what = shipment.is_template ? 'this usual order' : 'this delivery';
+    if (!window.confirm(`Delete ${what}? This cannot be undone.`)) return;
+    try {
+      const result = await shipmentService.deleteShipment(id);
+      if (result.success) {
+        navigate(`/care/equipment/shipments?patient=${selectedPatient?.id}`);
+      } else {
+        setError(result.error || 'Failed to delete');
+      }
+    } catch (err) {
+      setError(err.message);
+    }
   };
 
-  const openEditItem = (item) => {
-    setEditingItemId(item.id);
-    setItemFormData({
-      equipment_id: item.equipment_id ? String(item.equipment_id) : '',
-      item_number: item.item_number || '',
-      item_description: item.item_description || '',
-      manufacturer_name: item.manufacturer_name || '',
-      qty_ordered: item.qty_ordered ?? 0,
-      qty_shipped: item.qty_shipped ?? 0,
-      qty_backordered: item.qty_backordered ?? 0,
-      flagged_missing: !!item.flagged_missing,
-      unit_of_measure: item.unit_of_measure || '',
-      unit_description: item.unit_description || ''
-    });
-    setItemFormError(null);
-    setShowAddItemModal(true);
+  // Template ("usual order") -> spawn this month's delivery.
+  const handleCreateDelivery = async () => {
+    setCreatingDelivery(true);
+    try {
+      const result = await shipmentService.createDeliveryFromTemplate(id);
+      if (result.success) {
+        navigate(`/care/equipment/shipments/${result.id}?patient=${selectedPatient?.id}`);
+      } else {
+        setError(result.error || 'Failed to create delivery');
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setCreatingDelivery(false);
+    }
   };
 
-  const handleDeleteItem = async (item) => {
+  // --- Items ---
+
+  const saveItem = async (payload) => {
+    if (itemSheet.editing) await shipmentService.updateItem(id, itemSheet.editing.id, payload);
+    else await shipmentService.addItem(id, payload);
+    setItemSheet({ open: false, editing: null });
+    await fetchShipment();
+  };
+
+  const changeItemQty = async (item, qty) => {
+    // Optimistic: the stepper should not wait on a round trip per tap.
+    setShipment((s) => ({
+      ...s,
+      items: s.items.map((i) => (i.id === item.id ? { ...i, qty_ordered: qty } : i)),
+    }));
+    try {
+      await shipmentService.updateItem(id, item.id, { qty_ordered: qty });
+    } catch (err) {
+      setError(err.message);
+      fetchShipment();
+    }
+  };
+
+  const removeItem = async (item) => {
     const label = item.item_description || item.equipment_name || item.item_number || 'this item';
     if (!window.confirm(`Remove ${label} from this list?`)) return;
     try {
       await shipmentService.deleteItem(id, item.id);
       fetchShipment();
     } catch (err) {
-      alert(err.message);
+      setError(err.message);
     }
   };
 
-  const handleReceiveItem = async (itemId) => {
-    const data = receiveData[itemId];
-    if (!data) return;
-    
-    setSavingReceive(true);
-    
-    try {
-      const payload = {
-        shipment_item_id: itemId,
-        qty_received: parseInt(data.qty_received) || 0,
-        condition: data.condition,
-        lot_number: data.lot_number || null,
-        expiration_date: data.expiration_date || null,
-        discrepancy_notes: data.discrepancy_notes || null
-      };
-      
-      const response = await fetch(`${config.apiUrl}/api/shipments/${id}/receive`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(payload)
-      });
-      
-      if (response.ok) {
-        fetchShipment();
-      } else {
-        const errData = await response.json();
-        alert(errData.error || 'Failed to record receipt');
-      }
-    } catch (err) {
-      console.error('Error receiving item:', err);
-      alert('Error connecting to server');
-    } finally {
-      setSavingReceive(false);
-    }
-  };
-
-  const handleMarkAsOrdered = async () => {
-    if (!window.confirm('Mark this shipment as Ordered? You can still edit items after marking as ordered.')) {
-      return;
-    }
-    
-    try {
-      const response = await fetch(`${config.apiUrl}/api/shipments/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ status: 'ordered' })
-      });
-      
-      if (response.ok) {
-        fetchShipment();
-      } else {
-        const errData = await response.json();
-        alert(errData.error || 'Failed to update shipment status');
-      }
-    } catch (err) {
-      console.error('Error updating shipment:', err);
-      alert('Error connecting to server');
-    }
-  };
-
-  const updateDraftField = (field, value) => {
-    setDraftEdits(prev => ({ ...prev, [field]: value }));
-  };
-
-  const saveDraftField = async (field) => {
-    const value = draftEdits[field];
-    if (value === undefined) return;
-
-    try {
-      const response = await fetch(`${config.apiUrl}/api/shipments/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ [field]: value || null })
-      });
-      
-      if (response.ok) {
-        fetchShipment();
-        // Clear the edit for this field
-        setDraftEdits(prev => {
-          const { [field]: _, ...rest } = prev;
-          return rest;
-        });
-      } else {
-        const errData = await response.json();
-        alert(errData.error || 'Failed to save');
-      }
-    } catch (err) {
-      console.error('Error saving field:', err);
-      alert('Error connecting to server');
-    }
-  };
-
-  const handleBeginReceiving = async () => {
-    // Pre-fill item edits assuming order is OK
-    const edits = {};
-    (shipment.items || []).forEach(item => {
-      edits[item.id] = {
-        qty_shipped: item.qty_ordered,
-        qty_backordered: 0,
-        qty_received: item.qty_ordered
-      };
-    });
-    setItemEdits(edits);
-    setReceivingMode(true);
-    
-    // Update status to receiving
-    try {
-      await fetch(`${config.apiUrl}/api/shipments/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ status: 'receiving' })
-      });
-      fetchShipment();
-    } catch (err) {
-      console.error('Error updating status:', err);
-    }
-  };
-
-  const updateItemEdit = (itemId, field, value) => {
-    setItemEdits(prev => ({
-      ...prev,
-      [itemId]: {
-        ...prev[itemId],
-        [field]: field === 'flagged_missing' ? !!value : (parseInt(value) || 0)
-      }
-    }));
-  };
-
-  const handleSaveReceiving = async () => {
-    setSavingItems(true);
-    
-    try {
-      // Update each item's quantities
-      for (const [itemId, edits] of Object.entries(itemEdits)) {
-        await fetch(`${config.apiUrl}/api/shipments/${id}/items/${itemId}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({
-            qty_shipped: edits.qty_shipped,
-            qty_backordered: edits.qty_backordered,
-            ...(edits.flagged_missing !== undefined ? { flagged_missing: edits.flagged_missing } : {})
-          })
-        });
-        
-        // Record receipt for received quantity
-        if (edits.qty_received > 0) {
-          await fetch(`${config.apiUrl}/api/shipments/${id}/receive`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            credentials: 'include',
-            body: JSON.stringify({
-              shipment_item_id: parseInt(itemId),
-              qty_received: edits.qty_received,
-              condition: 'good'
-            })
-          });
-        }
-      }
-      
-      // Update status to complete
-      await fetch(`${config.apiUrl}/api/shipments/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ status: 'complete' })
-      });
-      
-      setReceivingMode(false);
-      setItemEdits({});
-      fetchShipment();
-    } catch (err) {
-      console.error('Error saving receiving data:', err);
-      alert('Error saving changes');
-    } finally {
-      setSavingItems(false);
-    }
-  };
-
-  const handleFinalizeShipment = async () => {
-    if (!window.confirm('Finalize this shipment? This will create backorder shipments and alerts for any discrepancies.')) {
-      return;
-    }
-    
-    setFinalizing(true);
-    
-    try {
-      const response = await fetch(`${config.apiUrl}/api/shipments/${id}/finalize`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include'
-      });
-      
-      if (response.ok) {
-        const result = await response.json();
-        fetchShipment();
-        
-        // Show summary of what was created
-        let msg = 'Shipment finalized!';
-        if (result.backorder_shipment_id) {
-          msg += `\nBackorder shipment #${result.backorder_shipment_id} created.`;
-        }
-        if (result.alerts_created > 0) {
-          msg += `\n${result.alerts_created} alert(s) created for discrepancies.`;
-        }
-        alert(msg);
-      } else {
-        const errData = await response.json();
-        alert(errData.error || 'Failed to finalize shipment');
-      }
-    } catch (err) {
-      console.error('Error finalizing shipment:', err);
-      alert('Error connecting to server');
-    } finally {
-      setFinalizing(false);
-    }
-  };
-
-  // --- Delivery-confirm flow -------------------------------------------------
-  // "Everything came as usual" — one call, zero per-line entry.
-  const handleConfirmAsUsual = async () => {
-    setConfirming(true);
-    setError(null);
-    try {
-      const result = await shipmentService.reconcileShipment(id, { mode: 'same_as_usual' });
-      if (result.success) {
-        setConfirmResult(result);
-        setReviewItems(null);
-        sessionClear(...importSessionKeys());
-        fetchShipment();
-      } else {
-        setConfirmResult({ success: false, error: result.error });
-      }
-    } catch (err) {
-      setConfirmResult({ success: false, error: err.message });
-    } finally {
-      setConfirming(false);
-    }
-  };
+  // --- Receiving. One reconcile call: the server records the receipts,
+  // raises the alerts, spawns the backorder and sets the final status. ---
 
   // Open the editable review grid, optionally seeded by resolved scan lines.
   // Lines matched by item number sum into that item's "arrived" count (the
@@ -625,49 +328,45 @@ const AdminV2ShipmentDetail = () => {
         sourceById.set(line.shipment_item_id, line.source);
       }
     }
-    setReviewItems(
-      (shipment.items || []).map((item) => {
-        const scanned = arrivedById.has(item.id);
-        const arrived = scanned
-          ? arrivedById.get(item.id)
-          : (item.qty_shipped ?? item.qty_ordered ?? 0);
-        return {
-          shipment_item_id: item.id,
-          label: item.item_description || item.equipment_name || item.item_number || `Item ${item.id}`,
-          item_number: item.item_number,
-          qty_ordered: item.qty_ordered,
-          qty_received: arrived,
-          qty_backordered: Math.max(0, (item.qty_ordered || 0) - arrived),
-          condition: 'good',
-          matched: scanned ? (sourceById.get(item.id) === 'barcode' ? 'barcode' : 'ocr') : null,
-        };
-      })
-    );
+    setReviewItems((shipment.items || []).map((item) => {
+      const scanned = arrivedById.has(item.id);
+      const arrived = scanned
+        ? arrivedById.get(item.id)
+        : (item.qty_shipped ?? item.qty_ordered ?? 0);
+      return {
+        shipment_item_id: item.id,
+        label: item.item_description || item.equipment_name || item.item_number || `Item ${item.id}`,
+        item_number: item.item_number,
+        qty_ordered: item.qty_ordered,
+        qty_received: arrived,
+        qty_backordered: Math.max(0, (item.qty_ordered || 0) - arrived),
+        condition: 'good',
+        matched: scanned ? (sourceById.get(item.id) === 'barcode' ? 'barcode' : 'ocr') : null,
+      };
+    }));
     // Lines the number match didn't claim become mapping suggestions:
     // best name match preselected, otherwise "add as new item".
-    setScanExtras(
-      (resolvedLines || [])
-        .filter((line) => line.matchType !== 'number')
-        .map((line, i) => ({
-          key: `${line.itemNumber}-${i}`,
-          line,
-          item_number: line.itemNumber || '',
-          item_description: line.description || '',
-          qty_ordered: line.qtyOrdered ?? line.qty ?? 1,
-          qty_shipped: line.qtyShipped ?? line.qty ?? 1,
-          qty_backordered: line.qtyToFollow ?? 0,
-          action: line.matchType === 'name' ? String(line.shipment_item_id) : 'new',
-        }))
-    );
+    setScanExtras((resolvedLines || [])
+      .filter((line) => line.matchType !== 'number')
+      .map((line, i) => ({
+        key: `${line.itemNumber}-${i}`,
+        line,
+        item_number: line.itemNumber || '',
+        item_description: line.description || '',
+        qty_ordered: line.qtyOrdered ?? line.qty ?? 1,
+        qty_shipped: line.qtyShipped ?? line.qty ?? 1,
+        qty_backordered: line.qtyToFollow ?? 0,
+        action: line.matchType === 'name' ? String(line.shipment_item_id) : 'new',
+      })));
     setConfirmResult(null);
+    setStep('receive');
   };
 
   const handleScanComplete = async ({ barcodes, ocrItems }) => {
     setShowCapture(false);
     if (captureMode === 'import') {
       const { buildNewItems } = await import('../../lib/slipScanner');
-      const drafts = buildNewItems(barcodes, ocrItems, shipment.items || [], equipment);
-      setNewItemDrafts(drafts);
+      setNewItemDrafts(buildNewItems(barcodes, ocrItems, shipment.items || [], equipment));
     } else {
       const { buildScanLines, resolveScanLines } = await import('../../lib/slipScanner');
       const lines = buildScanLines(barcodes, ocrItems);
@@ -691,23 +390,6 @@ const AdminV2ShipmentDetail = () => {
     });
   };
 
-  const updateScanExtra = (key, patch) => {
-    setScanExtras((prev) => prev.map((e) => (e.key === key ? { ...e, ...patch } : e)));
-  };
-
-  // OCR occasionally invents rows (mangled line fragments) — let them die fast.
-  const removeScanExtra = (key) => {
-    setScanExtras((prev) => prev.filter((e) => e.key !== key));
-  };
-
-  const updateNewItemDraft = (index, field, value) => {
-    setNewItemDrafts((prev) => prev.map((d, i) => (i === index ? { ...d, [field]: value } : d)));
-  };
-
-  const removeNewItemDraft = (index) => {
-    setNewItemDrafts((prev) => prev.filter((_, i) => i !== index));
-  };
-
   const handleSaveNewItems = async () => {
     setSavingBulk(true);
     try {
@@ -721,43 +403,50 @@ const AdminV2ShipmentDetail = () => {
         equipment_id: d.equipment_id || null,
       }));
       const result = await shipmentService.bulkAddItems(id, items);
-      if (result.success || result.count > 0) {
-        // Make the reconciliation stick: when a line was linked to one of our
-        // supplies that doesn't know its supplier item number yet, save the
-        // number onto the equipment — next month's scan auto-links by number,
-        // even if the distributor swaps brands and the printed name changes.
-        for (const d of newItemDrafts) {
-          if (!d.equipment_id || !d.item_number) continue;
-          const eq = equipment.find((e) => e.id === d.equipment_id);
-          if (eq && !eq.item_number) {
-            try {
-              await fetch(`${config.apiUrl}/api/equipment/${eq.id}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                credentials: 'include',
-                body: JSON.stringify({ item_number: d.item_number }),
-              });
-            } catch { /* non-fatal: linking still worked for this delivery */ }
-          }
+      if (!result.success && !result.count) throw new Error(result.error || 'Failed to add items');
+
+      // Make the reconciliation stick: when a line was linked to one of our
+      // supplies that doesn't know its supplier item number yet, save the
+      // number onto the equipment — next month's scan auto-links by number,
+      // even if the distributor swaps brands and the printed name changes.
+      for (const d of newItemDrafts) {
+        if (!d.equipment_id || !d.item_number) continue;
+        const eq = equipment.find((e) => e.id === d.equipment_id);
+        if (eq && !eq.item_number) {
+          try {
+            await equipmentService.update(eq.id, { item_number: d.item_number });
+          } catch { /* non-fatal: linking still worked for this delivery */ }
         }
-        setNewItemDrafts(null);
-        sessionClear(...importSessionKeys());
-        fetchShipment();
-        fetchEquipment();
-      } else {
-        alert(result.error || 'Failed to add items');
       }
+      setNewItemDrafts(null);
+      sessionClear(...importSessionKeys());
+      fetchShipment();
     } catch (err) {
-      alert(err.message);
+      setError(err.message);
     } finally {
       setSavingBulk(false);
     }
   };
 
-  const updateReviewItem = (itemId, field, value) => {
-    setReviewItems((prev) => prev.map((r) => (
-      r.shipment_item_id === itemId ? { ...r, [field]: value } : r
-    )));
+  // "Everything came as usual" — one call, zero per-line entry.
+  const handleConfirmAsUsual = async () => {
+    setConfirming(true);
+    setError(null);
+    try {
+      const result = await shipmentService.reconcileShipment(id, { mode: 'same_as_usual' });
+      if (result.success) {
+        setConfirmResult(result);
+        setReviewItems(null);
+        sessionClear(...importSessionKeys());
+        fetchShipment();
+      } else {
+        setConfirmResult({ success: false, error: result.error });
+      }
+    } catch (err) {
+      setConfirmResult({ success: false, error: err.message });
+    } finally {
+      setConfirming(false);
+    }
   };
 
   // Save the review grid: arrived + "coming later" per line, one reconcile call.
@@ -822,1050 +511,410 @@ const AdminV2ShipmentDetail = () => {
     }
   };
 
-  // Remove a packing-slip photo (e.g. duplicate or abandoned scan attempts).
   const handleDeleteDocument = async (doc) => {
     if (!window.confirm(`Remove ${doc.title || 'this slip photo'}?`)) return;
     try {
-      const result = await shipmentService.deleteDocument(id, doc.id);
-      if (result.success) {
-        fetchShipment();
-      } else {
-        alert(result.error || 'Failed to remove the photo');
-      }
+      await shipmentService.deleteDocument(id, doc.id);
+      fetchShipment();
     } catch (err) {
-      alert(err.message);
+      setError(err.message);
     }
   };
 
-  // Delete an unstarted shipment. The backend refuses once receipts exist or
-  // the delivery is finalized (inventory already counted those supplies).
-  const handleDeleteShipment = async () => {
-    const what = shipment.is_template ? 'this usual order' : 'this delivery';
-    if (!window.confirm(`Delete ${what}? This can't be undone.`)) return;
-    try {
-      const result = await shipmentService.deleteShipment(id);
-      if (result.success) {
-        navigate(`/care/equipment/shipments?patient=${selectedPatient?.id}`);
-      } else {
-        alert(result.error || 'Failed to delete');
-      }
-    } catch (err) {
-      alert(err.message);
-    }
-  };
+  // --- Render ---
 
-  // Template ("usual order") -> spawn this month's delivery.
-  const handleCreateDelivery = async () => {
-    setCreatingDelivery(true);
-    try {
-      const result = await shipmentService.createDeliveryFromTemplate(id);
-      if (result.success) {
-        navigate(`/care/equipment/shipments/${result.id}?patient=${selectedPatient?.id}`);
-      } else {
-        alert(result.error || 'Failed to create delivery');
-      }
-    } catch (err) {
-      alert(err.message);
-    } finally {
-      setCreatingDelivery(false);
-    }
-  };
-
-  const formatDate = (dateString) => {
-    if (!dateString) return '-';
-    return new Date(dateString).toLocaleDateString();
-  };
-
-  const getStatusBadgeClass = (status) => {
-    switch (status) {
-      case 'draft': return 'admin-v2-badge-warning';
-      case 'ordered': return 'admin-v2-badge-secondary';
-      case 'shipped': return 'admin-v2-badge-info';
-      case 'receiving': return 'admin-v2-badge-warning';
-      case 'complete': return 'admin-v2-badge-success';
-      case 'partial': return 'admin-v2-badge-danger';
-      case 'verified': return 'admin-v2-badge-success';
-      default: return 'admin-v2-badge-secondary';
-    }
-  };
-
-  const getConditionBadgeClass = (condition) => {
-    switch (condition) {
-      case 'good': return 'admin-v2-badge-success';
-      case 'damaged': return 'admin-v2-badge-danger';
-      case 'wrong_item': return 'admin-v2-badge-danger';
-      case 'short': return 'admin-v2-badge-warning';
-      case 'extra': return 'admin-v2-badge-info';
-      default: return 'admin-v2-badge-secondary';
-    }
-  };
-
-  const updateReceiveData = (itemId, field, value) => {
-    setReceiveData(prev => ({
-      ...prev,
-      [itemId]: {
-        ...prev[itemId],
-        [field]: value
-      }
-    }));
-  };
-
-  // Calculate item stats
-  const getItemStats = (item) => {
-    const totalReceived = (item.receipts || []).reduce((sum, r) => sum + r.qty_received, 0);
-    const remaining = item.qty_shipped - totalReceived;
-    return { totalReceived, remaining };
-  };
-
-  if (loading) {
-    return (
-      <AdminV2Layout>
-        <div className="admin-v2-loading">Loading shipment...</div>
-      </AdminV2Layout>
-    );
+  if (loading && !shipment) {
+    return <AdminV2Layout><div className="admin-v2-loading">Loading shipment…</div></AdminV2Layout>;
   }
-
-  if (error || !shipment) {
+  if (!shipment) {
     return (
       <AdminV2Layout>
-        <div className="admin-v2-page tw flex flex-col items-start gap-4">
-          <Alert variant="destructive">{error || 'Shipment not found'}</Alert>
-          <Button
-            variant="secondary"
-            onClick={() => navigate(`/care/equipment/shipments?patient=${selectedPatient?.id}`)}
-          >
-            <ChevronLeftIcon size={16} /> Back to Shipments
-          </Button>
+        <div className="admin-v2-page sh-page">
+          <div className="sh-error" role="alert">{error || 'Shipment not found'}</div>
         </div>
       </AdminV2Layout>
     );
   }
 
-  const isDraft = shipment.status === 'draft';
-  const isOrdered = shipment.status === 'ordered';
-  const canMarkOrdered = isDraft && shipment.items?.length > 0;
-  const canBeginReceiving = isOrdered && shipment.items?.length > 0;
-  const canReceive = ['shipped', 'receiving'].includes(shipment.status) && showAdvanced;
-  const canFinalize = ['receiving'].includes(shipment.status) && shipment.items?.length > 0;
-  const isFinalized = ['complete', 'partial', 'verified'].includes(shipment.status);
-  const isTemplate = !!shipment.is_template;
-  // The common path: a real (non-template) delivery that hasn't been confirmed yet.
-  const canConfirm = !isTemplate && !isFinalized && shipment.items?.length > 0
-    && hasPermission('equipment.update');
-  // Rows stay editable until the delivery is confirmed (and always on templates).
-  const canEditItems = hasPermission('equipment.update') && !isFinalized && !receivingMode;
+  const info = statusInfo(shipment.status);
+  const finalized = isFinalized(shipment);
+  const items = shipment.items || [];
+  const rail = stepStates(shipment);
+  const supplierName = shipment.supplier_name
+    || suppliers.find((s) => s.id === shipment.supplier_id)?.name;
+  const heading = shipment.is_template
+    ? 'Usual order'
+    : `Shipment ${shipment.order_number || shipment.po_number || `#${shipment.id}`}`;
+  const totalUnits = items.reduce((sum, i) => sum + (i.qty_ordered || 0), 0);
+  const editableList = !finalized && shipment.status === 'draft' && canUpdate;
+
+  const menu = [
+    ...(canUpdate ? [{ label: 'Edit details', onClick: () => setDetailsOpen(true) }] : []),
+    ...(canCreate ? [{
+      label: 'Copy to new draft',
+      onClick: async () => {
+        try {
+          const r = await shipmentService.copyShipment(id);
+          if (r.success) {
+            navigate(`/care/equipment/shipments/${r.id}?patient=${selectedPatient?.id}`);
+          } else setError(r.error || 'Failed to copy');
+        } catch (err) { setError(err.message); }
+      },
+    }] : []),
+    ...(canDelete && !finalized
+      ? [{ label: 'Delete', onClick: handleDeleteShipment, danger: true }] : []),
+  ];
 
   return (
     <AdminV2Layout>
-      <div className="admin-v2-page">
-        {/* Back Button & Header */}
-        <div className="admin-v2-page-header tw flex items-center justify-between">
-          <Button
-            variant="ghost"
-            onClick={() => navigate(`/care/equipment/shipments?patient=${selectedPatient?.id}`)}
-          >
-            <ChevronLeftIcon size={16} /> Back
-          </Button>
-          {hasPermission('equipment.delete') && !isFinalized
-            && !shipment.items?.some((i) => i.receipts?.length > 0) && (
-            <Button variant="ghost" onClick={handleDeleteShipment} title="Delete this shipment">
-              <TrashIcon size={16} /> Delete
-            </Button>
+      <div className="admin-v2-page sh-page">
+        {error && <div className="sh-error" role="alert">{error}</div>}
+
+        <header className="sd-head">
+          <button type="button" className="sd-back" aria-label="Back to deliveries"
+                  onClick={() => navigate(`/care/equipment/shipments?patient=${selectedPatient?.id}`)}>
+            <BackArrowIcon size={18} />
+          </button>
+          <h1 className="sd-title">{heading}</h1>
+          <span className={`sc-status tone-${info.tone}`}>{info.label}</span>
+          {menu.length > 0 && (
+            <div className="sc-menu-wrap" ref={menuRef}>
+              <button type="button" className="sc-kebab" aria-label="Shipment actions"
+                      aria-haspopup="menu" aria-expanded={menuOpen}
+                      onClick={() => setMenuOpen((v) => !v)}>
+                <MoreVerticalIcon size={18} />
+              </button>
+              {menuOpen && (
+                <div className="sc-menu" role="menu">
+                  {menu.map((entry) => (
+                    <button key={entry.label} type="button" role="menuitem"
+                            className={`sc-menu-item ${entry.danger ? 'danger' : ''}`}
+                            onClick={() => { setMenuOpen(false); entry.onClick(); }}>
+                      {entry.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </header>
+
+        {/* A standing order never receives anything itself; it spawns deliveries. */}
+        {shipment.is_template ? (
+          <section className="sd-usual">
+            <p>
+              This is the usual order — a template. It is not a delivery, and never
+              receives supplies itself.
+            </p>
+            {canCreate && (
+              <button type="button" className="sh-btn primary" disabled={creatingDelivery}
+                      onClick={handleCreateDelivery}>
+                <PackageIcon size={16} />
+                {creatingDelivery ? 'One moment…' : 'A delivery arrived'}
+              </button>
+            )}
+          </section>
+        ) : (
+          <nav className="sd-steps" aria-label="Shipment progress">
+            {DETAIL_STEPS.map((s, i) => {
+              // The three tabs collapse the four rail states: build, in
+              // flight, arrived.
+              const reached = i === 0
+                || (i === 1 && rail[1].state !== 'todo')
+                || (i === 2 && rail[3].state !== 'todo');
+              return (
+                <button key={s.key} type="button"
+                        className={`sd-step ${step === s.key ? 'is-active' : ''} ${reached ? 'is-reached' : ''}`}
+                        aria-current={step === s.key ? 'step' : undefined}
+                        onClick={() => setStep(s.key)}>
+                  <span className="sd-step-num">{i + 1}</span>
+                  <span className="sd-step-name">{s.label}</span>
+                </button>
+              );
+            })}
+          </nav>
+        )}
+
+        <div className="sd-meta">
+          <p className="sd-meta-line">
+            {supplierName || 'No supplier'}
+            {' · '}
+            {shipment.is_backorder ? 'Backorder' : 'Regular shipment'}
+          </p>
+          {canUpdate && (
+            <button type="button" className="sh-btn ghost" onClick={() => setDetailsOpen(true)}>
+              <EditIcon size={15} /> Edit details
+            </button>
           )}
         </div>
 
-        {/* Shipment Header */}
-        <div className="admin-v2-detail-header">
-          <div className="admin-v2-detail-title">
-            <h1>
-              {shipment.order_number || shipment.po_number || `Shipment #${shipment.id}`}
-              {shipment.is_backorder && (
-                <span className="admin-v2-badge admin-v2-badge-warning" style={{ marginLeft: '12px' }}>
-                  Backorder
-                </span>
-              )}
-            </h1>
-            <span className={`admin-v2-badge ${getStatusBadgeClass(shipment.status)}`}>
-              {shipment.status}
-            </span>
-          </div>
-          <div className="admin-v2-detail-meta">
-            <span><strong>Supplier:</strong> {shipment.supplier_name || '-'}</span>
-            {isDraft ? (
-              <>
-                <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <strong>PO:</strong>
-                  <input
-                    type="text"
-                    value={draftEdits.po_number ?? shipment.po_number ?? ''}
-                    onChange={e => updateDraftField('po_number', e.target.value)}
-                    onBlur={() => saveDraftField('po_number')}
-                    placeholder="Enter PO #"
-                    style={{ width: '120px', padding: '4px 8px', background: 'var(--admin-input-bg)', border: '1px solid var(--admin-border)', borderRadius: '4px', color: 'inherit' }}
-                  />
-                </span>
-                <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <strong>Order #:</strong>
-                  <input
-                    type="text"
-                    value={draftEdits.order_number ?? shipment.order_number ?? ''}
-                    onChange={e => updateDraftField('order_number', e.target.value)}
-                    onBlur={() => saveDraftField('order_number')}
-                    placeholder="Enter Order #"
-                    style={{ width: '120px', padding: '4px 8px', background: 'var(--admin-input-bg)', border: '1px solid var(--admin-border)', borderRadius: '4px', color: 'inherit' }}
-                  />
-                </span>
-                <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <strong>Ship Date:</strong>
-                  <input
-                    type="date"
-                    value={draftEdits.ship_date ?? (shipment.ship_date ? shipment.ship_date.split('T')[0] : '')}
-                    onChange={e => updateDraftField('ship_date', e.target.value)}
-                    onBlur={() => saveDraftField('ship_date')}
-                    style={{ padding: '4px 8px', background: 'var(--admin-input-bg)', border: '1px solid var(--admin-border)', borderRadius: '4px', color: 'inherit' }}
-                  />
-                </span>
-                <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <strong>Expected:</strong>
-                  <input
-                    type="date"
-                    value={draftEdits.expected_delivery ?? (shipment.expected_delivery ? shipment.expected_delivery.split('T')[0] : '')}
-                    onChange={e => updateDraftField('expected_delivery', e.target.value)}
-                    onBlur={() => saveDraftField('expected_delivery')}
-                    style={{ padding: '4px 8px', background: 'var(--admin-input-bg)', border: '1px solid var(--admin-border)', borderRadius: '4px', color: 'inherit' }}
-                  />
-                </span>
-                <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <strong>Tracking:</strong>
-                  <input
-                    type="text"
-                    value={draftEdits.tracking_number ?? shipment.tracking_number ?? ''}
-                    onChange={e => updateDraftField('tracking_number', e.target.value)}
-                    onBlur={() => saveDraftField('tracking_number')}
-                    placeholder="Enter tracking #"
-                    style={{ width: '150px', padding: '4px 8px', background: 'var(--admin-input-bg)', border: '1px solid var(--admin-border)', borderRadius: '4px', color: 'inherit' }}
-                  />
-                </span>
-              </>
-            ) : (
-              <>
-                <span><strong>PO:</strong> {shipment.po_number || '-'}</span>
-                <span><strong>Ship Date:</strong> {formatDate(shipment.ship_date)}</span>
-                <span><strong>Expected:</strong> {formatDate(shipment.expected_delivery)}</span>
-                {shipment.tracking_number && (
-                  <span><strong>Tracking:</strong> {shipment.tracking_number}</span>
-                )}
-              </>
-            )}
-          </div>
-        </div>
+        {/* Absent values are stated rather than left blank, so "no PO" reads as
+            a fact rather than as something that failed to load. */}
+        <p className="sd-refs">
+          {shipment.po_number ? `PO ${shipment.po_number}` : 'PO not added'}
+          {' · '}
+          {shipment.order_number ? `Order ${shipment.order_number}` : 'Order # not added'}
+          {shipment.expected_delivery && ` · Expected ${longDate(shipment.expected_delivery)}`}
+          {shipment.tracking_number && ` · Tracking ${shipment.tracking_number}`}
+        </p>
 
-        {/* Alerts Section */}
-        {shipment.alerts && shipment.alerts.length > 0 && (
-          <div className="admin-v2-alerts-section">
-            <h3><AlertIcon size={16} /> Alerts</h3>
-            <div className="admin-v2-alerts-list">
-              {shipment.alerts.map(alert => (
-                <div key={alert.id} className={`admin-v2-alert-item ${alert.resolved ? 'resolved' : ''}`}>
-                  <span className="admin-v2-badge admin-v2-badge-danger">{alert.alert_type}</span>
-                  <span>{alert.equipment_name || alert.item_number || 'Item'}</span>
-                  <span>Expected: {alert.expected_qty}, Actual: {alert.actual_qty}</span>
-                  {alert.resolved && <span className="admin-v2-badge admin-v2-badge-success">Resolved</span>}
-                </div>
-              ))}
+        {/* --- Step 1: the list --- */}
+        {(step === 'build' || shipment.is_template) && (
+          <section className="sd-section">
+            <div className="sd-section-head">
+              <h2 className="sd-section-title">
+                Items <span className="sd-pill">{items.length}</span>
+              </h2>
             </div>
-          </div>
-        )}
 
-        {/* Standing order ("usual order") banner */}
-        {isTemplate && (
-          <div className="admin-v2-info-banner">
-            <div className="admin-v2-info-content">
-              <strong>This is the usual order</strong>
-              <p>These are the supplies that normally arrive. When a box shows up, start here.</p>
-            </div>
-            {hasPermission('equipment.create') && (
-              <div className="tw">
-                <Button size="lg" onClick={handleCreateDelivery} disabled={creatingDelivery}>
-                  <PackageIcon size={16} /> {creatingDelivery ? 'One moment…' : 'A delivery arrived — start here'}
-                </Button>
+            {canUpdate && !finalized && (
+              <div className="sd-actions">
+                <button type="button" className="sh-btn primary"
+                        onClick={() => setImportChooserOpen(true)}>
+                  <FileTextIcon size={16} /> Scan invoice
+                </button>
+                <button type="button" className="sh-btn"
+                        onClick={() => setItemSheet({ open: true, editing: null })}>
+                  <PlusIcon size={16} /> Add item
+                </button>
+                <button type="button" className="sh-btn" onClick={() => setShowCsvImport(true)}>
+                  <PackageIcon size={16} /> Import CSV
+                </button>
               </div>
             )}
-          </div>
-        )}
 
-        {/* Delivery-confirm panel — the common path */}
-        {canConfirm && !reviewItems && (
-          <div className="admin-v2-info-banner">
-            <div className="admin-v2-info-content">
-              <strong>Did a delivery arrive?</strong>
-              <p>
-                If everything on the slip matches what came in the box, one tap is all it takes.
-                Scanning the slip checks items off for you.
-              </p>
-            </div>
-            <div className="tw flex flex-wrap gap-2">
-              <Button size="lg" onClick={handleConfirmAsUsual} disabled={confirming}>
-                <CheckIcon size={16} /> {confirming ? 'Saving…' : 'Everything came as usual — Confirm'}
-              </Button>
-              <Button size="lg" variant="secondary" onClick={() => { setCaptureMode('confirm'); setShowCapture(true); }} disabled={confirming}>
-                <CameraIcon size={16} /> Scan the packing slip
-              </Button>
-              <Button variant="ghost" onClick={() => openReview()} disabled={confirming}>
-                Adjust by hand
-              </Button>
-            </div>
-          </div>
-        )}
+            {newItemDrafts && newItemDrafts.length > 0 && (
+              <div className="sd-drafts">
+                <p className="sd-hint">Review scanned quantities before saving.</p>
+                {newItemDrafts.map((d, index) => (
+                  <div key={`${d.item_number || 'line'}-${index}`} className="sd-draft-row">
+                    <input className="em-input" value={d.item_description || ''}
+                           aria-label={`Description for line ${index + 1}`}
+                           onChange={(e) => setNewItemDrafts((prev) => prev.map((x, i) => (
+                             i === index ? { ...x, item_description: e.target.value } : x)))} />
+                    <input className="em-input sd-draft-sku" value={d.item_number || ''}
+                           aria-label={`Item number for line ${index + 1}`}
+                           onChange={(e) => setNewItemDrafts((prev) => prev.map((x, i) => (
+                             i === index ? { ...x, item_number: e.target.value } : x)))} />
+                    <input className="em-input sd-draft-qty" type="number" min="0"
+                           value={d.qty_ordered ?? 0}
+                           aria-label={`Quantity for line ${index + 1}`}
+                           onChange={(e) => setNewItemDrafts((prev) => prev.map((x, i) => (
+                             i === index ? { ...x, qty_ordered: e.target.value } : x)))} />
+                    <button type="button" className="sh-btn ghost"
+                            onClick={() => setNewItemDrafts((prev) => prev.filter((_, i) => i !== index))}>
+                      Remove
+                    </button>
+                  </div>
+                ))}
+                <div className="sd-drafts-foot">
+                  <button type="button" className="sh-btn ghost" onClick={() => setNewItemDrafts(null)}>
+                    Discard
+                  </button>
+                  <button type="button" className="sh-btn primary" disabled={savingBulk}
+                          onClick={handleSaveNewItems}>
+                    {savingBulk ? 'Saving…' : `Save ${newItemDrafts.length} items`}
+                  </button>
+                </div>
+              </div>
+            )}
 
-        {/* Post-confirm summary, in plain language */}
-        {confirmResult && (
-          <div className="admin-v2-info-banner tw">
-            {confirmResult.success ? (
-              <div className="admin-v2-info-content">
-                {confirmResult.status === 'complete' ? (
-                  <>
-                    <strong><CheckIcon size={14} /> All set!</strong>
-                    <p>The delivery is confirmed and your supplies on hand are up to date.</p>
-                  </>
-                ) : (
-                  <>
-                    <strong>Saved — a few things need attention</strong>
-                    <p>
-                      {(confirmResult.alerts || []).filter(a => !a.resolved && a.alert_type === 'short').length > 0 &&
-                        'Some items came up missing — we flagged them so you can follow up. '}
-                      {confirmResult.backorder_shipment_id &&
-                        "Items marked as coming later are being tracked as their own delivery — you'll confirm them when they show up."}
-                    </p>
-                  </>
-                )}
+            {items.length === 0 ? (
+              <div className="sh-empty">
+                <PackageIcon size={26} />
+                <p>Nothing on this list yet.</p>
               </div>
             ) : (
-              <Alert variant="destructive">{confirmResult.error}</Alert>
+              <div className="sd-items">
+                {items.map((item, i) => (
+                  <ShipmentItemCard
+                    key={item.id}
+                    index={i + 1}
+                    item={item}
+                    editableQty={editableList}
+                    onQtyChange={(qty) => changeItemQty(item, qty)}
+                    onOpen={canUpdate && !finalized
+                      ? () => setItemSheet({ open: true, editing: item }) : undefined}
+                    menu={canUpdate && !finalized ? [
+                      { label: 'Edit item', onClick: () => setItemSheet({ open: true, editing: item }) },
+                      { label: 'Remove', onClick: () => removeItem(item), danger: true },
+                    ] : []}
+                  />
+                ))}
+              </div>
             )}
-          </div>
+
+            {items.length > 0 && !shipment.is_template && (
+              <div className="sd-foot">
+                <span className="sd-foot-count">
+                  <PackageIcon size={15} />
+                  {items.length} items · {totalUnits} units
+                </span>
+                {shipment.status === 'draft' && canUpdate && (
+                  <button type="button" className="sh-btn primary" disabled={busy}
+                          onClick={markOrdered}>
+                    {busy ? 'Saving…' : 'Continue to shipping'}
+                  </button>
+                )}
+              </div>
+            )}
+          </section>
         )}
 
-        {/* Review grid: check the numbers before confirming */}
-        {reviewItems && (
-          <div className="admin-v2-section tw">
-            <div className="admin-v2-section-header">
-              <h2>Check the numbers</h2>
-            </div>
-            <p className="admin-v2-text-muted">
-              For each item: how many arrived, and how many the slip says are coming later
-              (the “To Follow” column). Fix anything that looks off — nothing is saved until you confirm.
-            </p>
-            {/* NEW lines first — a backorder box often carries items that
-                aren't on this delivery's list yet, and they shouldn't hide
-                below a page of already-known cards. */}
-            {scanExtras?.length > 0 && (
-              <>
-                <h3>New on this slip ({scanExtras.length})</h3>
-                <p className="admin-v2-text-muted">
-                  These came off the scan but aren't on the list below (backorder box,
-                  substitution, or new supply). Tell us what to do with each one.
-                </p>
-                <div className="flex flex-col gap-2">
-                  {scanExtras.map((e) => (
-                    <div key={e.key} className="rounded-lg border border-border bg-card p-3">
-                      <div className="flex items-start justify-between gap-2">
-                        <div style={{ flex: 1 }}>
-                          <textarea
-                            rows={2}
-                            value={e.item_description ?? e.line.description ?? ''}
-                            placeholder="What is it? (fix OCR mistakes here)"
-                            onChange={(ev) => updateScanExtra(e.key, { item_description: ev.target.value })}
-                            style={{ width: '100%', padding: '8px', resize: 'vertical' }}
-                          />
-                          <div className="flex flex-wrap items-center gap-2" style={{ marginTop: 6 }}>
-                            <input
-                              type="text"
-                              value={e.item_number ?? e.line.itemNumber ?? ''}
-                              placeholder="Item #"
-                              onChange={(ev) => updateScanExtra(e.key, { item_number: ev.target.value })}
-                              style={{ width: '120px', padding: '8px' }}
-                              aria-label="Item number"
-                            />
-                            {e.line.uom && <span className="admin-v2-text-muted">{e.line.uom}</span>}
-                            {e.line.source === 'barcode' && (
-                              <span className="admin-v2-badge admin-v2-badge-success">
-                                <CheckIcon size={12} /> scanned
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                        <button
-                          className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-secondary"
-                          onClick={() => removeScanExtra(e.key)}
-                          title="Remove this row (OCR mistake)"
-                          aria-label="Remove this row"
-                        >
-                          <XIcon size={14} />
-                        </button>
-                      </div>
-                      <div style={{ display: 'flex', gap: 14, alignItems: 'flex-end', marginTop: 8 }}>
-                        <QtyField label="Ordered">
-                          <input
-                            type="number" min="0" inputMode="numeric"
-                            value={e.qty_ordered ?? e.qty ?? 1}
-                            onChange={(ev) => updateScanExtra(e.key, { qty_ordered: ev.target.value })}
-                            style={{ width: '64px', textAlign: 'center', padding: '8px' }}
-                          />
-                        </QtyField>
-                        <QtyField label="Shipped">
-                          <input
-                            type="number" min="0" inputMode="numeric"
-                            value={e.qty_shipped ?? e.qty ?? 1}
-                            onChange={(ev) => updateScanExtra(e.key, { qty_shipped: ev.target.value })}
-                            style={{ width: '64px', textAlign: 'center', padding: '8px' }}
-                          />
-                        </QtyField>
-                        <QtyField label="B/O">
-                          <input
-                            type="number" min="0" inputMode="numeric"
-                            value={e.qty_backordered ?? 0}
-                            onChange={(ev) => updateScanExtra(e.key, { qty_backordered: ev.target.value })}
-                            style={{ width: '64px', textAlign: 'center', padding: '8px' }}
-                          />
-                        </QtyField>
-                      </div>
-                      <select
-                        value={e.action}
-                        onChange={(ev) => updateScanExtra(e.key, { action: ev.target.value })}
-                        style={{ width: '100%', marginTop: 8, padding: '8px' }}
-                      >
-                        <option value="new">Add as a new item on this delivery</option>
-                        {(shipment.items || []).map((item) => (
-                          <option key={item.id} value={String(item.id)}>
-                            Count toward: {item.item_description || item.equipment_name || item.item_number || `Item ${item.id}`}
-                          </option>
-                        ))}
-                        <option value="skip">Don't add this one</option>
-                      </select>
-                    </div>
-                  ))}
+        {/* --- Step 2: in flight --- */}
+        {step === 'shipping' && !shipment.is_template && (
+          <section className="sd-section">
+            <h2 className="sd-section-title">Shipping</h2>
+            <dl className="sd-facts">
+              <div><dt>Ship date</dt><dd>{longDate(shipment.ship_date) || 'Not set'}</dd></div>
+              <div><dt>Expected</dt><dd>{longDate(shipment.expected_delivery) || 'Not set'}</dd></div>
+              <div><dt>Tracking</dt><dd>{shipment.tracking_number || 'Not set'}</dd></div>
+              <div><dt>Method</dt><dd>{shipment.ship_method || 'Not set'}</dd></div>
+            </dl>
+            <p className="sh-note">{items.length} items · {totalUnits} units on this order.</p>
+            {canReceive && (
+              <button type="button" className="sh-btn primary" onClick={() => setStep('receive')}>
+                <PackageIcon size={16} /> The delivery arrived
+              </button>
+            )}
+          </section>
+        )}
+
+        {/* --- Step 3: receive --- */}
+        {step === 'receive' && !shipment.is_template && (
+          <section className="sd-section">
+            <h2 className="sd-section-title">Receive</h2>
+
+            {finalized ? (
+              <div className="sd-done">
+                <CheckCircleIcon size={20} />
+                <div>
+                  <p className="sd-done-title">{info.blurb}</p>
+                  <p className="sd-done-note">
+                    Finalized {longDate(shipment.finalized_at)}.
+                    {(shipment.unresolved_alert_count || 0) > 0
+                      && ` ${shipment.unresolved_alert_count} unresolved alert(s).`}
+                  </p>
                 </div>
-                <h3 style={{ marginTop: 16 }}>Already on this delivery</h3>
-              </>
-            )}
-            <div className="admin-v2-table-container admin-v2-table-cards-wrap">
-              <table className="admin-v2-table admin-v2-table-cards">
-                <thead>
-                  <tr>
-                    <th>Item</th>
-                    <th>Quantities</th>
-                    <th>Problem?</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {reviewItems.map((r) => (
-                    <tr key={r.shipment_item_id}>
-                      <td className="admin-v2-cell-name">
-                        <div>
-                          <strong>{r.label}</strong>
-                          {r.matched && (
-                            <span className="admin-v2-badge admin-v2-badge-success" style={{ marginLeft: 8 }}>
-                              <CheckIcon size={12} /> {r.matched === 'barcode' ? 'scanned' : 'read from slip'}
-                            </span>
-                          )}
-                        </div>
-                      </td>
-                      <td data-label="Quantities" className="admin-v2-cell-stack">
-                        <div style={{ display: 'flex', gap: 14, alignItems: 'flex-end' }}>
-                          <QtyField label="Expected">
-                            <div style={{ padding: '8px 4px', fontWeight: 600 }}>{r.qty_ordered}</div>
-                          </QtyField>
-                          <QtyField label="Arrived">
-                            <input
-                              type="number" min="0" inputMode="numeric"
-                              value={r.qty_received}
-                              onChange={(e) => updateReviewItem(r.shipment_item_id, 'qty_received', e.target.value)}
-                              style={{ width: '64px', textAlign: 'center', padding: '8px' }}
-                            />
-                          </QtyField>
-                          <QtyField label="Coming later">
-                            <input
-                              type="number" min="0" inputMode="numeric"
-                              value={r.qty_backordered}
-                              onChange={(e) => updateReviewItem(r.shipment_item_id, 'qty_backordered', e.target.value)}
-                              style={{ width: '64px', textAlign: 'center', padding: '8px' }}
-                            />
-                          </QtyField>
-                        </div>
-                      </td>
-                      <td data-label="Problem?">
-                        <select
-                          value={r.condition}
-                          onChange={(e) => updateReviewItem(r.shipment_item_id, 'condition', e.target.value)}
-                          style={{ padding: '8px' }}
-                        >
-                          <option value="good">No problem</option>
-                          <option value="damaged">Damaged</option>
-                          <option value="wrong_item">Wrong item</option>
-                        </select>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-
-            <div className="tw flex gap-2" style={{ marginTop: 12 }}>
-              <Button size="lg" onClick={handleSaveReview} disabled={confirming}>
-                <CheckIcon size={16} /> {confirming ? 'Saving…' : 'Confirm delivery'}
-              </Button>
-              <Button variant="secondary" onClick={() => { setCaptureMode('confirm'); setShowCapture(true); }} disabled={confirming}>
-                <CameraIcon size={16} /> Scan more pages
-              </Button>
-              <Button
-                variant="ghost"
-                onClick={() => { setReviewItems(null); setScanExtras(null); sessionClear(...importSessionKeys()); }}
-                disabled={confirming}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* New items from a scanned invoice: review before adding */}
-        {newItemDrafts && (
-          <div className="admin-v2-section tw">
-            <div className="admin-v2-section-header">
-              <h2>Items from the invoice</h2>
-            </div>
-            {newItemDrafts.length === 0 ? (
-              <p className="admin-v2-text-muted">
-                No new items found on that scan — every barcode we read is already on this list.
-                Try scanning again with more light, or add items by hand.
-              </p>
+              </div>
+            ) : reviewItems ? (
+              <ReceiveReview
+                items={reviewItems}
+                extras={scanExtras}
+                shipmentItems={items}
+                saving={confirming}
+                onChangeItem={(itemId, field, value) => setReviewItems((prev) => prev.map((r) => (
+                  r.shipment_item_id === itemId ? { ...r, [field]: value } : r)))}
+                onChangeExtra={(key, patch) => setScanExtras((prev) => prev.map((e) => (
+                  e.key === key ? { ...e, ...patch } : e)))}
+                onRemoveExtra={(key) => setScanExtras((prev) => prev.filter((e) => e.key !== key))}
+                onCancel={() => { setReviewItems(null); setScanExtras(null); }}
+                onSave={handleSaveReview}
+              />
             ) : (
-              <>
-                <p className="admin-v2-text-muted">
-                  Here's what we read off the invoice. Fix anything that looks wrong,
-                  remove what you don't want, then add them all at once.
+              <div className="sd-confirm">
+                <p className="sd-hint">
+                  If the box matched the order, confirm it in one tap. Otherwise scan
+                  the packing slip, or adjust the counts by hand.
                 </p>
-                <div className="admin-v2-table-container admin-v2-table-cards-wrap">
-                  <table className="admin-v2-table admin-v2-table-cards">
-                    <thead>
-                      <tr>
-                        <th>Item #</th>
-                        <th>Their name</th>
-                        <th>Our supply</th>
-                        <th>Quantities</th>
-                        <th style={{ textAlign: 'center' }}>Unit</th>
-                        <th></th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {newItemDrafts.map((d, i) => (
-                        <tr key={`${d.item_number}-${i}`}>
-                          <td className="admin-v2-cell-name">
-                            <div>
-                              <input
-                                type="text"
-                                value={d.item_number || ''}
-                                onChange={(e) => updateNewItemDraft(i, 'item_number', e.target.value)}
-                                style={{ width: '110px', padding: '8px' }}
-                              />
-                              {d.source === 'barcode' && (
-                                <span className="admin-v2-badge admin-v2-badge-success" style={{ marginLeft: 6 }}>
-                                  <CheckIcon size={12} /> scanned
-                                </span>
-                              )}
-                            </div>
-                          </td>
-                          <td data-label="Their name" className="admin-v2-cell-stack">
-                            <textarea
-                              rows={2}
-                              value={d.item_description || ''}
-                              placeholder="How the distributor lists it"
-                              onChange={(e) => updateNewItemDraft(i, 'item_description', e.target.value)}
-                              style={{ width: '100%', minWidth: '140px', padding: '8px', resize: 'vertical' }}
-                            />
-                          </td>
-                          <td data-label="Our supply" className="admin-v2-cell-stack">
-                            <select
-                              value={d.equipment_id ? String(d.equipment_id) : ''}
-                              onChange={(e) => updateNewItemDraft(i, 'equipment_id', e.target.value ? parseInt(e.target.value, 10) : null)}
-                              style={{ width: '100%', padding: '8px' }}
-                            >
-                              <option value="">Not one of our tracked supplies</option>
-                              {equipment.map((eq) => (
-                                <option key={eq.id} value={String(eq.id)}>{eq.name}</option>
-                              ))}
-                            </select>
-                            {d.equipment_match === 'name' && d.equipment_id && (
-                              <span className="admin-v2-badge admin-v2-badge-info" style={{ marginTop: 4 }}>
-                                our best guess — check it
-                              </span>
-                            )}
-                          </td>
-                          <td data-label="Quantities" className="admin-v2-cell-stack">
-                            <div style={{ display: 'flex', gap: 14, alignItems: 'flex-end' }}>
-                              <QtyField label="Ordered">
-                                <input
-                                  type="number" min="0" inputMode="numeric"
-                                  value={d.qty_ordered}
-                                  onChange={(e) => updateNewItemDraft(i, 'qty_ordered', e.target.value)}
-                                  style={{ width: '64px', textAlign: 'center', padding: '8px' }}
-                                />
-                              </QtyField>
-                              <QtyField label="Shipped">
-                                <input
-                                  type="number" min="0" inputMode="numeric"
-                                  value={d.qty_shipped ?? d.qty_ordered}
-                                  onChange={(e) => updateNewItemDraft(i, 'qty_shipped', e.target.value)}
-                                  style={{ width: '64px', textAlign: 'center', padding: '8px' }}
-                                />
-                              </QtyField>
-                              <QtyField label="B/O">
-                                <input
-                                  type="number" min="0" inputMode="numeric"
-                                  value={d.qty_backordered ?? 0}
-                                  onChange={(e) => updateNewItemDraft(i, 'qty_backordered', e.target.value)}
-                                  style={{ width: '64px', textAlign: 'center', padding: '8px' }}
-                                />
-                              </QtyField>
-                            </div>
-                          </td>
-                          <td data-label="Unit" style={{ textAlign: 'center' }}>
-                            <input
-                              type="text"
-                              value={d.unit_of_measure || ''}
-                              placeholder="EA"
-                              onChange={(e) => updateNewItemDraft(i, 'unit_of_measure', e.target.value)}
-                              style={{ width: '60px', textAlign: 'center', padding: '8px' }}
-                            />
-                          </td>
-                          <td className="admin-v2-cell-actions">
-                            <div className="admin-v2-action-buttons">
-                              <button
-                                className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-secondary"
-                                onClick={() => removeNewItemDraft(i)}
-                                title="Don't add this one"
-                              >
-                                <XIcon size={14} />
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </>
-            )}
-            <div className="tw flex flex-wrap gap-2" style={{ marginTop: 12 }}>
-              {newItemDrafts.length > 0 && (
-                <Button size="lg" onClick={handleSaveNewItems} disabled={savingBulk}>
-                  <PlusIcon size={16} /> {savingBulk ? 'Adding…' : `Add ${newItemDrafts.length} item${newItemDrafts.length === 1 ? '' : 's'}`}
-                </Button>
-              )}
-              <Button variant="secondary" onClick={() => setImportChooserOpen(true)} disabled={savingBulk}>
-                <BarcodeIcon size={16} /> Scan more pages
-              </Button>
-              <Button
-                variant="ghost"
-                onClick={() => { setNewItemDrafts(null); sessionClear(...importSessionKeys()); }}
-                disabled={savingBulk}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Attached packing-slip pages */}
-        {shipment.documents?.length > 0 && (
-          <div className="admin-v2-section tw">
-            <div className="admin-v2-section-header">
-              <h2>Packing slip</h2>
-            </div>
-            <div className="flex flex-wrap gap-3">
-              {shipment.documents.map((doc) => (
-                <div key={doc.id} className="relative">
-                  <a
-                    href={shipmentService.documentRawUrl(shipment.id, doc.id)}
-                    target="_blank" rel="noreferrer"
-                    className="block overflow-hidden rounded-lg border border-border"
-                    title={doc.title || `Page ${doc.page_number || ''}`}
-                  >
-                    {(doc.content_type || '').startsWith('image/') ? (
-                      <img
-                        src={shipmentService.documentRawUrl(shipment.id, doc.id)}
-                        alt={doc.title || 'Packing slip page'}
-                        style={{ width: 110, height: 140, objectFit: 'cover' }}
-                        loading="lazy"
-                      />
-                    ) : (
-                      <span className="flex h-[140px] w-[110px] flex-col items-center justify-center gap-1 text-center text-sm">
-                        <FileTextIcon size={20} /> {doc.title || 'Document'}
-                      </span>
-                    )}
-                  </a>
-                  {hasPermission('equipment.delete') && !isFinalized && (
-                    <button
-                      onClick={(e) => { e.preventDefault(); handleDeleteDocument(doc); }}
-                      title="Remove this photo"
-                      aria-label="Remove this photo"
-                      className="absolute flex items-center justify-center rounded-full border border-border bg-card"
-                      style={{ top: -8, right: -8, width: 32, height: 32 }}
-                    >
-                      <XIcon size={14} />
+                <div className="sd-actions">
+                  {canReceive && (
+                    <button type="button" className="sh-btn primary" disabled={confirming}
+                            onClick={handleConfirmAsUsual}>
+                      <CheckCircleIcon size={16} />
+                      {confirming ? 'Confirming…' : 'Everything came as usual'}
+                    </button>
+                  )}
+                  <button type="button" className="sh-btn"
+                          onClick={() => { setCaptureMode('confirm'); setShowCapture(true); }}>
+                    <BarcodeIcon size={16} /> Scan the packing slip
+                  </button>
+                  {canReceive && (
+                    <button type="button" className="sh-btn" onClick={() => openReview(null)}>
+                      Adjust by hand
                     </button>
                   )}
                 </div>
+              </div>
+            )}
+
+            {confirmResult && !confirmResult.success && (
+              <div className="sh-error" role="alert">{confirmResult.error}</div>
+            )}
+            {confirmResult?.success && (
+              <div className="sd-done">
+                <CheckCircleIcon size={20} />
+                <div>
+                  <p className="sd-done-title">Delivery recorded</p>
+                  <p className="sd-done-note">
+                    {confirmResult.backorder_shipment_id
+                      ? `Backorder #${confirmResult.backorder_shipment_id} created. ` : ''}
+                    {confirmResult.alerts_created > 0
+                      ? `${confirmResult.alerts_created} alert(s) raised.` : ''}
+                  </p>
+                </div>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Packing slips, wherever we are in the flow. */}
+        {(shipment.documents || []).length > 0 && (
+          <section className="sd-section">
+            <h2 className="sd-section-title">Packing slips</h2>
+            <div className="sd-slips">
+              {shipment.documents.map((doc) => (
+                <figure key={doc.id} className="sd-slip">
+                  <a href={shipmentService.documentRawUrl(id, doc.id)}
+                     target="_blank" rel="noreferrer">
+                    <img src={shipmentService.documentRawUrl(id, doc.id)}
+                         alt={doc.title || `Packing slip page ${doc.page_number || ''}`} />
+                  </a>
+                  {canDelete && (
+                    <button type="button" className="sd-slip-remove"
+                            aria-label={`Remove ${doc.title || 'slip'}`}
+                            onClick={() => handleDeleteDocument(doc)}>×</button>
+                  )}
+                </figure>
               ))}
             </div>
-          </div>
+          </section>
         )}
 
-        {/* Advanced (legacy) workflow, tucked away for the rare cases */}
-        {!isTemplate && !isFinalized && (
-          <div className="tw">
-            <Button variant="ghost" size="sm" onClick={() => setShowAdvanced(!showAdvanced)}>
-              {showAdvanced
-                ? <><ChevronDownIcon size={14} /> Hide advanced options</>
-                : <><ChevronRightIcon size={14} /> Advanced options</>}
-            </Button>
-          </div>
+        {(shipment.alerts || []).length > 0 && (
+          <section className="sd-section">
+            <h2 className="sd-section-title">Alerts</h2>
+            <ul className="sd-alerts">
+              {shipment.alerts.map((a) => (
+                <li key={a.id} className={a.resolved ? 'is-resolved' : ''}>
+                  <AlertIcon size={15} />
+                  <span className="sd-alert-type">{a.alert_type.replace('_', ' ')}</span>
+                  <span className="sd-alert-note">{a.notes}</span>
+                  {a.resolved && <span className="sd-alert-tag">Resolved</span>}
+                </li>
+              ))}
+            </ul>
+          </section>
         )}
 
-        {/* Draft Status Notice */}
-        {showAdvanced && isDraft && (
-          <div className="admin-v2-info-banner">
-            <div className="admin-v2-info-content">
-              <strong>Draft Shipment</strong>
-              <p>Add items to this shipment, then mark it as Ordered when ready.</p>
-            </div>
-            {hasPermission('equipment.update') && canMarkOrdered && (
-              <div className="tw">
-                <Button onClick={handleMarkAsOrdered}>
-                  <CheckIcon size={16} /> Mark as Ordered
-                </Button>
-              </div>
-            )}
-          </div>
-        )}
+        {/* --- Modals --- */}
+        <ShipmentDetailsModal
+          open={detailsOpen}
+          onOpenChange={setDetailsOpen}
+          shipment={shipment}
+          suppliers={suppliers}
+          saving={busy}
+          onSave={saveDetails}
+        />
 
-        {/* Ordered Status Notice - Begin Receiving */}
-        {showAdvanced && isOrdered && (
-          <div className="admin-v2-info-banner">
-            <div className="admin-v2-info-content">
-              <strong>Order Placed</strong>
-              <p>When the shipment arrives, begin receiving to record quantities.</p>
-            </div>
-            {hasPermission('equipment.update') && canBeginReceiving && (
-              <div className="tw">
-                <Button onClick={handleBeginReceiving}>
-                  <CheckIcon size={16} /> Begin Receiving
-                </Button>
-              </div>
-            )}
-          </div>
-        )}
+        <ShipmentItemSheet
+          open={itemSheet.open}
+          onOpenChange={(o) => setItemSheet({ open: o, editing: o ? itemSheet.editing : null })}
+          item={itemSheet.editing}
+          equipment={equipment}
+          onSave={saveItem}
+        />
 
-        {/* Receiving Mode Banner */}
-        {receivingMode && (
-          <div className="admin-v2-info-banner" style={{ background: 'var(--admin-info-bg, #e3f2fd)', borderColor: 'var(--admin-info-border, #90caf9)' }}>
-            <div className="admin-v2-info-content">
-              <strong>Receiving in Progress</strong>
-              <p>Update shipped, backordered, and received quantities below. Click Save to record changes.</p>
-            </div>
-            <div className="tw flex gap-2">
-              <Button variant="secondary" onClick={() => setReceivingMode(false)} disabled={savingItems}>
-                Cancel
-              </Button>
-              <Button onClick={handleSaveReceiving} disabled={savingItems}>
-                {savingItems ? 'Saving...' : 'Save & Finalize'}
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Items Section */}
-        <div className="admin-v2-section">
-          <div className="admin-v2-section-header">
-            <h2>Items</h2>
-            {hasPermission('equipment.update') && !isFinalized && (
-              <div className="tw flex flex-wrap gap-2">
-                <Button variant="secondary" onClick={() => setImportChooserOpen(true)}>
-                  <BarcodeIcon size={16} /> Scan invoice to add items
-                </Button>
-                <Button variant="secondary" onClick={() => setShowCsvImport(true)}>
-                  <FileTextIcon size={16} /> Import CSV
-                </Button>
-                <Button onClick={() => setShowAddItemModal(true)}>
-                  <PlusIcon size={16} /> Add Item
-                </Button>
-              </div>
-            )}
-          </div>
-
-          {shipment.items && shipment.items.length > 0 ? (
-            <div className="admin-v2-table-container admin-v2-table-cards-wrap">
-              <table className="admin-v2-table admin-v2-table-cards">
-                <thead>
-                  <tr>
-                    <th>Item</th>
-                    <th>Manufacturer</th>
-                    <th style={{ textAlign: 'center' }}>Ordered</th>
-                    <th style={{ textAlign: 'center' }}>Shipped</th>
-                    <th style={{ textAlign: 'center' }}>B/O</th>
-                    <th style={{ textAlign: 'center' }}>Received</th>
-                    {canReceive && !receivingMode && <th>Receive</th>}
-                    {canEditItems && <th></th>}
-                  </tr>
-                </thead>
-                <tbody>
-                  {shipment.items.map(item => {
-                    const { totalReceived, remaining } = getItemStats(item);
-                    const receiveEntry = receiveData[item.id];
-                    const itemEdit = itemEdits[item.id] || {};
-                    
-                    return (
-                      <tr
-                        key={item.id}
-                        className={canEditItems ? 'admin-v2-clickable-row' : undefined}
-                        onClick={canEditItems ? () => openEditItem(item) : undefined}
-                      >
-                        <td className="admin-v2-cell-name">
-                          <div>
-                            {/* Our name leads; the distributor's wording sits under it */}
-                            <strong>{item.equipment_name || item.item_description || item.item_number || '-'}</strong>
-                            {item.equipment_name && item.item_description && (
-                              <div className="admin-v2-text-muted">{item.item_description}</div>
-                            )}
-                            {item.item_number && (item.item_description || item.equipment_name) && (
-                              <div className="admin-v2-text-muted">#{item.item_number}</div>
-                            )}
-                            {item.unit_description && <div className="admin-v2-text-small">{item.unit_description}</div>}
-                          </div>
-                        </td>
-                        <td data-label="Manufacturer">{item.manufacturer_name || '-'}</td>
-                        <td data-label="Ordered" style={{ textAlign: 'center' }}>{item.qty_ordered}</td>
-                        <td data-label="Shipped" style={{ textAlign: 'center' }}>
-                          {receivingMode ? (
-                            <input
-                              type="number"
-                              min="0"
-                              value={itemEdit.qty_shipped ?? item.qty_shipped ?? 0}
-                              onChange={e => updateItemEdit(item.id, 'qty_shipped', parseInt(e.target.value) || 0)}
-                              style={{ width: '60px', textAlign: 'center' }}
-                            />
-                          ) : (
-                            item.qty_shipped
-                          )}
-                        </td>
-                        <td data-label="Coming later" style={{ textAlign: 'center' }}>
-                          {receivingMode ? (
-                            <input
-                              type="number"
-                              min="0"
-                              value={itemEdit.qty_backordered ?? item.qty_backordered ?? 0}
-                              onChange={e => updateItemEdit(item.id, 'qty_backordered', parseInt(e.target.value) || 0)}
-                              style={{ width: '60px', textAlign: 'center' }}
-                            />
-                          ) : (
-                            item.qty_backordered > 0 ? (
-                              <span className="admin-v2-badge admin-v2-badge-warning">{item.qty_backordered}</span>
-                            ) : '-'
-                          )}
-                        </td>
-                        <td data-label="Received" style={{ textAlign: 'center' }}>
-                          {receivingMode ? (
-                            <div style={{ display: 'inline-flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
-                              <input
-                                type="number"
-                                min="0"
-                                value={itemEdit.qty_received ?? totalReceived ?? 0}
-                                onChange={e => updateItemEdit(item.id, 'qty_received', parseInt(e.target.value) || 0)}
-                                style={{ width: '60px', textAlign: 'center' }}
-                              />
-                              {/* Invoice says shipped, box says otherwise — flag it to chase the supplier */}
-                              <label style={{ display: 'flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap', fontSize: '0.75rem', cursor: 'pointer' }}>
-                                <input
-                                  type="checkbox"
-                                  checked={itemEdit.flagged_missing ?? !!item.flagged_missing}
-                                  onChange={e => updateItemEdit(item.id, 'flagged_missing', e.target.checked)}
-                                />
-                                never arrived
-                              </label>
-                            </div>
-                          ) : (
-                            <>
-                              {totalReceived > 0 ? (
-                                <span className={totalReceived >= item.qty_shipped ? 'admin-v2-text-success' : ''}>
-                                  {totalReceived} / {item.qty_shipped}
-                                </span>
-                              ) : (item.flagged_missing ? null : '-')}
-                              {item.flagged_missing && (
-                                <div>
-                                  <span className="admin-v2-badge admin-v2-badge-danger">
-                                    <AlertIcon size={12} /> never arrived
-                                  </span>
-                                </div>
-                              )}
-                            </>
-                          )}
-                        </td>
-                        {canReceive && !receivingMode && (
-                          <td data-label="Receive">
-                            {remaining > 0 && receiveEntry ? (
-                              <div className="admin-v2-receive-form">
-                                <div className="admin-v2-receive-row">
-                                  <input
-                                    type="number"
-                                    min="0"
-                                    max={remaining}
-                                    value={receiveEntry.qty_received}
-                                    onChange={e => updateReceiveData(item.id, 'qty_received', e.target.value)}
-                                    style={{ width: '60px' }}
-                                  />
-                                  <select
-                                    value={receiveEntry.condition}
-                                    onChange={e => updateReceiveData(item.id, 'condition', e.target.value)}
-                                    style={{ width: '100px' }}
-                                  >
-                                    {CONDITION_OPTIONS.map(opt => (
-                                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                                    ))}
-                                  </select>
-                                  <button
-                                    className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-success"
-                                    onClick={() => handleReceiveItem(item.id)}
-                                    disabled={savingReceive}
-                                  >
-                                    <CheckIcon size={14} />
-                                  </button>
-                                </div>
-                                {receiveEntry.condition !== 'good' && (
-                                  <input
-                                    type="text"
-                                    placeholder="Discrepancy notes..."
-                                    value={receiveEntry.discrepancy_notes}
-                                    onChange={e => updateReceiveData(item.id, 'discrepancy_notes', e.target.value)}
-                                    style={{ marginTop: '4px', width: '100%' }}
-                                  />
-                                )}
-                              </div>
-                            ) : totalReceived >= item.qty_shipped ? (
-                              <span className="admin-v2-badge admin-v2-badge-success">
-                                <CheckIcon size={12} /> Complete
-                              </span>
-                            ) : null}
-                          </td>
-                        )}
-                        {canEditItems && (
-                          <td className="admin-v2-cell-actions" onClick={(e) => e.stopPropagation()} style={{ whiteSpace: 'nowrap' }}>
-                            <div className="admin-v2-action-buttons">
-                              <button
-                                className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-secondary"
-                                onClick={() => openEditItem(item)}
-                                title="Edit this item"
-                              >
-                                <EditIcon size={14} />
-                              </button>
-                              <button
-                                className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-secondary"
-                                onClick={() => handleDeleteItem(item)}
-                                title="Remove this item"
-                              >
-                                <TrashIcon size={14} />
-                              </button>
-                            </div>
-                          </td>
-                        )}
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <div className="admin-v2-empty-state">
-              <EquipmentIcon size={32} />
-              <p>No items on this list yet. The fast way: scan the invoice and we'll read them off for you.</p>
-              {hasPermission('equipment.update') && !isFinalized && (
-                <div className="tw flex flex-wrap justify-center gap-2">
-                  <Button onClick={() => setImportChooserOpen(true)}>
-                    <BarcodeIcon size={16} /> Scan invoice to add items
-                  </Button>
-                  <Button variant="secondary" onClick={() => setShowAddItemModal(true)}>
-                    <PlusIcon size={16} /> Add by hand
-                  </Button>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* Receipt History */}
-        {shipment.items?.some(item => item.receipts?.length > 0) && (
-          <div className="admin-v2-section">
-            <h2>Receipt History</h2>
-            <div className="admin-v2-table-container admin-v2-table-cards-wrap">
-              <table className="admin-v2-table admin-v2-table-cards">
-                <thead>
-                  <tr>
-                    <th>Item</th>
-                    <th>Qty</th>
-                    <th>Condition</th>
-                    <th>Lot #</th>
-                    <th>Expiration</th>
-                    <th>Received At</th>
-                    <th>Notes</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {shipment.items.flatMap(item =>
-                    (item.receipts || []).map(receipt => (
-                      <tr key={receipt.id}>
-                        <td className="admin-v2-cell-name">
-                          <strong>{item.item_description || item.equipment_name || item.item_number || 'Item'}</strong>
-                        </td>
-                        <td data-label="Qty">{receipt.qty_received}</td>
-                        <td data-label="Condition">
-                          <span className={`admin-v2-badge ${getConditionBadgeClass(receipt.condition)}`}>
-                            {receipt.condition}
-                          </span>
-                        </td>
-                        <td data-label="Lot #">{receipt.lot_number || '-'}</td>
-                        <td data-label="Expiration">{formatDate(receipt.expiration_date)}</td>
-                        <td data-label="Received At">{formatDate(receipt.received_at)}</td>
-                        <td data-label="Notes">{receipt.discrepancy_notes || '-'}</td>
-                      </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
-
-        {/* Finalize Button (advanced path; the confirm panel handles the common case) */}
-        {showAdvanced && canFinalize && hasPermission('equipment.update') && (
-          <div className="admin-v2-finalize-section tw">
-            <Button size="lg" onClick={handleFinalizeShipment} disabled={finalizing}>
-              {finalizing ? 'Finalizing...' : 'Finalize Shipment'}
-            </Button>
-            <p className="admin-v2-text-muted">
-              Finalizing will create backorder shipments for B/O items and generate alerts for any discrepancies.
-            </p>
-          </div>
-        )}
-
-        {/* Finalized Info */}
-        {isFinalized && shipment.finalized_at && (
-          <div className="admin-v2-finalized-info">
-            <CheckIcon size={16} />
-            <span>Finalized on {formatDate(shipment.finalized_at)}</span>
-          </div>
-        )}
-
-        {/* CSV item import */}
         <CsvItemImport
           open={showCsvImport}
           onClose={() => setShowCsvImport(false)}
@@ -1873,22 +922,22 @@ const AdminV2ShipmentDetail = () => {
           onDone={() => { setShowCsvImport(false); fetchShipment(); }}
         />
 
-        {/* Packing-slip / invoice capture */}
         <PackingSlipCapture
           open={showCapture}
           onClose={() => setShowCapture(false)}
           shipmentId={shipment.id}
-          expectedItems={shipment.items || []}
+          expectedItems={items}
           onComplete={handleScanComplete}
           mode={captureMode}
         />
+
         <ScannerChoiceDialog
           open={importChooserOpen}
           onClose={() => setImportChooserOpen(false)}
           title="How will you scan the invoice?"
-          onChoose={(mode) => {
+          onChoose={(choice) => {
             setImportChooserOpen(false);
-            if (mode === 'camera') {
+            if (choice === 'camera') {
               setCaptureMode('import');
               setShowCapture(true);
             } else {
@@ -1896,6 +945,7 @@ const AdminV2ShipmentDetail = () => {
             }
           }}
         />
+
         <ExternalScanDialog
           multi
           askExpected
@@ -1906,147 +956,6 @@ const AdminV2ShipmentDetail = () => {
           warnFor={(code) => (parseSlipBarcode(code) ? null : "doesn't look like an item barcode")}
           onComplete={handleExternalImport}
         />
-
-        {/* Add Item Dialog */}
-        <Dialog open={showAddItemModal} onOpenChange={(o) => { if (!o) closeItemModal(); }}>
-          <DialogContent className="sm:max-w-[640px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>{editingItemId ? 'Edit Item' : 'Add Shipment Item'}</DialogTitle>
-            </DialogHeader>
-            <form onSubmit={handleAddItem} className="flex flex-col gap-4">
-              {itemFormError && <Alert variant="destructive">{itemFormError}</Alert>}
-
-              <Field label="Link to Equipment (optional)">
-                <Select
-                  value={itemFormData.equipment_id || '__none__'}
-                  onValueChange={(v) => {
-                    const eqId = v === '__none__' ? '' : v;
-                    if (eqId) {
-                      const eq = equipment.find(eq => eq.id === parseInt(eqId));
-                      if (eq) {
-                        setItemFormData(prev => ({
-                          ...prev,
-                          equipment_id: eqId,
-                          item_number: eq.item_number || '',
-                          manufacturer_name: eq.default_manufacturer || '',
-                          unit_of_measure: eq.unit_of_measure || '',
-                          unit_description: eq.unit_description || ''
-                        }));
-                        return;
-                      }
-                    }
-                    setItemFormData(prev => ({ ...prev, equipment_id: eqId }));
-                  }}
-                >
-                  <SelectTrigger><SelectValue placeholder="-- No Link --" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__none__">-- No Link --</SelectItem>
-                    {equipment.map(eq => (
-                      <SelectItem key={eq.id} value={String(eq.id)}>
-                        {eq.name} {eq.item_number ? `(${eq.item_number})` : ''}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </Field>
-
-              <FormRow>
-                <Field label="Item Number" required htmlFor="item-number">
-                  <Input
-                    id="item-number"
-                    value={itemFormData.item_number}
-                    onChange={e => setItemFormData({...itemFormData, item_number: e.target.value})}
-                    required
-                    placeholder="e.g., 6025"
-                  />
-                </Field>
-                <Field label="Manufacturer" htmlFor="item-mfr">
-                  <Input
-                    id="item-mfr"
-                    value={itemFormData.manufacturer_name}
-                    onChange={e => setItemFormData({...itemFormData, manufacturer_name: e.target.value})}
-                    placeholder="e.g., Hollister"
-                  />
-                </Field>
-              </FormRow>
-
-              <Field label="Description (how the distributor lists it)" htmlFor="item-desc">
-                <Textarea
-                  id="item-desc"
-                  rows={2}
-                  value={itemFormData.item_description}
-                  onChange={e => setItemFormData({...itemFormData, item_description: e.target.value})}
-                  placeholder="e.g. CIRCUIT, BRTHNG HTD SNGL LIMB — your own name comes from the linked supply above"
-                />
-              </Field>
-
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-                <Field label="Qty Ordered" htmlFor="item-qty-ordered">
-                  <Input
-                    id="item-qty-ordered"
-                    type="number"
-                    min="0"
-                    value={itemFormData.qty_ordered}
-                    onChange={e => setItemFormData({...itemFormData, qty_ordered: e.target.value})}
-                  />
-                </Field>
-                <Field label="Qty Shipped" htmlFor="item-qty-shipped">
-                  <Input
-                    id="item-qty-shipped"
-                    type="number"
-                    min="0"
-                    value={itemFormData.qty_shipped}
-                    onChange={e => setItemFormData({...itemFormData, qty_shipped: e.target.value})}
-                  />
-                </Field>
-                <Field label="Qty B/O" htmlFor="item-qty-bo">
-                  <Input
-                    id="item-qty-bo"
-                    type="number"
-                    min="0"
-                    value={itemFormData.qty_backordered}
-                    onChange={e => setItemFormData({...itemFormData, qty_backordered: e.target.value})}
-                  />
-                </Field>
-              </div>
-
-              <label className="flex items-center gap-2 text-sm" style={{ cursor: 'pointer' }}>
-                <input
-                  type="checkbox"
-                  checked={!!itemFormData.flagged_missing}
-                  onChange={e => setItemFormData({...itemFormData, flagged_missing: e.target.checked})}
-                />
-                Flag as missing — the invoice says it shipped, but it never arrived
-              </label>
-
-              <FormRow>
-                <Field label="Unit of Measure" htmlFor="item-uom">
-                  <Input
-                    id="item-uom"
-                    value={itemFormData.unit_of_measure}
-                    onChange={e => setItemFormData({...itemFormData, unit_of_measure: e.target.value})}
-                    placeholder="e.g., Box"
-                  />
-                </Field>
-                <Field label="Unit Description" htmlFor="item-unit-desc">
-                  <Input
-                    id="item-unit-desc"
-                    value={itemFormData.unit_description}
-                    onChange={e => setItemFormData({...itemFormData, unit_description: e.target.value})}
-                    placeholder="e.g., Box of 10"
-                  />
-                </Field>
-              </FormRow>
-
-              <DialogFooter>
-                <Button type="button" variant="secondary" onClick={closeItemModal}>Cancel</Button>
-                <Button type="submit" disabled={savingItem}>
-                  {savingItem ? 'Saving…' : (editingItemId ? 'Save Changes' : 'Add Item')}
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
       </div>
     </AdminV2Layout>
   );

--- a/frontend/src/pages/admin-v2/AdminV2ShipmentDetail.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2ShipmentDetail.test.jsx
@@ -1,0 +1,202 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The shipment detail wizard: which step it opens on, what is editable
+// where, and that receiving goes through reconcile rather than the removed
+// receive + PATCH + finalize path.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('./AdminV2Layout', () => ({ default: ({ children }) => <div>{children}</div> }));
+
+// The scanning stack owns its own tests; stub it out of the page's way.
+vi.mock('./components/PackingSlipCapture', () => ({ default: () => null }));
+vi.mock('./components/CsvItemImport', () => ({ default: () => null }));
+vi.mock('./components/ScannerChoiceDialog', () => ({ default: () => null }));
+vi.mock('./components/ExternalScanDialog', () => ({ default: () => null }));
+vi.mock('../../lib/slipScanner', () => ({ parseSlipBarcode: () => null }));
+
+let mockUser = { is_system_admin: true, permissions: [] };
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => ({ user: mockUser }) }));
+
+const patient = { id: 1, first_name: 'Pat', last_name: 'Ient' };
+vi.mock('../../contexts/AdminPatientContext', () => ({
+  useAdminPatient: () => ({
+    patients: [patient], selectedPatient: patient, selectPatient: vi.fn(),
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useParams: () => ({ id: '5' }) };
+});
+
+const getShipment = vi.fn();
+const reconcileShipment = vi.fn();
+const patchShipment = vi.fn();
+const updateItem = vi.fn();
+vi.mock('../../services/shipments', () => ({
+  shipmentService: {
+    getShipment: (...a) => getShipment(...a),
+    reconcileShipment: (...a) => reconcileShipment(...a),
+    patchShipment: (...a) => patchShipment(...a),
+    updateItem: (...a) => updateItem(...a),
+    addItem: vi.fn(), deleteItem: vi.fn(), bulkAddItems: vi.fn(),
+    deleteShipment: vi.fn(), copyShipment: vi.fn(), deleteDocument: vi.fn(),
+    createDeliveryFromTemplate: vi.fn(),
+    documentRawUrl: () => 'blob:slip',
+  },
+}));
+vi.mock('../../services/businesses', () => ({
+  businessService: { listDmeSuppliers: async () => [{ id: 9, name: 'Pediatric Home Service' }] },
+}));
+vi.mock('../../services/equipment', () => ({
+  equipmentService: { list: async () => ({ equipment: [] }), update: vi.fn() },
+}));
+
+import AdminV2ShipmentDetail from './AdminV2ShipmentDetail';
+
+const ITEM = {
+  id: 11, item_description: 'Trach suction catheter', item_number: '14FR-100',
+  qty_ordered: 30, qty_shipped: 30, qty_received: 0, receipts: [],
+};
+
+const shipment = (over = {}) => ({
+  id: 5, order_number: '78711852', status: 'draft', supplier_id: 9,
+  items: [ITEM], documents: [], alerts: [], finalized_at: null, ...over,
+});
+
+const renderPage = () => render(
+  <MemoryRouter><AdminV2ShipmentDetail /></MemoryRouter>,
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUser = { is_system_admin: true, permissions: [] };
+  window.sessionStorage.clear();
+  getShipment.mockResolvedValue(shipment());
+  reconcileShipment.mockResolvedValue({ success: true, alerts_created: 0 });
+  patchShipment.mockResolvedValue({ success: true });
+  updateItem.mockResolvedValue({ success: true });
+});
+
+describe('AdminV2ShipmentDetail', () => {
+  it('opens a draft on the list it still needs', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Items')).toBeInTheDocument());
+    expect(screen.getByText('Trach suction catheter')).toBeInTheDocument();
+  });
+
+  it('opens an in-flight shipment on shipping, not on the list', async () => {
+    getShipment.mockResolvedValue(shipment({ status: 'shipped' }));
+    renderPage();
+    // 'Shipping' is also the step tab, so assert on the section heading.
+    await waitFor(() => expect(
+      screen.getByRole('heading', { name: 'Shipping' }),
+    ).toBeInTheDocument());
+    expect(screen.queryByText('Trach suction catheter')).not.toBeInTheDocument();
+  });
+
+  it('opens an arrived shipment on receive', async () => {
+    getShipment.mockResolvedValue(shipment({ status: 'receiving' }));
+    renderPage();
+    await waitFor(() => expect(
+      screen.getByRole('button', { name: /Everything came as usual/ }),
+    ).toBeInTheDocument());
+  });
+
+  it('states absent reference numbers rather than leaving them blank', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/PO not added/)).toBeInTheDocument());
+    expect(screen.getByText(/Order 78711852/)).toBeInTheDocument();
+  });
+
+  it('lets the quantity be stepped while the shipment is a draft', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/One more/)).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText(/One more/));
+    await waitFor(() => expect(updateItem).toHaveBeenCalledWith('5', 11, { qty_ordered: 31 }));
+  });
+
+  it('stops the quantity being edited once the shipment is placed', async () => {
+    // By then it is a claim about what the supplier sent, not what we asked for.
+    getShipment.mockResolvedValue(shipment({ status: 'ordered' }));
+    renderPage();
+    await waitFor(() => expect(
+      screen.getByRole('heading', { name: 'Shipping' }),
+    ).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /1\s*Build list/ }));
+    expect(await screen.findByText('Trach suction catheter')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/One more/)).not.toBeInTheDocument();
+  });
+
+  it('receives through reconcile in one call', async () => {
+    getShipment.mockResolvedValue(shipment({ status: 'receiving' }));
+    renderPage();
+    const confirm = await screen.findByRole('button', { name: /Everything came as usual/ });
+    fireEvent.click(confirm);
+    await waitFor(() => expect(reconcileShipment)
+      .toHaveBeenCalledWith('5', { mode: 'same_as_usual' }));
+  });
+
+  it('reports what reconcile created rather than a bare success', async () => {
+    getShipment.mockResolvedValue(shipment({ status: 'receiving' }));
+    reconcileShipment.mockResolvedValue({
+      success: true, backorder_shipment_id: 77, alerts_created: 2,
+    });
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: /Everything came as usual/ }));
+    await waitFor(() => expect(screen.getByText(/Backorder #77 created/)).toBeInTheDocument());
+    expect(screen.getByText(/2 alert\(s\) raised/)).toBeInTheDocument();
+  });
+
+  it('surfaces a reconcile failure instead of implying it worked', async () => {
+    getShipment.mockResolvedValue(shipment({ status: 'receiving' }));
+    reconcileShipment.mockResolvedValue({ success: false, error: 'Already finalized' });
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: /Everything came as usual/ }));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Already finalized'));
+  });
+
+  it('shows a finalized shipment as done, with no way to receive it again', async () => {
+    getShipment.mockResolvedValue(shipment({
+      status: 'complete', finalized_at: '2026-08-19T00:00:00Z',
+    }));
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Finalized/)).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /Everything came as usual/ })).not.toBeInTheDocument();
+  });
+
+  it('treats a standing order as a template, never as a delivery', async () => {
+    getShipment.mockResolvedValue(shipment({ is_template: true }));
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/never\s+receives supplies itself/))
+      .toBeInTheDocument());
+    expect(screen.queryByRole('navigation', { name: 'Shipment progress' })).not.toBeInTheDocument();
+  });
+
+  it('hides receiving from a user without shipments.receive', async () => {
+    mockUser = { is_system_admin: false, permissions: ['shipments.read', 'shipments.update'] };
+    getShipment.mockResolvedValue(shipment({ status: 'receiving' }));
+    renderPage();
+    await waitFor(() => expect(
+      screen.getByRole('heading', { name: 'Receive' }),
+    ).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /Everything came as usual/ })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/admin-v2/AdminV2Shipments.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Shipments.jsx
@@ -15,120 +15,86 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import React, { useState, useEffect } from 'react';
+// Deliveries — every shipment for the selected patient.
+//
+// Grouped by whether the shipment is still moving: the ones you can act on
+// first, the ones that already landed underneath. The three counts at the top
+// name the states worth interrupting for, and each opens the list filtered to
+// what it counted rather than being a number with no way in.
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import AdminV2Layout from './AdminV2Layout';
-import config from '../../config';
 import { useAuth } from '../../contexts/AuthContext';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
-import {
-  PlusIcon,
-  EquipmentIcon,
-  ClockIcon,
-  ChevronRightIcon,
-  AlertIcon,
-  CopyIcon,
-  PackageIcon,
-  TrashIcon
-} from '../../components/Icons';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Alert } from '@/components/ui/alert';
-import { Field, FormRow } from '@/components/ui/field';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
+import { PlusIcon, PackageIcon, SearchIcon } from '../../components/Icons';
+import ShipmentCard from '../../components/shipment/ShipmentCard';
+import ShipmentDetailsModal from '../../components/shipment/ShipmentDetailsModal';
+import ChipGroup from '../../components/vc/ChipGroup';
 import { shipmentService } from '../../services/shipments';
+import { businessService } from '../../services/businesses';
+import {
+  STATUS_FILTERS, statusLabel, isOpen, needsAttention,
+} from '../../lib/shipmentStatus';
 import './AdminV2.css';
+import './components/shipments-page.css';
 
-const STATUS_OPTIONS = [
-  { value: '', label: 'All Statuses' },
-  { value: 'draft', label: 'Draft' },
-  { value: 'ordered', label: 'Ordered' },
-  { value: 'shipped', label: 'Shipped' },
-  { value: 'receiving', label: 'Receiving' },
-  { value: 'complete', label: 'Complete' },
-  { value: 'partial', label: 'Partial' },
-  { value: 'verified', label: 'Verified' },
-];
+const shortDate = (value) => (value
+  ? new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }).toUpperCase()
+  : null);
+
+/** Tracking numbers are long and the card is narrow; keep both ends. */
+const shortTracking = (value) => {
+  if (!value) return null;
+  return value.length > 12 ? `${value.slice(0, 4)}…${value.slice(-3)}` : value;
+};
 
 const AdminV2Shipments = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { 
-    patients, 
-    selectedPatient: contextPatient, 
-    selectPatient: setContextPatient,
-    loadingPatients 
+  const {
+    patients, selectedPatient: contextPatient,
+    selectPatient: setContextPatient, loadingPatients,
   } = useAdminPatient();
-  
+
   const selectedPatient = contextPatient;
-  
-  // Shipments state
+
   const [shipments, setShipments] = useState([]);
+  const [templates, setTemplates] = useState([]);
+  const [suppliers, setSuppliers] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  // Standing orders ("usual order") state
-  const [templates, setTemplates] = useState([]);
-  const [creatingDelivery, setCreatingDelivery] = useState(false);
-  
-  // Filter state
   const [statusFilter, setStatusFilter] = useState('');
-  const [backorderFilter, setBackorderFilter] = useState('');
-  
-  // Modal states
-  const [showCreateModal, setShowCreateModal] = useState(false);
-  const [formData, setFormData] = useState({
-    po_number: '',
-    order_number: '',
-    ship_date: '',
-    expected_delivery: '',
-    tracking_number: '',
-    ship_method: '',
-    warehouse_loc: '',
-    notes: ''
-  });
-  const [formError, setFormError] = useState(null);
-  const [saving, setSaving] = useState(false);
-  
-  // Businesses (suppliers) for dropdown
-  const [suppliers, setSuppliers] = useState([]);
-  const [selectedSupplierId, setSelectedSupplierId] = useState('');
+  const [search, setSearch] = useState('');
+  const [showSearch, setShowSearch] = useState(false);
 
-  // Permission helper
+  const [createOpen, setCreateOpen] = useState(false);
+  const [creatingDelivery, setCreatingDelivery] = useState(false);
+  const [busy, setBusy] = useState(false);
+
   const hasPermission = (permission) => {
     if (!user) return false;
     if (user.is_system_admin) return true;
     return user.permissions?.includes(permission) || false;
   };
 
-  // Check URL params for patient ID
+  // The endpoints behind these all require shipments.*; the old page gated
+  // them on equipment.*, so a role with one and not the other saw buttons
+  // that 403'd, or none where they would have worked.
+  const canCreate = hasPermission('shipments.create');
+  const canUpdate = hasPermission('shipments.update');
+  const canDelete = hasPermission('shipments.delete');
+
   useEffect(() => {
     const patientId = searchParams.get('patient');
     if (patientId && patients.length > 0) {
-      const patient = patients.find(p => p.id === parseInt(patientId));
-      if (patient && patient.id !== contextPatient?.id) {
-        setContextPatient(patient);
-      }
+      const patient = patients.find((p) => p.id === parseInt(patientId, 10));
+      if (patient && patient.id !== contextPatient?.id) setContextPatient(patient);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way URL→context sync; adding contextPatient would re-run on selection change and revert it to the stale URL param
   }, [searchParams, patients, loadingPatients]);
 
-  // Update URL when context patient changes
   useEffect(() => {
     if (contextPatient && searchParams.get('patient') !== String(contextPatient.id)) {
       setSearchParams({ patient: contextPatient.id });
@@ -136,545 +102,318 @@ const AdminV2Shipments = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way context→URL sync; runs only when the selection changes
   }, [contextPatient]);
 
-  // Fetch data when patient is selected
-  useEffect(() => {
-    if (selectedPatient) {
-      fetchShipments();
-      fetchSuppliers();
-      fetchTemplates();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helpers are recreated each render; effect is keyed on patient change only
-  }, [selectedPatient, statusFilter, backorderFilter]);
-
-  const fetchShipments = async () => {
+  const fetchAll = useCallback(async () => {
     if (!selectedPatient) return;
-    
+    setLoading(true);
+    setError(null);
     try {
-      setLoading(true);
-      setError(null);
-      
-      const params = new URLSearchParams();
-      params.append('patient_id', selectedPatient.id.toString());
-      params.append('is_template', 'false'); // standing orders live in their own card
-      if (statusFilter) params.append('status', statusFilter);
-      if (backorderFilter === 'true') params.append('is_backorder', 'true');
-      if (backorderFilter === 'false') params.append('is_backorder', 'false');
-      
-      const response = await fetch(`${config.apiUrl}/api/shipments?${params.toString()}`, {
-        credentials: 'include'
-      });
-      
-      if (response.ok) {
-        const data = await response.json();
-        setShipments(data.shipments || []);
-      } else {
-        setError('Failed to load shipments');
-      }
+      const [list, templateList, supplierList] = await Promise.all([
+        shipmentService.listShipments({
+          patient_id: selectedPatient.id,
+          is_template: false,
+          status: statusFilter || undefined,
+        }),
+        shipmentService.listTemplates(selectedPatient.id),
+        businessService.listDmeSuppliers(),
+      ]);
+      setShipments(list.shipments || []);
+      setTemplates(templateList.shipments || []);
+      setSuppliers(supplierList);
     } catch (err) {
-      setError('Error connecting to server');
-      console.error('Error fetching shipments:', err);
+      setError(err.message);
     } finally {
       setLoading(false);
     }
-  };
+  }, [selectedPatient, statusFilter]);
 
-  const fetchSuppliers = async () => {
-    try {
-      const response = await fetch(`${config.apiUrl}/api/businesses?type=dme`, {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setSuppliers(data.businesses || data || []);
-      }
-    } catch (err) {
-      console.error('Error fetching suppliers:', err);
-    }
-  };
+  useEffect(() => { fetchAll(); }, [fetchAll]);
 
-  const resetForm = () => {
-    setFormData({
-      po_number: '',
-      order_number: '',
-      ship_date: '',
-      expected_delivery: '',
-      tracking_number: '',
-      ship_method: '',
-      warehouse_loc: '',
-      notes: ''
-    });
-    setSelectedSupplierId('');
-    setFormError(null);
-  };
+  const supplierName = useCallback((shipment) => (
+    shipment.supplier_name
+      || suppliers.find((s) => s.id === shipment.supplier_id)?.name
+      || null
+  ), [suppliers]);
 
-  const handleCreateShipment = async (e) => {
-    e.preventDefault();
-    setSaving(true);
-    setFormError(null);
-    
-    try {
-      const payload = {
-        patient_id: selectedPatient.id,
-        supplier_id: selectedSupplierId ? parseInt(selectedSupplierId) : null,
-        ...formData
-      };
-      
-      const response = await fetch(`${config.apiUrl}/api/shipments`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(payload)
-      });
-      
-      if (response.ok) {
-        const data = await response.json();
-        setShowCreateModal(false);
-        resetForm();
-        // Navigate to the new shipment detail page
-        navigate(`/care/equipment/shipments/${data.id}?patient=${selectedPatient.id}`);
-      } else {
-        const errorData = await response.json();
-        setFormError(errorData.error || 'Failed to create shipment');
-      }
-    } catch {
-      setFormError('Error connecting to server');
-    } finally {
-      setSaving(false);
-    }
-  };
+  const openShipment = (id) => navigate(
+    `/care/equipment/shipments/${id}?patient=${selectedPatient.id}`,
+  );
 
-  // --- Standing orders ("usual order") ---
-  const fetchTemplates = async () => {
-    if (!selectedPatient) return;
-    try {
-      const data = await shipmentService.listTemplates(selectedPatient.id);
-      setTemplates(data.shipments || []);
-    } catch (err) {
-      console.error('Error fetching standing orders:', err);
-    }
-  };
+  // --- Counts. Derived from the loaded list, so they describe what is here. ---
+  const counts = useMemo(() => ({
+    open: shipments.filter(isOpen).length,
+    draft: shipments.filter((s) => s.status === 'draft').length,
+    attention: shipments.filter(needsAttention).length,
+  }), [shipments]);
+
+  const visible = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (!needle) return shipments;
+    return shipments.filter((s) => [
+      s.order_number, s.po_number, s.tracking_number, supplierName(s), `#${s.id}`,
+    ].some((field) => String(field || '').toLowerCase().includes(needle)));
+  }, [shipments, search, supplierName]);
+
+  const inProgress = visible.filter(isOpen);
+  const recent = visible.filter((s) => !isOpen(s));
+
+  // --- Actions ---
 
   const handleDeliveryArrived = async (templateId) => {
     setCreatingDelivery(true);
+    setError(null);
     try {
       const result = await shipmentService.createDeliveryFromTemplate(templateId);
-      if (result.success) {
-        navigate(`/care/equipment/shipments/${result.id}?patient=${selectedPatient.id}`);
-      } else {
-        alert(result.error || 'Failed to create delivery');
-      }
+      if (result.success) openShipment(result.id);
+      else setError(result.error || 'Failed to create delivery');
     } catch (err) {
-      alert(err.message);
+      setError(err.message);
     } finally {
       setCreatingDelivery(false);
     }
   };
 
-  // Turn a past delivery into the standing order: clone it (clears receipts,
-  // order numbers, quantities-received), then flag the clone as the template.
-  const handleSaveAsUsualOrder = async (shipmentId) => {
+  const handleCreate = async (payload) => {
+    setBusy(true);
     try {
-      const response = await fetch(`${config.apiUrl}/api/shipments/${shipmentId}/copy`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include'
+      const result = await shipmentService.createShipment({
+        ...payload, patient_id: selectedPatient.id,
       });
-      if (!response.ok) throw new Error('Failed to copy shipment');
-      const data = await response.json();
-      await shipmentService.patchShipment(data.id, { is_template: true });
-      fetchTemplates();
-    } catch (err) {
-      alert(err.message || 'Failed to save as usual order');
+      if (!result.success) throw new Error(result.error || 'Failed to create shipment');
+      setCreateOpen(false);
+      openShipment(result.id);
+    } finally {
+      setBusy(false);
     }
   };
 
-  const handleDeleteShipment = async (shipment) => {
+  const handleCopy = async (shipment) => {
+    try {
+      const result = await shipmentService.copyShipment(shipment.id);
+      if (result.success) openShipment(result.id);
+      else setError(result.error || 'Failed to copy shipment');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  // Turn a past delivery into the standing order: clone it (clearing receipts,
+  // order numbers and received quantities), then flag the clone as template.
+  const handleSaveAsUsual = async (shipment) => {
+    try {
+      const copy = await shipmentService.copyShipment(shipment.id);
+      if (!copy.success) throw new Error(copy.error || 'Failed to copy shipment');
+      await shipmentService.patchShipment(copy.id, { is_template: true });
+      fetchAll();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleDelete = async (shipment) => {
     const label = shipment.order_number || shipment.po_number || `#${shipment.id}`;
-    if (!window.confirm(`Delete draft ${label}? This can't be undone.`)) return;
+    if (!window.confirm(`Delete draft ${label}? This cannot be undone.`)) return;
     try {
       const result = await shipmentService.deleteShipment(shipment.id);
-      if (result.success) {
-        fetchShipments();
-      } else {
-        alert(result.error || 'Failed to delete');
-      }
+      if (result.success) fetchAll();
+      else setError(result.error || 'Failed to delete shipment');
     } catch (err) {
-      alert(err.message);
+      setError(err.message);
     }
   };
 
-  const handleCopyShipment = async (shipmentId) => {
-    try {
-      const response = await fetch(`${config.apiUrl}/api/shipments/${shipmentId}/copy`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include'
-      });
-      
-      if (response.ok) {
-        const data = await response.json();
-        // Navigate to the new copied shipment
-        navigate(`/care/equipment/shipments/${data.id}?patient=${selectedPatient.id}`);
-      } else {
-        const errorData = await response.json();
-        alert(errorData.error || 'Failed to copy shipment');
-      }
-    } catch (err) {
-      console.error('Error copying shipment:', err);
-      alert('Error connecting to server');
+  // --- Card shaping. What is worth showing depends on where it is. ---
+
+  const detailsFor = (shipment) => {
+    if (shipment.status === 'draft') {
+      return [
+        { label: 'Updated', value: shortDate(shipment.updated_at) },
+        { label: 'Items', value: shipment.item_count ?? 0 },
+        { label: 'Type', value: shipment.is_backorder ? 'BACKORDER' : 'REGULAR' },
+      ];
     }
-  };
-
-  const formatDate = (dateString) => {
-    if (!dateString) return '-';
-    return new Date(dateString).toLocaleDateString();
-  };
-
-  const getStatusBadgeClass = (status) => {
-    switch (status) {
-      case 'draft': return 'admin-v2-badge-warning';
-      case 'ordered': return 'admin-v2-badge-secondary';
-      case 'shipped': return 'admin-v2-badge-info';
-      case 'receiving': return 'admin-v2-badge-warning';
-      case 'complete': return 'admin-v2-badge-success';
-      case 'partial': return 'admin-v2-badge-danger';
-      case 'verified': return 'admin-v2-badge-success';
-      default: return 'admin-v2-badge-secondary';
+    if (isOpen(shipment)) {
+      return [
+        { label: 'Expected', value: shortDate(shipment.expected_delivery) },
+        { label: 'Tracking', value: shortTracking(shipment.tracking_number) },
+        { label: 'Items', value: shipment.item_count ?? 0 },
+      ];
     }
+    return [
+      { label: 'Received', value: shortDate(shipment.actual_delivery || shipment.finalized_at) },
+      { label: 'Items', value: shipment.item_count ?? 0 },
+      { label: 'Type', value: shipment.is_backorder ? 'BACKORDER' : 'REGULAR' },
+    ];
   };
 
-  // Stats
-  const stats = {
-    total: shipments.length,
-    draft: shipments.filter(s => s.status === 'draft').length,
-    receiving: shipments.filter(s => s.status === 'receiving').length,
-    backorders: shipments.filter(s => s.is_backorder).length,
-    partial: shipments.filter(s => s.status === 'partial').length
+  const actionFor = (shipment) => {
+    if (shipment.status === 'draft') {
+      return { label: 'Continue draft', onClick: () => openShipment(shipment.id) };
+    }
+    if (isOpen(shipment)) {
+      return { label: 'Open delivery', onClick: () => openShipment(shipment.id) };
+    }
+    return { label: 'View receipt', onClick: () => openShipment(shipment.id) };
   };
 
-  // Loading state
+  const menuFor = (shipment) => {
+    const menu = [];
+    if (canCreate) menu.push({ label: 'Copy to new draft', onClick: () => handleCopy(shipment) });
+    if (canUpdate && !isOpen(shipment)) {
+      menu.push({ label: 'Save as usual order', onClick: () => handleSaveAsUsual(shipment) });
+    }
+    if (canDelete && shipment.status === 'draft') {
+      menu.push({ label: 'Delete draft', onClick: () => handleDelete(shipment), danger: true });
+    }
+    return menu;
+  };
+
+  const renderCard = (shipment) => (
+    <ShipmentCard
+      key={shipment.id}
+      shipment={shipment}
+      supplierName={supplierName(shipment)}
+      details={detailsFor(shipment)}
+      action={actionFor(shipment)}
+      menu={menuFor(shipment)}
+      showRail={isOpen(shipment) && shipment.status !== 'draft'}
+      onOpen={() => openShipment(shipment.id)}
+    />
+  );
+
   if (loadingPatients) {
+    return <AdminV2Layout><div className="admin-v2-loading">Loading patients…</div></AdminV2Layout>;
+  }
+
+  if (!selectedPatient) {
     return (
       <AdminV2Layout>
-        <div className="admin-v2-loading">Loading patients...</div>
+        <div className="admin-v2-loading">Select a patient from the sidebar</div>
       </AdminV2Layout>
     );
   }
 
   return (
     <AdminV2Layout>
-      <div className="admin-v2-page">
-        {selectedPatient ? (
-          <>
-            {/* Usual order — the zero-effort path when the monthly box shows up */}
-            {templates.length > 0 && (
-              <div className="admin-v2-info-banner">
-                <div className="admin-v2-info-content">
-                  <strong>Usual order{templates.length > 1 ? 's' : ''}</strong>
-                  <p>
-                    {templates.length === 1 && templates[0].supplier_name
-                      ? `Supplies from ${templates[0].supplier_name} arrive on a schedule. When the box shows up, start here.`
-                      : 'When the recurring box shows up, start here.'}
-                  </p>
-                </div>
-                <div className="tw flex flex-wrap gap-2">
-                  {templates.map((t) => (
-                    <React.Fragment key={t.id}>
-                      {hasPermission('equipment.create') && (
-                        <Button size="lg" onClick={() => handleDeliveryArrived(t.id)} disabled={creatingDelivery}>
-                          <PackageIcon size={16} /> {creatingDelivery ? 'One moment…' : `A delivery arrived${templates.length > 1 ? ` — ${t.supplier_name || t.order_number || `#${t.id}`}` : ' — start here'}`}
-                        </Button>
-                      )}
-                      <Button
-                        variant="ghost"
-                        onClick={() => navigate(`/care/equipment/shipments/${t.id}?patient=${selectedPatient.id}`)}
-                      >
-                        View usual order
-                      </Button>
-                    </React.Fragment>
-                  ))}
-                </div>
-              </div>
-            )}
+      <div className="admin-v2-page sh-page">
+        {error && <div className="sh-error" role="alert">{error}</div>}
 
-            {/* Stats Row */}
-            <div className="admin-v2-summary-stats admin-v2-shipments-summary">
-              <div className="admin-v2-stat-card">
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(88, 166, 255, 0.15)' }}>
-                  <EquipmentIcon size={20} />
-                </div>
-                <div className="admin-v2-stat-info">
-                  <h4>{stats.total}</h4>
-                  <p>Total Shipments</p>
-                </div>
-              </div>
-              <div className="admin-v2-stat-card">
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(187, 128, 9, 0.15)' }}>
-                  <ClockIcon size={20} />
-                </div>
-                <div className="admin-v2-stat-info">
-                  <h4>{stats.draft}</h4>
-                  <p>Drafts</p>
-                </div>
-              </div>
-              <div className="admin-v2-stat-card">
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(158, 106, 3, 0.15)' }}>
-                  <ClockIcon size={20} />
-                </div>
-                <div className="admin-v2-stat-info">
-                  <h4>{stats.receiving}</h4>
-                  <p>Receiving</p>
-                </div>
-              </div>
-              <div className="admin-v2-stat-card">
-                <div className="admin-v2-stat-icon" style={{ background: 'rgba(248, 81, 73, 0.15)' }}>
-                  <AlertIcon size={20} />
-                </div>
-                <div className="admin-v2-stat-info">
-                  <h4>{stats.partial}</h4>
-                  <p>With Issues</p>
-                </div>
-              </div>
+        {/* The zero-effort path: the recurring box turned up, start here. */}
+        {templates.length > 0 && canCreate && (
+          <section className="sh-usual">
+            <h2 className="sh-usual-title">Usual order{templates.length > 1 ? 's' : ''}</h2>
+            <p className="sh-usual-note">
+              Supplies that arrive on a schedule. When the box shows up, start here.
+            </p>
+            <div className="sh-usual-actions">
+              {templates.map((t) => (
+                <button key={t.id} type="button" className="sh-btn primary"
+                        disabled={creatingDelivery}
+                        onClick={() => handleDeliveryArrived(t.id)}>
+                  <PackageIcon size={16} />
+                  {creatingDelivery ? 'One moment…' : (
+                    templates.length > 1
+                      ? `Arrived — ${supplierName(t) || t.order_number || `#${t.id}`}`
+                      : 'A delivery arrived'
+                  )}
+                </button>
+              ))}
+              {templates.map((t) => (
+                <button key={`view-${t.id}`} type="button" className="sh-btn ghost"
+                        onClick={() => openShipment(t.id)}>
+                  View usual order
+                </button>
+              ))}
             </div>
-
-            {/* Filter Bar */}
-            <div className="history-filter-bar">
-              <div className="history-filter-row">
-                <div className="history-filter-group">
-                  <label>Status</label>
-                  <select
-                    value={statusFilter}
-                    onChange={e => setStatusFilter(e.target.value)}
-                    className="history-filter-select"
-                  >
-                    {STATUS_OPTIONS.map(opt => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </select>
-                </div>
-                
-                <div className="history-filter-group">
-                  <label>Type</label>
-                  <select
-                    value={backorderFilter}
-                    onChange={e => setBackorderFilter(e.target.value)}
-                    className="history-filter-select"
-                  >
-                    <option value="">All Types</option>
-                    <option value="false">Regular</option>
-                    <option value="true">Backorder</option>
-                  </select>
-                </div>
-                
-                {hasPermission('equipment.create') && (
-                  <div className="tw" style={{ marginLeft: 'auto' }}>
-                    <Button onClick={() => { resetForm(); setShowCreateModal(true); }}>
-                      <PlusIcon size={16} /> New Shipment
-                    </Button>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Shipments Table */}
-            {loading ? (
-              <div className="admin-v2-loading">Loading shipments...</div>
-            ) : error ? (
-              <div className="tw"><Alert variant="destructive">{error}</Alert></div>
-            ) : shipments.length === 0 ? (
-              <div className="admin-v2-empty-state">
-                <EquipmentIcon size={48} />
-                <h3>No Shipments Found</h3>
-                <p className="admin-v2-text-muted">Create a shipment to start tracking DME deliveries.</p>
-                {hasPermission('equipment.create') && (
-                  <div className="tw">
-                    <Button onClick={() => { resetForm(); setShowCreateModal(true); }}>
-                      <PlusIcon size={16} /> New Shipment
-                    </Button>
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div className="admin-v2-table-container admin-v2-table-cards-wrap">
-                <table className="admin-v2-table admin-v2-table-cards">
-                  <thead>
-                    <tr>
-                      <th>Order #</th>
-                      <th>Supplier</th>
-                      <th>Order Date</th>
-                      <th>Status</th>
-                      <th>Items</th>
-                      <th>Type</th>
-                      <th></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {shipments.map(shipment => (
-                      <tr 
-                        key={shipment.id}
-                        className="admin-v2-clickable-row"
-                        onClick={() => navigate(`/care/equipment/shipments/${shipment.id}?patient=${selectedPatient.id}`)}
-                      >
-                        <td className="admin-v2-cell-name">
-                          <strong>{shipment.order_number || shipment.po_number || `#${shipment.id}`}</strong>
-                        </td>
-                        <td data-label="Supplier">{shipment.supplier_name || '-'}</td>
-                        <td data-label="Order Date">{formatDate(shipment.order_date || shipment.ship_date)}</td>
-                        <td data-label="Status">
-                          <span className={`admin-v2-badge ${getStatusBadgeClass(shipment.status)}`}>
-                            {shipment.status}
-                          </span>
-                        </td>
-                        <td data-label="Items">{shipment.item_count || 0}</td>
-                        <td data-label="Type">
-                          {shipment.is_backorder ? (
-                            <span className="admin-v2-badge admin-v2-badge-warning">Backorder</span>
-                          ) : (
-                            <span className="admin-v2-badge admin-v2-badge-secondary">Regular</span>
-                          )}
-                        </td>
-                        <td className="admin-v2-cell-actions" style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-                          {templates.length === 0 && ['complete', 'verified'].includes(shipment.status)
-                            && hasPermission('equipment.create') && (
-                            <button
-                              className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-secondary"
-                              onClick={(e) => { e.stopPropagation(); handleSaveAsUsualOrder(shipment.id); }}
-                              title="Save this as the usual order, so next month is one tap"
-                            >
-                              Save as usual order
-                            </button>
-                          )}
-                          <button
-                            className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-secondary"
-                            onClick={(e) => { e.stopPropagation(); handleCopyShipment(shipment.id); }}
-                            title="Copy Shipment"
-                          >
-                            <CopyIcon size={14} />
-                          </button>
-                          {shipment.status === 'draft' && hasPermission('equipment.delete') && (
-                            <button
-                              className="admin-v2-btn admin-v2-btn-sm admin-v2-btn-secondary"
-                              onClick={(e) => { e.stopPropagation(); handleDeleteShipment(shipment); }}
-                              title="Delete this draft"
-                            >
-                              <TrashIcon size={14} />
-                            </button>
-                          )}
-                          <ChevronRightIcon size={16} />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </>
-        ) : (
-          <div className="admin-v2-loading">Select a patient from the sidebar</div>
+          </section>
         )}
 
-        {/* Create Shipment Dialog */}
-        <Dialog open={showCreateModal} onOpenChange={(o) => { if (!o) setShowCreateModal(false); }}>
-          <DialogContent className="sm:max-w-[640px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>New Shipment</DialogTitle>
-            </DialogHeader>
-            <form onSubmit={handleCreateShipment} className="flex flex-col gap-4">
-              {formError && <Alert variant="destructive">{formError}</Alert>}
+        <div className="sh-head">
+          <h1 className="sh-title">Shipments</h1>
+          <div className="sh-head-actions">
+            <button type="button" className={`sh-btn ghost ${showSearch ? 'active' : ''}`}
+                    aria-label="Search shipments" aria-expanded={showSearch}
+                    onClick={() => { setShowSearch((v) => !v); if (showSearch) setSearch(''); }}>
+              <SearchIcon size={16} /> Search
+            </button>
+            {canCreate && (
+              <button type="button" className="sh-btn primary" onClick={() => setCreateOpen(true)}>
+                <PlusIcon size={16} /> New
+              </button>
+            )}
+          </div>
+        </div>
 
-              <Field label="Supplier (DME Provider)">
-                <Select
-                  value={selectedSupplierId || '__none__'}
-                  onValueChange={(v) => setSelectedSupplierId(v === '__none__' ? '' : v)}
-                >
-                  <SelectTrigger><SelectValue placeholder="-- Select Supplier --" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__none__">-- Select Supplier --</SelectItem>
-                    {suppliers.map(s => (
-                      <SelectItem key={s.id} value={String(s.id)}>{s.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </Field>
+        {/* Each count filters to what it counted — a number you can act on. */}
+        <div className="sh-stats">
+          <button type="button" className="sh-stat" onClick={() => setStatusFilter('')}>
+            <span className="sh-stat-label">Open</span>
+            <span className="sh-stat-value tone-accent">{counts.open}</span>
+          </button>
+          <button type="button" className="sh-stat" onClick={() => setStatusFilter('draft')}>
+            <span className="sh-stat-label">Drafts</span>
+            <span className="sh-stat-value tone-due">{counts.draft}</span>
+          </button>
+          <button type="button" className="sh-stat"
+                  onClick={() => navigate(`/care/equipment/alerts?patient=${selectedPatient.id}`)}>
+            <span className="sh-stat-label">Needs attention</span>
+            <span className={`sh-stat-value ${counts.attention ? 'tone-alert' : 'tone-idle'}`}>
+              {counts.attention}
+            </span>
+          </button>
+        </div>
 
-              <FormRow>
-                <Field label="PO Number" htmlFor="ship-po">
-                  <Input
-                    id="ship-po"
-                    value={formData.po_number}
-                    onChange={e => setFormData({...formData, po_number: e.target.value})}
-                    placeholder="e.g., 55811"
-                  />
-                </Field>
-                <Field label="Order Number" htmlFor="ship-order">
-                  <Input
-                    id="ship-order"
-                    value={formData.order_number}
-                    onChange={e => setFormData({...formData, order_number: e.target.value})}
-                    placeholder="e.g., 1099274055"
-                  />
-                </Field>
-              </FormRow>
+        {showSearch && (
+          <div className="sh-search">
+            <SearchIcon size={16} />
+            <input type="text" value={search} autoFocus
+                   aria-label="Search shipments"
+                   placeholder="Order, PO, tracking or supplier"
+                   onChange={(e) => setSearch(e.target.value)} />
+          </div>
+        )}
 
-              <FormRow>
-                <Field label="Ship Date" htmlFor="ship-date">
-                  <Input
-                    id="ship-date"
-                    type="date"
-                    value={formData.ship_date}
-                    onChange={e => setFormData({...formData, ship_date: e.target.value})}
-                  />
-                </Field>
-                <Field label="Expected Delivery" htmlFor="ship-expected">
-                  <Input
-                    id="ship-expected"
-                    type="date"
-                    value={formData.expected_delivery}
-                    onChange={e => setFormData({...formData, expected_delivery: e.target.value})}
-                  />
-                </Field>
-              </FormRow>
+        <ChipGroup
+          options={[
+            { value: '', label: 'All' },
+            ...STATUS_FILTERS.map((s) => ({ value: s, label: statusLabel(s) })),
+          ]}
+          value={statusFilter}
+          onChange={setStatusFilter}
+          label="Status"
+          scroll
+        />
 
-              <FormRow>
-                <Field label="Tracking Number" htmlFor="ship-tracking">
-                  <Input
-                    id="ship-tracking"
-                    value={formData.tracking_number}
-                    onChange={e => setFormData({...formData, tracking_number: e.target.value})}
-                    placeholder="Tracking #"
-                  />
-                </Field>
-                <Field label="Ship Method" htmlFor="ship-method">
-                  <Input
-                    id="ship-method"
-                    value={formData.ship_method}
-                    onChange={e => setFormData({...formData, ship_method: e.target.value})}
-                    placeholder="e.g., FedEx-Ground"
-                  />
-                </Field>
-              </FormRow>
+        {loading ? (
+          <div className="admin-v2-loading">Loading shipments…</div>
+        ) : visible.length === 0 ? (
+          <div className="sh-empty">
+            <PackageIcon size={28} />
+            <p>{search || statusFilter ? 'Nothing matches that.' : 'No shipments yet.'}</p>
+          </div>
+        ) : (
+          <>
+            {inProgress.length > 0 && (
+              <section className="sh-group">
+                <h2 className="sh-group-title">In progress ({inProgress.length})</h2>
+                <div className="sh-list">{inProgress.map(renderCard)}</div>
+              </section>
+            )}
+            {recent.length > 0 && (
+              <section className="sh-group">
+                <h2 className="sh-group-title">Recent ({recent.length})</h2>
+                <div className="sh-list">{recent.map(renderCard)}</div>
+              </section>
+            )}
+          </>
+        )}
 
-              <Field label="Notes" htmlFor="ship-notes">
-                <Textarea
-                  id="ship-notes"
-                  value={formData.notes}
-                  onChange={e => setFormData({...formData, notes: e.target.value})}
-                  rows={2}
-                  placeholder="Optional notes"
-                />
-              </Field>
-
-              <DialogFooter>
-                <Button type="button" variant="secondary" onClick={() => setShowCreateModal(false)}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={saving}>
-                  {saving ? 'Creating...' : 'Create & Add Items'}
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
+        <ShipmentDetailsModal
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          suppliers={suppliers}
+          saving={busy}
+          onSave={handleCreate}
+        />
       </div>
     </AdminV2Layout>
   );

--- a/frontend/src/pages/admin-v2/AdminV2Shipments.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Shipments.test.jsx
@@ -1,0 +1,145 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The Deliveries list: grouping, the counts, and the permission gating that
+// used to ask for equipment.* while the endpoints required shipments.*.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('./AdminV2Layout', () => ({ default: ({ children }) => <div>{children}</div> }));
+
+let mockUser = { is_system_admin: false, permissions: [] };
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => ({ user: mockUser }) }));
+
+const patient = { id: 1, first_name: 'Pat', last_name: 'Ient' };
+vi.mock('../../contexts/AdminPatientContext', () => ({
+  useAdminPatient: () => ({
+    patients: [patient],
+    selectedPatient: patient,
+    selectPatient: vi.fn(),
+    loadingPatients: false,
+  }),
+}));
+
+const listShipments = vi.fn();
+const listTemplates = vi.fn();
+vi.mock('../../services/shipments', () => ({
+  shipmentService: {
+    listShipments: (...a) => listShipments(...a),
+    listTemplates: (...a) => listTemplates(...a),
+    createShipment: vi.fn(),
+    copyShipment: vi.fn(),
+    patchShipment: vi.fn(),
+    deleteShipment: vi.fn(),
+    createDeliveryFromTemplate: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/businesses', () => ({
+  businessService: { listDmeSuppliers: async () => [{ id: 9, name: 'Pediatric Home Service' }] },
+}));
+
+import AdminV2Shipments from './AdminV2Shipments';
+
+const SHIPMENTS = [
+  { id: 1, order_number: '78711852', status: 'shipped', supplier_id: 9, item_count: 14, tracking_number: '1Z8400000000392' },
+  { id: 2, status: 'draft', supplier_id: 9, item_count: 0, updated_at: '2026-08-18T10:00:00Z' },
+  { id: 3, order_number: '78599210', status: 'complete', supplier_id: 9, item_count: 18, finalized_at: '2026-08-04T10:00:00Z' },
+  { id: 4, order_number: '78500000', status: 'partial', supplier_id: 9, item_count: 3, finalized_at: '2026-08-01T10:00:00Z' },
+];
+
+const renderPage = () => render(
+  <MemoryRouter><AdminV2Shipments /></MemoryRouter>,
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUser = { is_system_admin: true, permissions: [] };
+  listShipments.mockResolvedValue({ shipments: SHIPMENTS });
+  listTemplates.mockResolvedValue({ shipments: [] });
+});
+
+describe('AdminV2Shipments', () => {
+  it('splits the list into what is moving and what has landed', async () => {
+    renderPage();
+    // shipped + draft are open; complete + partial have landed
+    await waitFor(() => expect(screen.getByText('In progress (2)')).toBeInTheDocument());
+    expect(screen.getByText('Recent (2)')).toBeInTheDocument();
+  });
+
+  it('counts open, drafts and what needs attention', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Open')).toBeInTheDocument());
+    const value = (label) => screen.getByText(label).parentElement.querySelector('.sh-stat-value');
+    expect(value('Open').textContent).toBe('2');
+    expect(value('Drafts').textContent).toBe('1');
+    // the partial delivery is the one that wants a person
+    expect(value('Needs attention').textContent).toBe('1');
+  });
+
+  it('falls back to the id when a draft has no order number', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByRole('button', { name: '#2' })).toBeInTheDocument());
+  });
+
+  it('searches across order, tracking and supplier', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('In progress (2)')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText('Search shipments'));
+    fireEvent.change(screen.getByPlaceholderText(/Order, PO, tracking/), {
+      target: { value: '1Z84' },
+    });
+    await waitFor(() => expect(screen.getByText('In progress (1)')).toBeInTheDocument());
+    expect(screen.queryByText(/Recent/)).not.toBeInTheDocument();
+  });
+
+  it('hides New from a user without shipments.create', async () => {
+    mockUser = { is_system_admin: false, permissions: ['shipments.read'] };
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Shipments')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /New/ })).not.toBeInTheDocument();
+  });
+
+  it('does not accept equipment.* in place of shipments.*', async () => {
+    // The old page gated every button on equipment.*, so this user saw
+    // actions whose endpoints would have refused them.
+    mockUser = { is_system_admin: false, permissions: ['equipment.create', 'equipment.delete'] };
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Shipments')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /New/ })).not.toBeInTheDocument();
+  });
+
+  it('shows New to a user who holds shipments.create', async () => {
+    mockUser = { is_system_admin: false, permissions: ['shipments.read', 'shipments.create'] };
+    renderPage();
+    await waitFor(() => expect(screen.getByRole('button', { name: /New/ })).toBeInTheDocument());
+  });
+
+  it('says so when there is nothing rather than rendering empty groups', async () => {
+    listShipments.mockResolvedValue({ shipments: [] });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('No shipments yet.')).toBeInTheDocument());
+  });
+
+  it('surfaces a failed load instead of showing an empty list', async () => {
+    listShipments.mockRejectedValue(new Error('Boom'));
+    renderPage();
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Boom'));
+  });
+});

--- a/frontend/src/pages/admin-v2/components/shipments-page.css
+++ b/frontend/src/pages/admin-v2/components/shipments-page.css
@@ -247,3 +247,541 @@
   font-size: 0.78rem;
   color: var(--vc-text-tertiary);
 }
+
+/* --- shipment detail --- */
+
+:root:not(.light) .sd-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+:root:not(.light) .sd-back {
+  display: grid;
+  place-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  background: none;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+:root:not(.light) .sd-back:hover {
+  border-color: var(--vc-data-live);
+  color: var(--vc-data-live);
+}
+
+:root:not(.light) .sd-title {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+
+/* --- wizard rail --- */
+
+:root:not(.light) .sd-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+}
+
+:root:not(.light) .sd-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 9px 6px;
+  background: none;
+  border: 0;
+  border-radius: 7px;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+:root:not(.light) .sd-step:hover {
+  background: color-mix(in srgb, var(--vc-text-primary) 6%, transparent);
+}
+:root:not(.light) .sd-step.is-active {
+  background: color-mix(in srgb, var(--vc-data-live) 16%, transparent);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .sd-step:focus-visible {
+  outline: 2px solid var(--vc-data-live);
+  outline-offset: -2px;
+}
+
+:root:not(.light) .sd-step-num {
+  display: grid;
+  place-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border: 2px solid var(--vc-state-idle);
+  border-radius: 50%;
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+}
+:root:not(.light) .sd-step.is-reached .sd-step-num {
+  border-color: var(--vc-data-live);
+  color: var(--vc-data-live);
+}
+:root:not(.light) .sd-step.is-active .sd-step-num {
+  background: var(--vc-data-live);
+  border-color: var(--vc-data-live);
+  color: var(--vc-bg-base);
+}
+
+:root:not(.light) .sd-step-name {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+/* --- meta --- */
+
+:root:not(.light) .sd-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+:root:not(.light) .sd-meta-line {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .sd-refs {
+  margin: -8px 0 0;
+  font-size: 0.78rem;
+  color: var(--vc-text-tertiary);
+}
+
+:root:not(.light) .sd-usual {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+  padding: 14px 16px;
+  border: 1px solid color-mix(in srgb, var(--vc-data-live) 40%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--vc-data-live) 8%, var(--vc-bg-surface));
+}
+:root:not(.light) .sd-usual p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--vc-text-secondary);
+}
+
+/* --- sections --- */
+
+:root:not(.light) .sd-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+}
+
+:root:not(.light) .sd-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+:root:not(.light) .sd-section-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .sd-pill {
+  padding: 2px 9px;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 999px;
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .sd-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+:root:not(.light) .sd-hint {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .sd-items {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+:root:not(.light) .sd-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-top: 12px;
+  border-top: 1px solid var(--vc-line-hairline);
+}
+
+:root:not(.light) .sd-foot-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--vc-font-mono);
+  font-size: 0.8rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .sd-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+:root:not(.light) .sd-facts dt {
+  font-size: 0.62rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .sd-facts dd {
+  margin: 3px 0 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.88rem;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .sd-done {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 13px 15px;
+  border: 1px solid color-mix(in srgb, var(--vc-state-complete) 45%, transparent);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--vc-state-complete) 10%, transparent);
+  color: var(--vc-state-complete);
+}
+:root:not(.light) .sd-done-title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .sd-done-note {
+  margin: 3px 0 0;
+  font-size: 0.82rem;
+  color: var(--vc-text-secondary);
+}
+
+/* --- scanned drafts --- */
+
+:root:not(.light) .sd-drafts {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px dashed var(--vc-line-strong);
+  border-radius: 9px;
+}
+
+:root:not(.light) .sd-draft-row {
+  display: grid;
+  grid-template-columns: 1fr 130px 80px auto;
+  gap: 8px;
+  align-items: center;
+}
+@media (max-width: 640px) {
+  :root:not(.light) .sd-draft-row { grid-template-columns: 1fr 1fr; }
+}
+
+:root:not(.light) .sd-drafts-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+/* --- packing slips --- */
+
+:root:not(.light) .sd-slips {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 10px;
+}
+
+:root:not(.light) .sd-slip {
+  position: relative;
+  margin: 0;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  overflow: hidden;
+}
+:root:not(.light) .sd-slip img {
+  display: block;
+  width: 100%;
+  height: 110px;
+  object-fit: cover;
+}
+
+:root:not(.light) .sd-slip-remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.65);
+  color: var(--vc-text-primary);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+/* --- alerts --- */
+
+:root:not(.light) .sd-alerts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+:root:not(.light) .sd-alerts li {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 11px;
+  border: 1px solid color-mix(in srgb, var(--vc-state-due) 40%, transparent);
+  border-radius: 8px;
+  color: var(--vc-state-due);
+  font-size: 0.85rem;
+}
+:root:not(.light) .sd-alerts li.is-resolved {
+  border-color: var(--vc-line-hairline);
+  color: var(--vc-text-tertiary);
+}
+:root:not(.light) .sd-alert-type {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+:root:not(.light) .sd-alert-note {
+  flex: 1;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .sd-alert-tag {
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* --- receive review --- */
+
+:root:not(.light) .rr {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+:root:not(.light) .rr-sub {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .rr-rows,
+:root:not(.light) .rr-extras {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+:root:not(.light) .rr-row,
+:root:not(.light) .rr-extra {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 11px 12px;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 9px;
+  background: var(--vc-bg-raised);
+}
+
+:root:not(.light) .rr-row-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+:root:not(.light) .rr-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .rr-tag {
+  padding: 2px 8px;
+  border: 1px solid var(--vc-data-live);
+  border-radius: 999px;
+  font-size: 0.62rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--vc-data-live);
+  white-space: nowrap;
+}
+
+:root:not(.light) .rr-fields,
+:root:not(.light) .rr-extra-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 8px;
+  align-items: end;
+}
+
+:root:not(.light) .rr-mini {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+:root:not(.light) .rr-mini > span {
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .rr-mini input[readonly] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* --- delivery problems (alerts) --- */
+
+:root:not(.light) .sa-selectall {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 0.82rem;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+
+:root:not(.light) .sa-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 13px 15px;
+  border: 1px solid color-mix(in srgb, var(--vc-state-due) 40%, transparent);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+}
+:root:not(.light) .sa-card.is-resolved {
+  border-color: var(--vc-line-hairline);
+  opacity: 0.75;
+}
+
+:root:not(.light) .sa-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--vc-state-due);
+}
+:root:not(.light) .sa-card.is-resolved .sa-head { color: var(--vc-text-tertiary); }
+
+:root:not(.light) .sa-type {
+  flex: 1;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .sa-tag {
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+:root:not(.light) .sa-tag.open {
+  border: 1px solid var(--vc-state-due);
+  color: var(--vc-state-due);
+}
+:root:not(.light) .sa-tag.resolved {
+  border: 1px solid var(--vc-line-strong);
+  color: var(--vc-text-tertiary);
+}
+
+:root:not(.light) .sa-notes {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .sa-facts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin: 0;
+  padding-top: 9px;
+  border-top: 1px solid var(--vc-line-hairline);
+}
+:root:not(.light) .sa-facts dt {
+  font-size: 0.6rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .sa-facts dd {
+  margin: 3px 0 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.88rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .sa-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}

--- a/frontend/src/pages/admin-v2/components/shipments-page.css
+++ b/frontend/src/pages/admin-v2/components/shipments-page.css
@@ -1,0 +1,249 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* The Deliveries list and the shipment detail page. Dark-only, matching the
+ * rest of the vc skin. */
+
+:root:not(.light) .sh-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+:root:not(.light) .sh-error {
+  padding: 10px 14px;
+  border: 1px solid color-mix(in srgb, var(--vc-state-alert) 50%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
+  color: var(--vc-text-primary);
+  font-size: 0.85rem;
+}
+
+/* --- head --- */
+
+:root:not(.light) .sh-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+:root:not(.light) .sh-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .sh-head-actions { display: flex; gap: 8px; }
+
+/* --- buttons --- */
+
+:root:not(.light) .sh-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 14px;
+  border-radius: 7px;
+  border: 1px solid var(--vc-line-strong);
+  background: transparent;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+:root:not(.light) .sh-btn:hover:not(:disabled) {
+  border-color: var(--vc-data-live);
+  color: var(--vc-data-live);
+}
+
+:root:not(.light) .sh-btn.primary {
+  background: var(--vc-data-live);
+  border-color: var(--vc-data-live);
+  color: var(--vc-bg-base);
+}
+:root:not(.light) .sh-btn.primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--vc-data-live) 85%, white);
+  color: var(--vc-bg-base);
+}
+
+:root:not(.light) .sh-btn.active {
+  border-color: var(--vc-data-live);
+  color: var(--vc-data-live);
+}
+
+:root:not(.light) .sh-btn:disabled { opacity: 0.55; cursor: default; }
+
+:root:not(.light) .sh-btn:focus-visible {
+  outline: 2px solid var(--vc-data-live);
+  outline-offset: 2px;
+}
+
+/* --- usual order --- */
+
+:root:not(.light) .sh-usual {
+  padding: 14px 16px;
+  border: 1px solid color-mix(in srgb, var(--vc-data-live) 40%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--vc-data-live) 8%, var(--vc-bg-surface));
+}
+
+:root:not(.light) .sh-usual-title {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .sh-usual-note {
+  margin: 4px 0 12px;
+  font-size: 0.85rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .sh-usual-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* --- stat row --- */
+
+:root:not(.light) .sh-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+
+:root:not(.light) .sh-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 14px 8px;
+  background: none;
+  border: 0;
+  border-left: 1px solid var(--vc-line-hairline);
+  cursor: pointer;
+}
+:root:not(.light) .sh-stat:first-child { border-left: 0; }
+:root:not(.light) .sh-stat:hover {
+  background: color-mix(in srgb, var(--vc-text-primary) 5%, transparent);
+}
+:root:not(.light) .sh-stat:focus-visible {
+  outline: 2px solid var(--vc-data-live);
+  outline-offset: -2px;
+}
+
+:root:not(.light) .sh-stat-label {
+  font-size: 0.62rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  text-align: center;
+}
+
+:root:not(.light) .sh-stat-value {
+  font-family: var(--vc-font-mono);
+  font-size: 1.6rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+:root:not(.light) .sh-stat-value.tone-accent { color: var(--vc-data-live); }
+:root:not(.light) .sh-stat-value.tone-due { color: var(--vc-state-due); }
+:root:not(.light) .sh-stat-value.tone-alert { color: var(--vc-state-alert); }
+:root:not(.light) .sh-stat-value.tone-idle { color: var(--vc-text-tertiary); }
+
+/* --- search --- */
+
+:root:not(.light) .sh-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 7px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .sh-search input {
+  flex: 1;
+  padding: 10px 0;
+  background: none;
+  border: 0;
+  color: var(--vc-text-primary);
+  font-size: 0.9rem;
+}
+:root:not(.light) .sh-search input:focus { outline: none; }
+:root:not(.light) .sh-search:focus-within { border-color: var(--vc-data-live); }
+
+/* --- groups --- */
+
+:root:not(.light) .sh-group-title {
+  margin: 0 0 10px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .sh-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+:root:not(.light) .sh-group + .sh-group { margin-top: 20px; }
+
+/* --- empty --- */
+
+:root:not(.light) .sh-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 40px 20px;
+  border: 1px dashed var(--vc-line-strong);
+  border-radius: 10px;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .sh-empty p { margin: 0; font-size: 0.9rem; }
+
+/* --- footnote --- */
+
+:root:not(.light) .sh-note {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--vc-text-tertiary);
+}

--- a/frontend/src/services/businesses.js
+++ b/frontend/src/services/businesses.js
@@ -1,0 +1,45 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Businesses. Only the supplier lookup the shipments pages need lives here so
+// far — both of them fetched `/api/businesses?type=dme` by hand, and each
+// unwrapped the response differently.
+import config, { apiFetch } from '../config';
+
+async function asJson(response, fallbackMessage) {
+  if (!response.ok) {
+    let detail = fallbackMessage;
+    try {
+      const body = await response.json();
+      detail = body.detail || body.error || fallbackMessage;
+    } catch { /* non-JSON error body */ }
+    throw new Error(detail);
+  }
+  return response.json();
+}
+
+export const businessService = {
+  /** DME suppliers, always as an array. */
+  async listDmeSuppliers() {
+    const response = await apiFetch(`${config.apiUrl}/api/businesses?type=dme`);
+    const data = await asJson(response, 'Failed to fetch suppliers');
+    if (Array.isArray(data)) return data;
+    return data.businesses || [];
+  },
+};
+
+export default businessService;

--- a/frontend/src/services/shipments.js
+++ b/frontend/src/services/shipments.js
@@ -73,6 +73,74 @@ export const shipmentService = {
     return asJson(response, 'Failed to update shipment');
   },
 
+  async copyShipment(shipmentId) {
+    const response = await apiFetch(`${config.apiUrl}/api/shipments/${shipmentId}/copy`, {
+      method: 'POST',
+    });
+    return asJson(response, 'Failed to copy shipment');
+  },
+
+  // --- Items ---
+  async addItem(shipmentId, data) {
+    const response = await apiFetch(`${config.apiUrl}/api/shipments/${shipmentId}/items`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    return asJson(response, 'Failed to add item');
+  },
+
+  // --- Receiving ---
+  async receiveItems(shipmentId, items) {
+    const response = await apiFetch(`${config.apiUrl}/api/shipments/${shipmentId}/receive`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(items),
+    });
+    return asJson(response, 'Failed to record receipt');
+  },
+
+  async finalizeShipment(shipmentId) {
+    const response = await apiFetch(`${config.apiUrl}/api/shipments/${shipmentId}/finalize`, {
+      method: 'POST',
+    });
+    return asJson(response, 'Failed to finalize shipment');
+  },
+
+  // --- Alerts ---
+  // These had no service entry at all; the alerts page hand-rolled every call.
+  async listAlerts(params = {}) {
+    const qs = new URLSearchParams();
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined && v !== null && v !== '') qs.set(k, v);
+    });
+    const response = await apiFetch(`${config.apiUrl}/api/shipments/alerts?${qs}`);
+    return asJson(response, 'Failed to fetch alerts');
+  },
+
+  async listShipmentAlerts(shipmentId) {
+    const response = await apiFetch(`${config.apiUrl}/api/shipments/${shipmentId}/alerts`);
+    return asJson(response, 'Failed to fetch alerts');
+  },
+
+  async resolveAlert(alertId, resolutionNotes = null) {
+    const response = await apiFetch(`${config.apiUrl}/api/shipments/alerts/${alertId}/resolve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ resolution_notes: resolutionNotes }),
+    });
+    return asJson(response, 'Failed to resolve alert');
+  },
+
+  async createFollowupOrder(alertIds) {
+    const response = await apiFetch(`${config.apiUrl}/api/shipments/alerts/create-followup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alert_ids: alertIds }),
+    });
+    return asJson(response, 'Failed to create follow-up order');
+  },
+
   // --- Standing orders ("usual order") ---
   async listTemplates(patientId) {
     return this.listShipments({ patient_id: patientId, is_template: true });


### PR DESCRIPTION
Equipment was the last unconverted family — all three shipment pages were pre-vc, 3,248 lines between them with no component test. Rebuilt from the supplied mockups.

## One status vocabulary

The label, the tone and the position on the progress rail were each written out separately on the list page and the detail page, so a status could read one way in the table and another on the page it linked to. `lib/shipmentStatus.js` is the one copy.

It describes the statuses the server **actually writes** — `draft, ordered, shipped, receiving, complete, partial`:

- **`verified` is gone.** It appears in a model comment and in both old badge maps, but no backend path sets it, so it is not a state a shipment can be found in.
- **There is no `delivered` or `received`.** Arrival is `receiving` until finalize decides between `complete` and `partial`. The mockup's four-node rail maps onto that rather than inventing states to match the drawing.

## Deliveries list

Cards instead of a seven-column table, grouped by whether the shipment is still moving. What a card shows changes with where it is — a draft has no tracking to show, a finished one has no date to wait for. The three counts name the states worth interrupting for and **each opens what it counted** instead of being a number with no way in.

## Shipment detail

Three steps in order — build the list, say it was placed, receive what turned up — opening on the step the shipment is actually at. The page was a flat scroll of twelve conditional sections with a whole second workflow behind an "Advanced options" disclosure.

The quantity stepper works only while the shipment is a draft. After that the number is a claim about what the supplier sent rather than what we asked for, and correcting it belongs to the receive step.

Received shows an em dash until a receipt exists, so "nothing recorded yet" stops reading as a recorded zero.

## Bugs found and fixed

- **Receiving never worked outside the reconcile path.** Both legacy handlers POSTed a single object to `/receive`, which takes a `List[ReceiveItem]`. Every receipt 422'd — and `handleSaveReceiving` went on to PATCH the shipment to `complete` regardless, so a delivery run through that path read as fully received with **no receipt rows and no inventory movement**. Verified against the API: the bare object returns 422, the list returns 200. The fix is deleting that path; `reconcile` already does receive + alerts + backorder + status server-side in one call.
- **A successful follow-up order landed on `/shipments/undefined`.** The alerts page read `result.shipment_id`; the endpoint returns `followup_shipment_id`.
- **The follow-up modal's supplier picker was inert.** `CreateFollowupOrder` accepts `alert_ids` and nothing else, so the choice was dropped. The follow-up inherits the supplier of the shipment the alerts came from — which is what it always did. The dead control is gone rather than left looking functional.
- **Every shipment button was gated on `equipment.*`** while the endpoints require `shipments.*`. Per `seed_auth.py`, at least one seeded role holds `shipments.create/read/update/receive/finalize` but not `shipments.delete` — so the UI offered actions that would 403, and hid ones that would have worked.

## Consolidation

- 21 raw `fetch()` calls move into `shipmentService`, which had **no alerts entry at all** — that page hand-rolled all four of its calls. Four separate hand-rolled `PATCH /api/shipments/{id}` blocks in one file collapse to the service method that already existed.
- `businessService` replaces the DME-supplier fetch both pages hand-rolled and each unwrapped differently.
- `hasPermission`, `formatDate` and `getStatusBadgeClass` were reimplemented per page; the status one is now the shared vocabulary.
- The scan/OCR/wedge/CSV stack and the session-checkpoint logic are preserved as-is — restyled, not rewritten.

## Notes for review

- Nav is unchanged: the tabs were already History / Deliveries / Supplies, matching the mockup.
- **No backend changes in this PR** (`git diff dev/main...HEAD -- backend/` is empty). The `/receive` shape bug is fixed by deleting the broken caller, not by changing the endpoint.
- Gating on `shipments.*` is a live behaviour change: a role holding `equipment.*` but not `shipments.*` now correctly sees fewer actions.
- The mockup's tab strip shows three tabs with scroll chevrons; Overview and Alerts are still there, off-screen in the crop. I did not remove them on that evidence.

## Verification

Frontend **884 pass** (809 baseline + 75 new) · `npm run lint` clean at `--max-warnings 0` · production build succeeds.

The three pages drop from 3,248 lines to 1,661; the detail page alone goes from 2,055 to 964. The diff is +3,602 / −2,653 overall, the difference being the extracted components, the vc stylesheets and 75 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
