### PR TITLE
Gate and scope the equipment module

### DIFF
--- a/backend/crud/equipment.py
+++ b/backend/crud/equipment.py
@@ -30,6 +30,32 @@ from crud.patients import get_or_create_default_patient
 logger = logging.getLogger('crud')
 
 
+# --- Account scoping ---
+#
+# The list queries have taken an account_id since accounts landed, but every
+# by-id operation looked equipment up on its primary key alone, so a supply
+# could be read, changed, received, counted, renamed or deleted from another
+# account by naming its id.
+#
+# Equipment genuinely has shared rows -- a supply with no account belongs to
+# everyone in a single-tenant install -- so the filter is "mine or shared",
+# matching get_equipment_list, rather than the strict equality the shipment
+# tables use.
+
+def _scope_equipment(query, account_id):
+    if account_id is None:
+        return query
+    return query.filter(or_(Equipment.account_id == account_id,
+                            Equipment.account_id.is_(None)))
+
+
+def _owned_equipment(db: Session, equipment_id, account_id=None):
+    """The supply, or None if it does not exist or belongs to another account."""
+    return _scope_equipment(
+        db.query(Equipment).filter(Equipment.id == equipment_id), account_id,
+    ).first()
+
+
 # --- Equipment CRUD ---
 def add_equipment_simple(db: Session, name, quantity=1, scheduled_replacement=True, last_changed=None, useful_days=None, patient_id=None,
                          account_id=None, item_number=None, description=None, category='equipment', tracking_level='item',
@@ -75,12 +101,12 @@ def add_equipment_simple(db: Session, name, quantity=1, scheduled_replacement=Tr
         return None
 
 
-def get_equipment(db: Session, equipment_id):
+def get_equipment(db: Session, equipment_id, account_id=None):
     """
     Get a specific equipment item by ID
     """
     try:
-        equipment = db.query(Equipment).filter(Equipment.id == equipment_id).first()
+        equipment = _owned_equipment(db, equipment_id, account_id)
         if equipment:
             return {
                 'id': equipment.id,
@@ -115,7 +141,7 @@ def get_equipment(db: Session, equipment_id):
         return None
 
 
-def update_equipment(db: Session, equipment_id, name=None, quantity=None, scheduled_replacement=None, last_changed=None, useful_days=None, patient_id=None,
+def update_equipment(db: Session, equipment_id, account_id=None, name=None, quantity=None, scheduled_replacement=None, last_changed=None, useful_days=None, patient_id=None,
                       item_number=None, description=None, category=None, tracking_level=None,
                       default_manufacturer=None, unit_of_measure=None, unit_size=None, unit_description=None,
                       reorder_point=None, par_level=None, storage_location=None):
@@ -123,7 +149,7 @@ def update_equipment(db: Session, equipment_id, name=None, quantity=None, schedu
     Update an equipment item
     """
     try:
-        equipment = db.query(Equipment).filter(Equipment.id == equipment_id).first()
+        equipment = _owned_equipment(db, equipment_id, account_id)
         if not equipment:
             return False
         
@@ -224,12 +250,12 @@ def list_equipment(db: Session, patient_id=None, shared_only=False, skip=0, limi
         return []
 
 
-def delete_equipment(db: Session, equipment_id):
+def delete_equipment(db: Session, equipment_id, account_id=None):
     """
     Delete an equipment item
     """
     try:
-        equipment = db.query(Equipment).filter(Equipment.id == equipment_id).first()
+        equipment = _owned_equipment(db, equipment_id, account_id)
         if not equipment:
             return False
         
@@ -339,11 +365,14 @@ def get_equipment_list(db: Session, patient_id: int = None, account_id: int = No
         return []
 
 
-def log_equipment_change(db: Session, equipment_id, changed_at, patient_id=None, notes=None, changed_by=None):
+def log_equipment_change(db: Session, equipment_id, changed_at, patient_id=None, notes=None, changed_by=None, account_id=None):
     """
     Log an equipment change and update the last_changed date
     """
     try:
+        if not _owned_equipment(db, equipment_id, account_id):
+            return False
+
         # Create change log entry
         change_log = EquipmentChangeLog(
             equipment_id=equipment_id,
@@ -356,7 +385,7 @@ def log_equipment_change(db: Session, equipment_id, changed_at, patient_id=None,
         db.add(change_log)
 
         # Update last_changed in equipment
-        equipment = db.query(Equipment).filter(Equipment.id == equipment_id).first()
+        equipment = _owned_equipment(db, equipment_id, account_id)
         if equipment:
             equipment.last_changed = changed_at
             equipment.updated_at = utc_now()
@@ -383,11 +412,14 @@ def log_equipment_change(db: Session, equipment_id, changed_at, patient_id=None,
         return False
 
 
-def get_equipment_change_history(db: Session, equipment_id):
+def get_equipment_change_history(db: Session, equipment_id, account_id=None):
     """
     Get change history for equipment
     """
     try:
+        if not _owned_equipment(db, equipment_id, account_id):
+            return []
+
         changes = db.query(EquipmentChangeLog).filter(
             EquipmentChangeLog.equipment_id == equipment_id
         ).order_by(EquipmentChangeLog.changed_at.desc()).all()
@@ -405,12 +437,12 @@ def get_equipment_change_history(db: Session, equipment_id):
         return []
 
 
-def receive_equipment(db: Session, equipment_id: int, amount: int = 1):
+def receive_equipment(db: Session, equipment_id: int, amount: int = 1, account_id=None):
     """
     Increase equipment quantity (receive new stock)
     """
     try:
-        equipment = db.query(Equipment).filter(Equipment.id == equipment_id).first()
+        equipment = _owned_equipment(db, equipment_id, account_id)
         if not equipment:
             return False
         
@@ -433,12 +465,12 @@ def receive_equipment(db: Session, equipment_id: int, amount: int = 1):
         return False
 
 
-def open_equipment(db: Session, equipment_id: int, amount: int = 1):
+def open_equipment(db: Session, equipment_id: int, amount: int = 1, account_id=None):
     """
     Decrease equipment quantity (open/use equipment) and log the action
     """
     try:
-        equipment = db.query(Equipment).filter(Equipment.id == equipment_id).first()
+        equipment = _owned_equipment(db, equipment_id, account_id)
         if not equipment:
             return False
         
@@ -701,14 +733,14 @@ def catalog_import(db: Session, items, account_id=None, patient_id=None, supplie
         return {'created': [], 'matched': [], 'errors': [{'index': None, 'reason': 'import failed'}]}
 
 
-def set_equipment_count(db: Session, equipment_id: int, quantity: int, note=None, counted_by=None):
+def set_equipment_count(db: Session, equipment_id: int, quantity: int, note=None, counted_by=None, account_id=None):
     """Physical stocktake: set the absolute on-hand quantity with an audit row.
 
     Unlike log_equipment_change this never touches last_changed — counting a
     shelf is not replacing an item.
     """
     try:
-        equipment = db.query(Equipment).filter(Equipment.id == equipment_id).first()
+        equipment = _owned_equipment(db, equipment_id, account_id)
         if not equipment:
             return None
         before = equipment.quantity or 0
@@ -736,9 +768,12 @@ def set_equipment_count(db: Session, equipment_id: int, quantity: int, note=None
         return None
 
 
-def get_equipment_count_history(db: Session, equipment_id: int, limit: int = 50):
+def get_equipment_count_history(db: Session, equipment_id: int, limit: int = 50, account_id=None):
     """Stocktake history for one supply, newest first."""
     try:
+        if not _owned_equipment(db, equipment_id, account_id):
+            return []
+
         counts = db.query(EquipmentCountLog).filter(
             EquipmentCountLog.equipment_id == equipment_id
         ).order_by(EquipmentCountLog.counted_at.desc()).limit(limit).all()
@@ -762,7 +797,7 @@ def get_equipment_count_history(db: Session, equipment_id: int, limit: int = 50)
 def add_equipment_alias(db: Session, equipment_id: int, item_number: str, supplier_id=None, raw_description=None, account_id=None):
     """Attach a provider item number to a supply. Returns the alias id, or None."""
     try:
-        equipment = db.query(Equipment).filter(Equipment.id == equipment_id).first()
+        equipment = _owned_equipment(db, equipment_id, account_id)
         if not equipment:
             return None
         item_number = (item_number or '').strip()
@@ -786,9 +821,12 @@ def add_equipment_alias(db: Session, equipment_id: int, item_number: str, suppli
         return None
 
 
-def delete_equipment_alias(db: Session, equipment_id: int, alias_id: int):
+def delete_equipment_alias(db: Session, equipment_id: int, alias_id: int, account_id=None):
     """Remove a provider alias from a supply."""
     try:
+        if not _owned_equipment(db, equipment_id, account_id):
+            return False
+
         alias = db.query(EquipmentProviderAlias).filter(
             EquipmentProviderAlias.id == alias_id,
             EquipmentProviderAlias.equipment_id == equipment_id,

--- a/backend/routes/equipment.py
+++ b/backend/routes/equipment.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm import Session
 from typing import List, Optional
 
 from db import get_db
-from dependencies import get_optional_account_id, get_optional_user
+from dependencies import get_optional_account_id, get_optional_user, require_permission
 from models.equipment import (
     EquipmentCreate,
     EquipmentUpdate,
@@ -54,7 +54,7 @@ logger = logging.getLogger("app")
 router = APIRouter(prefix="/api/equipment", tags=["equipment"])
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_permission("equipment.create"))])
 async def api_add_equipment(
     data: EquipmentCreate,
     db: Session = Depends(get_db),
@@ -78,15 +78,19 @@ async def api_add_equipment(
     return {"id": eid, "status": "success"}
 
 
-@router.get("", response_model=List[dict])
-async def api_get_equipment(patient_id: int = None, db: Session = Depends(get_db)):
+@router.get("", response_model=List[dict], dependencies=[Depends(require_permission("equipment.read"))])
+async def api_get_equipment(
+    patient_id: int = None,
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
+):
     """Get equipment list sorted by due next. Optionally filter by patient_id."""
-    return get_equipment_list(db, patient_id=patient_id)
+    return get_equipment_list(db, patient_id=patient_id, account_id=account_id)
 
 
 # NOTE: declared before the /{equipment_id} routes so the literal path
 # "catalog-import" is never parsed as an equipment id.
-@router.post("/catalog-import")
+@router.post("/catalog-import", dependencies=[Depends(require_permission("equipment.create"))])
 async def api_catalog_import(
     data: CatalogImportRequest,
     db: Session = Depends(get_db),
@@ -109,13 +113,18 @@ async def api_catalog_import(
     )
 
 
-@router.post("/{equipment_id}/change")
-async def api_log_equipment_change(equipment_id: int, data: EquipmentChangeLog, db: Session = Depends(get_db)):
+@router.post("/{equipment_id}/change", dependencies=[Depends(require_permission("equipment.change"))])
+async def api_log_equipment_change(
+    equipment_id: int,
+    data: EquipmentChangeLog,
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
+):
     """Log a change and update last_changed."""
-    
+
     # Check if equipment has scheduled replacement
-    from models import Equipment
-    equipment = db.query(Equipment).filter(Equipment.id == equipment_id).first()
+    from crud.equipment import _owned_equipment
+    equipment = _owned_equipment(db, equipment_id, account_id)
     if not equipment:
         return JSONResponse(status_code=404, content={"detail": "Equipment not found"})
     
@@ -140,54 +149,74 @@ async def api_log_equipment_change(equipment_id: int, data: EquipmentChangeLog, 
             "unit_of_measure": equipment.unit_of_measure,
         })
 
-    success = log_equipment_change(db, equipment_id, data.changed_at)
+    success = log_equipment_change(db, equipment_id, data.changed_at, account_id=account_id)
     return {"success": success}
 
 
-@router.get("/{equipment_id}/history")
-async def api_get_equipment_history(equipment_id: int, db: Session = Depends(get_db)):
+@router.get("/{equipment_id}/history", dependencies=[Depends(require_permission("equipment.read"))])
+async def api_get_equipment_history(
+    equipment_id: int,
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
+):
     """Get change history for equipment."""
-    return get_equipment_change_history(db, equipment_id)
+    return get_equipment_change_history(db, equipment_id, account_id=account_id)
 
 
-@router.post("/{equipment_id}/receive")
-async def api_receive_equipment(equipment_id: int, data: EquipmentQuantityChange, db: Session = Depends(get_db)):
+@router.post("/{equipment_id}/receive", dependencies=[Depends(require_permission("equipment.update"))])
+async def api_receive_equipment(
+    equipment_id: int,
+    data: EquipmentQuantityChange,
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
+):
     """Increase equipment quantity (receive new stock)."""
-    success = receive_equipment(db, equipment_id, data.amount)
+    success = receive_equipment(db, equipment_id, data.amount, account_id=account_id)
     return {"success": success}
 
 
-@router.post("/{equipment_id}/open")
-async def api_open_equipment(equipment_id: int, data: EquipmentQuantityChange, db: Session = Depends(get_db)):
+@router.post("/{equipment_id}/open", dependencies=[Depends(require_permission("equipment.update"))])
+async def api_open_equipment(
+    equipment_id: int,
+    data: EquipmentQuantityChange,
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
+):
     """Decrease equipment quantity (open/use equipment)."""
-    success = open_equipment(db, equipment_id, data.amount)
+    success = open_equipment(db, equipment_id, data.amount, account_id=account_id)
     return {"success": success}
 
 
-@router.post("/{equipment_id}/count")
+@router.post("/{equipment_id}/count", dependencies=[Depends(require_permission("equipment.update"))])
 async def api_set_equipment_count(
     equipment_id: int,
     data: EquipmentCountSet,
     db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
     current_user=Depends(get_optional_user),
 ):
     """Physical stocktake: set the absolute on-hand quantity (audited)."""
     result = set_equipment_count(
         db, equipment_id, data.quantity, note=data.note,
         counted_by=current_user.id if current_user else None,
+        account_id=account_id,
     )
     if result is None:
         return JSONResponse(status_code=404, content={"detail": "Equipment not found"})
     return result
 
 
-@router.get("/{equipment_id}/counts")
-async def api_get_equipment_count_history(equipment_id: int, db: Session = Depends(get_db)):
+@router.get("/{equipment_id}/counts", dependencies=[Depends(require_permission("equipment.read"))])
+async def api_get_equipment_count_history(
+    equipment_id: int,
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
+):
     """Stocktake history for one supply, newest first."""
-    return {"counts": get_equipment_count_history(db, equipment_id)}
+    return {"counts": get_equipment_count_history(db, equipment_id, account_id=account_id)}
 
 
-@router.post("/{equipment_id}/aliases")
+@router.post("/{equipment_id}/aliases", dependencies=[Depends(require_permission("equipment.update"))])
 async def api_add_equipment_alias(
     equipment_id: int,
     data: EquipmentAliasCreate,
@@ -205,34 +234,45 @@ async def api_add_equipment_alias(
     return {"id": alias_id, "status": "success"}
 
 
-@router.delete("/{equipment_id}/aliases/{alias_id}")
-async def api_delete_equipment_alias(equipment_id: int, alias_id: int, db: Session = Depends(get_db)):
+@router.delete("/{equipment_id}/aliases/{alias_id}", dependencies=[Depends(require_permission("equipment.update"))])
+async def api_delete_equipment_alias(
+    equipment_id: int,
+    alias_id: int,
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
+):
     """Remove a provider alias from a supply."""
-    success = delete_equipment_alias(db, equipment_id, alias_id)
+    success = delete_equipment_alias(db, equipment_id, alias_id, account_id=account_id)
     if not success:
         return JSONResponse(status_code=404, content={"detail": "Alias not found"})
     return {"status": "success"}
 
 
-@router.get("/history")
+@router.get("/history", dependencies=[Depends(require_permission("equipment.read"))])
 async def api_get_all_equipment_history(
     equipment_id: int = None,
     patient_id: int = None,
     start_date: str = None,
     end_date: str = None,
     limit: int = 100,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
 ):
     """Get change history for all equipment with optional filtering."""
     from schemas.equipment_change_log import EquipmentChangeLog as EquipmentChangeLogSchema
     from schemas.equipment import Equipment
-    from sqlalchemy import desc
-    
+    from sqlalchemy import desc, or_
+
     try:
         query = db.query(EquipmentChangeLogSchema).join(
             Equipment, EquipmentChangeLogSchema.equipment_id == Equipment.id
         )
-        
+
+        # The join already reaches equipment; scope it the way the list does.
+        if account_id is not None:
+            query = query.filter(or_(Equipment.account_id == account_id,
+                                     Equipment.account_id.is_(None)))
+
         if patient_id:
             query = query.filter(Equipment.patient_id == patient_id)
         
@@ -267,12 +307,18 @@ async def api_get_all_equipment_history(
         return {"history": [], "total": 0}
 
 
-@router.put("/{equipment_id}")
-async def api_update_equipment(equipment_id: int, data: EquipmentUpdate, db: Session = Depends(get_db)):
+@router.put("/{equipment_id}", dependencies=[Depends(require_permission("equipment.update"))])
+async def api_update_equipment(
+    equipment_id: int,
+    data: EquipmentUpdate,
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
+):
     """Update an equipment item."""
     success = update_equipment(
         db,
         equipment_id,
+        account_id=account_id,
         name=data.name,
         quantity=data.quantity,
         scheduled_replacement=data.scheduled_replacement,
@@ -295,16 +341,20 @@ async def api_update_equipment(equipment_id: int, data: EquipmentUpdate, db: Ses
     return {"status": "success"}
 
 
-@router.delete("/{equipment_id}")
-async def api_delete_equipment(equipment_id: int, db: Session = Depends(get_db)):
+@router.delete("/{equipment_id}", dependencies=[Depends(require_permission("equipment.delete"))])
+async def api_delete_equipment(
+    equipment_id: int,
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
+):
     """Delete an equipment item."""
-    success = delete_equipment(db, equipment_id)
+    success = delete_equipment(db, equipment_id, account_id=account_id)
     if not success:
         return JSONResponse(status_code=404, content={"detail": "Equipment not found or could not be deleted"})
     return {"status": "success"}
 
 
-@router.get("/due/count")
+@router.get("/due/count", dependencies=[Depends(require_permission("equipment.read"))])
 async def api_get_equipment_due_count(
     patient_id: Optional[int] = None,
     db: Session = Depends(get_db),

--- a/backend/tests/test_equipment_authz.py
+++ b/backend/tests/test_equipment_authz.py
@@ -1,0 +1,223 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Equipment is permission-gated and scoped to an account.
+
+Neither held before: not one of the module's fifteen endpoints called
+require_permission, so the seeded read-only roles ("view-only", "Monitor
+Only") could write through every one of them, and every by-id operation
+looked equipment up on its primary key alone, so another account's supply
+could be read, changed, received, counted, renamed or deleted by naming its
+id. GET /api/equipment did not pass the account_id its CRUD already accepted,
+so it returned every account's supplies.
+"""
+import pytest
+
+
+@pytest.fixture
+def other_account(db_session):
+    from models.users import Account
+    import bcrypt
+    acc = Account(
+        name="Other Family", slug="other-equipment",
+        password_hash=bcrypt.hashpw(b"otherpass", bcrypt.gensalt()).decode(),
+        timezone="America/New_York", is_default=False,
+    )
+    db_session.add(acc)
+    db_session.commit()
+    db_session.refresh(acc)
+    return acc
+
+
+@pytest.fixture
+def other_client(client, db_session, other_account):
+    """A fully-privileged client belonging to a different account."""
+    from crud.users import create_user, get_role_by_name
+    from routes.auth import create_access_token
+    from starlette.testclient import TestClient
+    role = get_role_by_name(db_session, "system_admin")
+    user = create_user(
+        db_session, username="other_eq_admin", password="otherpass",
+        full_name="Other Admin", is_system_admin=True,
+        role_ids=[role.id] if role else None, force_password_reset=False,
+    )
+    user.account_id = other_account.id
+    db_session.commit()
+    token = create_access_token(user=user, account=other_account, auth_level="full")
+    fresh = TestClient(client.app)
+    fresh.headers.update({"Authorization": f"Bearer {token}"})
+    return fresh
+
+
+@pytest.fixture
+def readonly_client(client, db_session, account):
+    """A user holding equipment.read and nothing else — the seeded view-only shape."""
+    from crud.users import create_user, get_role_by_name
+    from routes.auth import create_access_token
+    from starlette.testclient import TestClient
+    role = get_role_by_name(db_session, "viewer") or get_role_by_name(db_session, "monitor")
+    user = create_user(
+        db_session, username="eq_readonly", password="ropass",
+        full_name="Read Only", is_system_admin=False,
+        role_ids=[role.id] if role else None, force_password_reset=False,
+    )
+    user.account_id = account.id
+    db_session.commit()
+    token = create_access_token(user=user, account=account, auth_level="full")
+    fresh = TestClient(client.app)
+    fresh.headers.update({"Authorization": f"Bearer {token}"})
+    return fresh
+
+
+def _make(cl, patient, **over):
+    payload = {
+        "name": "Trach tube", "quantity": 5, "scheduled_replacement": False,
+        "patient_id": patient.id,
+    }
+    payload.update(over)
+    resp = cl.post("/api/equipment", json=payload)
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+# --- Permission gating ----------------------------------------------------
+
+def test_readonly_can_read(readonly_client, admin_client, patient):
+    _make(admin_client, patient)
+    assert readonly_client.get("/api/equipment").status_code == 200
+
+
+def test_readonly_cannot_create(readonly_client, patient):
+    resp = readonly_client.post("/api/equipment", json={
+        "name": "Snuck in", "quantity": 1, "scheduled_replacement": False,
+        "patient_id": patient.id,
+    })
+    assert resp.status_code == 403
+
+
+def test_readonly_cannot_update_or_delete(readonly_client, admin_client, patient):
+    eid = _make(admin_client, patient)
+    assert readonly_client.put(f"/api/equipment/{eid}", json={"name": "Renamed"}).status_code == 403
+    assert readonly_client.delete(f"/api/equipment/{eid}").status_code == 403
+
+
+def test_readonly_cannot_move_stock(readonly_client, admin_client, patient):
+    """receive/open/count all write Equipment.quantity."""
+    eid = _make(admin_client, patient)
+    assert readonly_client.post(f"/api/equipment/{eid}/receive", json={"amount": 5}).status_code == 403
+    assert readonly_client.post(f"/api/equipment/{eid}/open", json={"amount": 1}).status_code == 403
+    assert readonly_client.post(f"/api/equipment/{eid}/count", json={"quantity": 99}).status_code == 403
+
+
+def test_readonly_cannot_log_a_change(readonly_client, admin_client, patient):
+    eid = _make(admin_client, patient, scheduled_replacement=True,
+                last_changed="2026-08-01T00:00:00Z", useful_days=30)
+    resp = readonly_client.post(f"/api/equipment/{eid}/change",
+                                json={"changed_at": "2026-08-19T00:00:00Z"})
+    assert resp.status_code == 403
+
+
+# --- Account scoping ------------------------------------------------------
+
+def test_list_excludes_other_accounts(admin_client, other_client, patient):
+    mine = _make(admin_client, patient)
+    theirs = _make(other_client, patient, name="Theirs")
+
+    ids = [e["id"] for e in admin_client.get("/api/equipment").json()]
+    assert mine in ids
+    assert theirs not in ids
+
+
+def test_update_across_accounts_does_not_apply(admin_client, other_client, patient, db_session):
+    theirs = _make(other_client, patient, name="Theirs")
+    admin_client.put(f"/api/equipment/{theirs}", json={"name": "Stolen"})
+
+    from schemas.equipment import Equipment
+    db_session.expire_all()
+    assert db_session.query(Equipment).filter(Equipment.id == theirs).first().name == "Theirs"
+
+
+def test_delete_across_accounts_does_not_apply(admin_client, other_client, patient, db_session):
+    theirs = _make(other_client, patient, name="Theirs")
+    admin_client.delete(f"/api/equipment/{theirs}")
+
+    from schemas.equipment import Equipment
+    db_session.expire_all()
+    assert db_session.query(Equipment).filter(Equipment.id == theirs).first() is not None
+
+
+def test_stock_cannot_be_moved_across_accounts(admin_client, other_client, patient, db_session):
+    theirs = _make(other_client, patient, name="Theirs")
+    admin_client.post(f"/api/equipment/{theirs}/receive", json={"amount": 100})
+    admin_client.post(f"/api/equipment/{theirs}/open", json={"amount": 3})
+    admin_client.post(f"/api/equipment/{theirs}/count", json={"quantity": 999})
+
+    from schemas.equipment import Equipment
+    db_session.expire_all()
+    assert db_session.query(Equipment).filter(Equipment.id == theirs).first().quantity == 5
+
+
+def test_change_log_cannot_be_written_across_accounts(admin_client, other_client, patient):
+    theirs = _make(other_client, patient, name="Theirs", scheduled_replacement=True,
+                   last_changed="2026-08-01T00:00:00Z", useful_days=30)
+    resp = admin_client.post(f"/api/equipment/{theirs}/change",
+                             json={"changed_at": "2026-08-19T00:00:00Z"})
+    # 404 rather than a silent success: from this account it does not exist.
+    assert resp.status_code == 404
+    assert other_client.get(f"/api/equipment/{theirs}/history").json() == []
+
+
+def test_history_across_accounts_is_empty(admin_client, other_client, patient):
+    theirs = _make(other_client, patient, name="Theirs", scheduled_replacement=True,
+                   last_changed="2026-08-01T00:00:00Z", useful_days=30)
+    other_client.post(f"/api/equipment/{theirs}/change",
+                      json={"changed_at": "2026-08-19T00:00:00Z"})
+    assert other_client.get(f"/api/equipment/{theirs}/history").json(), "their own history is visible"
+
+    assert admin_client.get(f"/api/equipment/{theirs}/history").json() == []
+
+
+def test_global_history_excludes_other_accounts(admin_client, other_client, patient):
+    theirs = _make(other_client, patient, name="Theirs", scheduled_replacement=True,
+                   last_changed="2026-08-01T00:00:00Z", useful_days=30)
+    other_client.post(f"/api/equipment/{theirs}/change",
+                      json={"changed_at": "2026-08-19T00:00:00Z"})
+
+    rows = admin_client.get("/api/equipment/history").json()["history"]
+    assert all(r["equipment_id"] != theirs for r in rows)
+
+
+def test_count_history_across_accounts_is_empty(admin_client, other_client, patient):
+    theirs = _make(other_client, patient, name="Theirs")
+    other_client.post(f"/api/equipment/{theirs}/count", json={"quantity": 12})
+    assert other_client.get(f"/api/equipment/{theirs}/counts").json()["counts"]
+
+    assert admin_client.get(f"/api/equipment/{theirs}/counts").json()["counts"] == []
+
+
+# --- Same-account behaviour is unchanged ----------------------------------
+
+def test_own_equipment_still_works_end_to_end(admin_client, patient, db_session):
+    eid = _make(admin_client, patient)
+    assert admin_client.put(f"/api/equipment/{eid}", json={"name": "Renamed"}).status_code == 200
+    assert admin_client.post(f"/api/equipment/{eid}/receive", json={"amount": 5}).status_code == 200
+    assert admin_client.post(f"/api/equipment/{eid}/count", json={"quantity": 7}).status_code == 200
+    assert admin_client.get(f"/api/equipment/{eid}/counts").json()["counts"]
+
+    from schemas.equipment import Equipment
+    db_session.expire_all()
+    row = db_session.query(Equipment).filter(Equipment.id == eid).first()
+    assert row.name == "Renamed"
+    assert row.quantity == 7


### PR DESCRIPTION
The equipment module had neither a permission gate nor a tenant boundary. Found while scoping the Equipment Overview rebuild; sent separately, same as #133.

## No endpoint was gated

Not one of the module's fifteen endpoints called `require_permission`. Shipments has 27 gates, care tasks 15, equipment 0.

The permissions were seeded the whole time — `equipment.create/read/update/delete/change` — and **two seeded roles hold `equipment.read` and nothing else**: "view-only" and "Monitor Only" (`seed_auth.py:158-180`). The UI hid the buttons from them. The API took the calls.

So a monitor-only account could create supplies, rename them, delete them, log scheduled changes, and move stock.

## No by-id operation was scoped to an account

Every by-id lookup was `Equipment.id == equipment_id` on the primary key alone, so another account's supply could be read, changed, received, opened, counted, renamed or deleted by naming its id. `receive` / `open` / `count` all write `Equipment.quantity`, so those moved real stock.

`GET /api/equipment` never passed the `account_id` its CRUD **has always accepted** (`crud/equipment.py:272`), so the main list returned every account's supplies. Same shape as the `/api/shipments/inventory` leak in #133: a scoping parameter that existed and simply wasn't used. The global change-history route already joined equipment, so it takes the same filter.

## Choices worth reviewing

- **Scoping is "mine or shared", not strict equality.** Equipment genuinely has rows with no account — shared supplies in a single-tenant install — and `get_equipment_list` has always included them. Filtering strictly would hide supplies the page is meant to list. This is deliberately different from the shipment tables, where a shipment always belongs to a patient and so to an account.
- **`change` gets its own permission.** `equipment.change` is seeded separately and held by roles that cannot otherwise write, because recording a scheduled tube change is a caregiver action, not an inventory edit.
- **`receive`/`open`/`count` are gated on `equipment.update`** — they write the quantity column, so they are inventory edits rather than reads.
- **Cross-account writes 404 rather than silently succeeding.** From the calling account the row does not exist, and that is what the caller should be told.

## Verification

Backend **660 pass**, 1 skipped (646 baseline + 14 new).

The new tests were checked against the unfixed code: **12 of the 14 fail without this change**. The two that pass either way are the controls — a read-only user *can* still read, and same-account create → update → receive → count → read still works end to end. The read control is what makes the twelve 403 assertions meaningful rather than a user with no roles failing everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
