### PR TITLE
Equipment overview rebuilt as a dashboard

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -35,6 +35,7 @@ import AdminV2CareTasks from './pages/admin-v2/AdminV2CareTasks';
 import AdminV2CareTasksOverview from './pages/admin-v2/AdminV2CareTasksOverview';
 import AdminV2CareTasksSchedule from './pages/admin-v2/AdminV2CareTasksSchedule';
 import AdminV2Equipment from './pages/admin-v2/AdminV2Equipment';
+import AdminV2EquipmentOverview from './pages/admin-v2/AdminV2EquipmentOverview';
 import AdminV2EquipmentHistory from './pages/admin-v2/AdminV2EquipmentHistory';
 import AdminV2Shipments from './pages/admin-v2/AdminV2Shipments';
 import AdminV2ShipmentDetail from './pages/admin-v2/AdminV2ShipmentDetail';
@@ -137,7 +138,9 @@ function AppContent() {
           <Route path="/care/care-tasks/schedule" element={<ProtectedRoute><Layout><AdminV2CareTasksSchedule /></Layout></ProtectedRoute>} />
           {/* History is a modal on the Overview now; the old path lands there. */}
           <Route path="/care/care-tasks/history" element={<ProtectedRoute><Layout><AdminV2CareTasksOverview /></Layout></ProtectedRoute>} />
-          <Route path="/care/equipment" element={<ProtectedRoute><Layout><AdminV2Equipment /></Layout></ProtectedRoute>} />
+          <Route path="/care/equipment" element={<ProtectedRoute><Layout><AdminV2EquipmentOverview /></Layout></ProtectedRoute>} />
+          {/* The catalogue the Overview's "Manage" opens; unchanged, just no longer the landing page. */}
+          <Route path="/care/equipment/manage" element={<ProtectedRoute><Layout><AdminV2Equipment /></Layout></ProtectedRoute>} />
           <Route path="/care/equipment/history" element={<ProtectedRoute><Layout><AdminV2EquipmentHistory /></Layout></ProtectedRoute>} />
           <Route path="/care/equipment/shipments" element={<ProtectedRoute><Layout><AdminV2Shipments /></Layout></ProtectedRoute>} />
           <Route path="/care/equipment/shipments/:id" element={<ProtectedRoute><Layout><AdminV2ShipmentDetail /></Layout></ProtectedRoute>} />

--- a/frontend/src/lib/equipmentOverview.js
+++ b/frontend/src/lib/equipmentOverview.js
@@ -1,0 +1,193 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// What the Equipment overview claims, derived in one place.
+//
+// The page states several numbers that have to agree with the pages they link
+// to -- what is due, what is short, how ready a category is -- so the rules
+// live here with tests rather than inline in the panels.
+//
+// Due dates are the server's: get_equipment_list already returns due_date as
+// last_changed + useful_days, and get_equipment_due_count calls an item due
+// when that date is today or past. This matches both rather than inventing a
+// third rule.
+
+/** Local midnight, so "due today" means the calendar day, not 24 hours.
+ *
+ * A bare 'YYYY-MM-DD' is parsed by the platform as UTC midnight, which lands
+ * on the previous day everywhere west of Greenwich -- enough on its own to
+ * report a change due today as overdue. Those are read as local dates; values
+ * that carry a time are left to the normal parser.
+ */
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+const startOfDay = (date) => {
+  if (typeof date === 'string' && DATE_ONLY.test(date)) {
+    const [y, m, d] = date.split('-').map(Number);
+    return new Date(y, m - 1, d);
+  }
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+export const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Whole days from today to a date: negative is in the past. */
+export function daysUntil(dateish, today = new Date()) {
+  if (!dateish) return null;
+  const then = startOfDay(dateish);
+  if (Number.isNaN(then.getTime())) return null;
+  return Math.round((then - startOfDay(today)) / DAY_MS);
+}
+
+/**
+ * Where a scheduled change stands.
+ *
+ * 'overdue' and 'due' are both counted as due by the server's own rule
+ * (due_date <= today); they are separated here only so the UI can say which.
+ * 'soon' is a UI-side lookahead and is deliberately NOT counted as due.
+ */
+export function dueState(item, today = new Date(), soonDays = 7) {
+  if (!item?.scheduled_replacement || !item.due_date) return 'none';
+  const days = daysUntil(item.due_date, today);
+  if (days === null) return 'none';
+  if (days < 0) return 'overdue';
+  if (days === 0) return 'due';
+  if (days <= soonDays) return 'soon';
+  return 'ok';
+}
+
+export const isDue = (item, today = new Date()) => ['overdue', 'due'].includes(dueState(item, today));
+
+/**
+ * Where a supply's stock stands against the levels set for it.
+ *
+ * An item with no reorder point and no par level is not tracked for stock at
+ * all, and reports 'none' rather than a reassuring 'ok' it has not earned.
+ */
+export function stockState(item) {
+  if (!item) return 'none';
+  if ((item.tracking_level || 'item') === 'none') return 'none';
+  // No quantity at all is unknown, not empty: only a recorded 0 means out.
+  if (item.quantity == null) return 'none';
+  const qty = item.quantity;
+  const reorder = item.reorder_point;
+  const par = item.par_level;
+  if (reorder == null && par == null) return qty === 0 ? 'out' : 'none';
+  if (qty === 0) return 'out';
+  if (reorder != null && qty <= reorder) return 'reorder';
+  if (par != null && qty < par) return 'low';
+  return 'ok';
+}
+
+export const isLowStock = (item) => ['out', 'reorder', 'low'].includes(stockState(item));
+export const isBelowMinimum = (item) => ['out', 'reorder'].includes(stockState(item));
+
+/**
+ * Readiness per category, as the share of that category's tracked supplies
+ * sitting at or above par.
+ *
+ * Deliberately a count, not a sum of quantities: a category mixes boxes of
+ * catheters with millilitres of saline, and adding those together would
+ * produce a percentage that means nothing. "How many of these supplies are
+ * stocked to plan" is a question the units survive.
+ *
+ * Supplies with no levels set are excluded from both halves of the ratio —
+ * counting them as ready would inflate the bar for items nobody has told the
+ * system how to stock.
+ */
+export function readinessByCategory(equipment = []) {
+  const groups = new Map();
+  for (const item of equipment) {
+    if (stockState(item) === 'none') continue;
+    const key = item.category || 'Uncategorised';
+    if (!groups.has(key)) groups.set(key, { category: key, total: 0, ready: 0, belowMinimum: 0 });
+    const g = groups.get(key);
+    g.total += 1;
+    if (stockState(item) === 'ok') g.ready += 1;
+    if (isBelowMinimum(item)) g.belowMinimum += 1;
+  }
+  return [...groups.values()]
+    .map((g) => ({ ...g, percent: g.total ? Math.round((g.ready / g.total) * 100) : 0 }))
+    .sort((a, b) => a.percent - b.percent || a.category.localeCompare(b.category));
+}
+
+/** How many supplies are at or below their reorder point, across every category. */
+export const belowMinimumCount = (equipment = []) => equipment.filter(isBelowMinimum).length;
+
+/**
+ * The things that want a person, worst first.
+ *
+ * Two independent reasons — a change is due, or stock has run short — and an
+ * item can carry both, in which case it appears once with the more urgent
+ * reason leading.
+ */
+const RANK = { overdue: 0, out: 1, due: 2, reorder: 3, low: 4, soon: 5 };
+
+export function attentionItems(equipment = [], today = new Date()) {
+  const rows = [];
+  for (const item of equipment) {
+    const due = dueState(item, today);
+    const stock = stockState(item);
+    const reasons = [];
+    if (['overdue', 'due', 'soon'].includes(due)) reasons.push(due);
+    if (['out', 'reorder', 'low'].includes(stock)) reasons.push(stock);
+    if (reasons.length === 0) continue;
+    reasons.sort((a, b) => RANK[a] - RANK[b]);
+    rows.push({ item, reasons, lead: reasons[0], rank: RANK[reasons[0]] });
+  }
+  return rows.sort((a, b) => a.rank - b.rank
+    || String(a.item.name || '').localeCompare(String(b.item.name || '')));
+}
+
+/**
+ * Scheduled changes ahead, grouped by the day they fall due.
+ *
+ * Anything already overdue is folded into today rather than given a heading
+ * in the past — the question the panel answers is what to do next, and an
+ * overdue change is due now.
+ */
+export function upcomingChanges(equipment = [], today = new Date(), horizonDays = 30) {
+  const byDay = new Map();
+  for (const item of equipment) {
+    if (!item.scheduled_replacement || !item.due_date) continue;
+    const days = daysUntil(item.due_date, today);
+    if (days === null || days > horizonDays) continue;
+    const key = days < 0 ? 0 : days;
+    if (!byDay.has(key)) byDay.set(key, { inDays: key, items: [] });
+    byDay.get(key).items.push(item);
+  }
+  return [...byDay.values()]
+    .sort((a, b) => a.inDays - b.inDays)
+    .map((group) => ({
+      ...group,
+      date: new Date(startOfDay(today).getTime() + group.inDays * DAY_MS),
+      isToday: group.inDays === 0,
+      items: group.items.sort((a, b) => String(a.name || '').localeCompare(String(b.name || ''))),
+    }));
+}
+
+/** The four numbers across the top. */
+export function overviewCounts(equipment = [], shipments = [], today = new Date()) {
+  return {
+    tracked: equipment.length,
+    dueNow: equipment.filter((item) => isDue(item, today)).length,
+    lowStock: equipment.filter(isLowStock).length,
+    incoming: shipments.length,
+  };
+}

--- a/frontend/src/lib/equipmentOverview.test.js
+++ b/frontend/src/lib/equipmentOverview.test.js
@@ -1,0 +1,226 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  daysUntil, dueState, isDue, stockState, isLowStock, isBelowMinimum,
+  readinessByCategory, belowMinimumCount, attentionItems, upcomingChanges,
+  overviewCounts,
+} from './equipmentOverview';
+
+const TODAY = new Date('2026-08-19T14:30:00');
+
+const scheduled = (dueDate, over = {}) => ({
+  id: 1, name: 'Trach tube', scheduled_replacement: true, due_date: dueDate, ...over,
+});
+
+const supply = (over = {}) => ({
+  id: 2, name: 'Catheter', scheduled_replacement: false, tracking_level: 'item',
+  quantity: 10, reorder_point: 3, par_level: 12, ...over,
+});
+
+describe('daysUntil', () => {
+  it('counts calendar days, not elapsed hours', () => {
+    // 14:30 today to 00:00 tomorrow is under 24h but is still one day away.
+    expect(daysUntil('2026-08-20T00:00:00', TODAY)).toBe(1);
+    expect(daysUntil('2026-08-19T23:00:00', TODAY)).toBe(0);
+  });
+
+  it('goes negative for the past', () => {
+    expect(daysUntil('2026-08-17T00:00:00', TODAY)).toBe(-2);
+  });
+
+  it('tolerates missing and unparseable dates', () => {
+    expect(daysUntil(null, TODAY)).toBeNull();
+    expect(daysUntil('not a date', TODAY)).toBeNull();
+  });
+});
+
+describe('dueState', () => {
+  it('separates overdue from due today, and counts both as due', () => {
+    expect(dueState(scheduled('2026-08-17'), TODAY)).toBe('overdue');
+    expect(dueState(scheduled('2026-08-19'), TODAY)).toBe('due');
+    expect(isDue(scheduled('2026-08-17'), TODAY)).toBe(true);
+    expect(isDue(scheduled('2026-08-19'), TODAY)).toBe(true);
+  });
+
+  it('does not count a lookahead as due', () => {
+    // 'soon' is a UI affordance; the server's rule is due_date <= today.
+    expect(dueState(scheduled('2026-08-23'), TODAY)).toBe('soon');
+    expect(isDue(scheduled('2026-08-23'), TODAY)).toBe(false);
+  });
+
+  it('says nothing about an item that is not on a schedule', () => {
+    expect(dueState(supply(), TODAY)).toBe('none');
+    expect(dueState(scheduled(null), TODAY)).toBe('none');
+  });
+});
+
+describe('stockState', () => {
+  it('reports out, reorder, low and ok against the levels set', () => {
+    expect(stockState(supply({ quantity: 0 }))).toBe('out');
+    expect(stockState(supply({ quantity: 3 }))).toBe('reorder');   // at the reorder point
+    expect(stockState(supply({ quantity: 8 }))).toBe('low');       // under par
+    expect(stockState(supply({ quantity: 12 }))).toBe('ok');       // at par
+  });
+
+  it('does not claim ok for a supply with no levels set', () => {
+    // Reporting 'ok' would be a judgement nobody made.
+    expect(stockState(supply({ reorder_point: null, par_level: null }))).toBe('none');
+  });
+
+  it('still calls an untracked supply out when it is at zero', () => {
+    expect(stockState(supply({ reorder_point: null, par_level: null, quantity: 0 }))).toBe('out');
+  });
+
+  it('ignores items not stock-tracked at all', () => {
+    expect(stockState(supply({ tracking_level: 'none', quantity: 0 }))).toBe('none');
+  });
+
+  it('separates below-minimum from merely low', () => {
+    expect(isBelowMinimum(supply({ quantity: 3 }))).toBe(true);
+    expect(isBelowMinimum(supply({ quantity: 8 }))).toBe(false);
+    expect(isLowStock(supply({ quantity: 8 }))).toBe(true);
+  });
+});
+
+describe('readinessByCategory', () => {
+  const items = [
+    supply({ id: 1, category: 'Airway', quantity: 12 }),   // ok
+    supply({ id: 2, category: 'Airway', quantity: 2 }),    // reorder
+    supply({ id: 3, category: 'Airway', quantity: 8 }),    // low
+    supply({ id: 4, category: 'Nutrition', quantity: 12 }), // ok
+  ];
+
+  it('is the share of a category stocked to plan', () => {
+    const byName = Object.fromEntries(readinessByCategory(items).map((g) => [g.category, g]));
+    expect(byName.Airway.percent).toBe(33);      // 1 of 3
+    expect(byName.Nutrition.percent).toBe(100);  // 1 of 1
+  });
+
+  it('counts supplies rather than summing quantities across units', () => {
+    // Boxes and millilitres do not add up; a count survives the mixed units.
+    const mixed = [
+      supply({ id: 1, category: 'Airway', quantity: 1000, unit_of_measure: 'ml', par_level: 1 }),
+      supply({ id: 2, category: 'Airway', quantity: 0, unit_of_measure: 'BX' }),
+    ];
+    expect(readinessByCategory(mixed)[0].percent).toBe(50);
+  });
+
+  it('excludes supplies with no levels set from both halves', () => {
+    const withUntracked = [...items, supply({ id: 9, category: 'Airway', reorder_point: null, par_level: null })];
+    const airway = readinessByCategory(withUntracked).find((g) => g.category === 'Airway');
+    expect(airway.total).toBe(3);
+  });
+
+  it('reports each category below minimum, and the total', () => {
+    const airway = readinessByCategory(items).find((g) => g.category === 'Airway');
+    expect(airway.belowMinimum).toBe(1);
+    expect(belowMinimumCount(items)).toBe(1);
+  });
+
+  it('leads with the least ready category', () => {
+    expect(readinessByCategory(items)[0].category).toBe('Airway');
+  });
+
+  it('groups uncategorised supplies rather than dropping them', () => {
+    expect(readinessByCategory([supply({ category: null })])[0].category).toBe('Uncategorised');
+  });
+});
+
+describe('attentionItems', () => {
+  it('lists the worst first', () => {
+    const rows = attentionItems([
+      supply({ id: 1, name: 'Low one', quantity: 8 }),
+      scheduled('2026-08-17', { id: 2, name: 'Overdue one' }),
+      supply({ id: 3, name: 'Out one', quantity: 0 }),
+    ], TODAY);
+    expect(rows.map((r) => r.lead)).toEqual(['overdue', 'out', 'low']);
+  });
+
+  it('shows an item once when it is both due and short, most urgent first', () => {
+    const both = { ...supply({ quantity: 0, id: 5, name: 'Both' }), scheduled_replacement: true, due_date: '2026-08-19' };
+    const rows = attentionItems([both], TODAY);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].reasons).toEqual(['out', 'due']);
+  });
+
+  it('leaves healthy items out', () => {
+    expect(attentionItems([supply({ quantity: 12 }), scheduled('2026-12-01')], TODAY)).toEqual([]);
+  });
+});
+
+describe('upcomingChanges', () => {
+  it('groups by the day a change falls due', () => {
+    const groups = upcomingChanges([
+      scheduled('2026-08-26', { id: 1, name: 'Nebuliser kit' }),
+      scheduled('2026-08-19', { id: 2, name: 'Vent tube' }),
+      scheduled('2026-08-19', { id: 3, name: 'Humidification chamber' }),
+    ], TODAY);
+    expect(groups.map((g) => g.inDays)).toEqual([0, 7]);
+    expect(groups[0].items.map((i) => i.name)).toEqual(['Humidification chamber', 'Vent tube']);
+    expect(groups[0].isToday).toBe(true);
+  });
+
+  it('folds an overdue change into today rather than heading a past date', () => {
+    const groups = upcomingChanges([scheduled('2026-08-10', { name: 'Late' })], TODAY);
+    expect(groups[0].inDays).toBe(0);
+    expect(groups[0].isToday).toBe(true);
+  });
+
+  it('stops at the horizon', () => {
+    expect(upcomingChanges([scheduled('2026-12-01')], TODAY)).toEqual([]);
+  });
+
+  it('ignores items with no schedule', () => {
+    expect(upcomingChanges([supply()], TODAY)).toEqual([]);
+  });
+});
+
+describe('overviewCounts', () => {
+  it('counts what the four tiles claim', () => {
+    const equipment = [
+      scheduled('2026-08-17', { id: 1 }),
+      scheduled('2026-08-19', { id: 2 }),
+      supply({ id: 3, quantity: 0 }),
+      supply({ id: 4, quantity: 12 }),
+    ];
+    const counts = overviewCounts(equipment, [{ id: 1 }], TODAY);
+    expect(counts).toEqual({ tracked: 4, dueNow: 2, lowStock: 1, incoming: 1 });
+  });
+
+  it('is all zeroes for an empty catalogue rather than throwing', () => {
+    expect(overviewCounts()).toEqual({ tracked: 0, dueNow: 0, lowStock: 0, incoming: 0 });
+  });
+});
+
+describe('missing data is not a claim', () => {
+  it('does not call a supply out just because no quantity was recorded', () => {
+    // Every real row has a quantity, but a partial payload should not
+    // manufacture an out-of-stock warning nobody reported.
+    expect(stockState(supply({ quantity: undefined, reorder_point: null, par_level: null })))
+      .toBe('none');
+    expect(stockState(supply({ quantity: null }))).toBe('none');
+  });
+
+  it('reads a bare YYYY-MM-DD as a local date, not UTC midnight', () => {
+    // Parsed as UTC this lands on the 18th anywhere west of Greenwich, and a
+    // change due today would report as overdue.
+    expect(dueState(scheduled('2026-08-19'), TODAY)).toBe('due');
+    expect(daysUntil('2026-08-19', TODAY)).toBe(0);
+  });
+});

--- a/frontend/src/pages/admin-v2/AdminV2EquipmentOverview.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2EquipmentOverview.jsx
@@ -1,0 +1,438 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Equipment overview: what is due, what is short, what is on its way.
+//
+// Every number here opens the thing it counted rather than being a figure
+// with no way in, and each panel says where its rule came from — the due
+// dates are the server's own, and readiness counts supplies at par rather
+// than summing quantities across units that do not add up.
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import AdminV2Layout from './AdminV2Layout';
+import { useAuth } from '../../contexts/AuthContext';
+import { useAdminPatient } from '../../contexts/AdminPatientContext';
+import {
+  EquipmentIcon, ClockIcon, AlertIcon, PackageIcon, EditIcon,
+  BarcodeIcon, ChevronRightIcon, CalendarIcon, CheckCircleIcon, PlusIcon,
+} from '../../components/Icons';
+import { equipmentService } from '../../services/equipment';
+import { shipmentService } from '../../services/shipments';
+import { statusInfo, stepStates, isOpen } from '../../lib/shipmentStatus';
+import {
+  overviewCounts, attentionItems, readinessByCategory, belowMinimumCount,
+  upcomingChanges, dueState,
+} from '../../lib/equipmentOverview';
+import './AdminV2.css';
+import './components/shipments-page.css';
+import './components/equipment-overview.css';
+
+const dayLabel = (date) => date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+const stamp = (value) => (value
+  ? new Date(value).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+  })
+  : '—');
+
+// What to call each reason an item is on the attention list.
+const REASON = {
+  overdue: { label: 'Overdue', tone: 'alert' },
+  due: { label: 'Due today', tone: 'due' },
+  soon: { label: 'Due soon', tone: 'idle' },
+  out: { label: 'None on hand', tone: 'alert' },
+  reorder: { label: 'Reorder', tone: 'due' },
+  low: { label: 'Low', tone: 'due' },
+};
+
+const AdminV2EquipmentOverview = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const {
+    patients, selectedPatient: contextPatient,
+    selectPatient: setContextPatient, loadingPatients,
+  } = useAdminPatient();
+  const selectedPatient = contextPatient;
+
+  const [equipment, setEquipment] = useState([]);
+  const [shipments, setShipments] = useState([]);
+  const [activity, setActivity] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [busyId, setBusyId] = useState(null);
+  const [showAllAttention, setShowAllAttention] = useState(false);
+
+  const hasPermission = (permission) => {
+    if (!user) return false;
+    if (user.is_system_admin) return true;
+    return user.permissions?.includes(permission) || false;
+  };
+
+  const canChange = hasPermission('equipment.change');
+  const canManage = hasPermission('equipment.update');
+  const canReceive = hasPermission('shipments.receive');
+
+  useEffect(() => {
+    const patientId = searchParams.get('patient');
+    if (patientId && patients.length > 0) {
+      const patient = patients.find((p) => p.id === parseInt(patientId, 10));
+      if (patient && patient.id !== contextPatient?.id) setContextPatient(patient);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way URL→context sync; adding contextPatient would re-run on selection change and revert it to the stale URL param
+  }, [searchParams, patients, loadingPatients]);
+
+  useEffect(() => {
+    if (contextPatient && searchParams.get('patient') !== String(contextPatient.id)) {
+      setSearchParams({ patient: contextPatient.id });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way context→URL sync; runs only when the selection changes
+  }, [contextPatient]);
+
+  const fetchAll = useCallback(async () => {
+    if (!selectedPatient) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [eq, ships, history] = await Promise.all([
+        equipmentService.list(selectedPatient.id),
+        shipmentService.listShipments({ patient_id: selectedPatient.id, is_template: false }),
+        equipmentService.changeHistory({ patientId: selectedPatient.id, limit: 8 }),
+      ]);
+      setEquipment(Array.isArray(eq) ? eq : (eq.equipment || []));
+      setShipments((ships.shipments || []).filter(isOpen));
+      setActivity(history.history || []);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedPatient]);
+
+  useEffect(() => { fetchAll(); }, [fetchAll]);
+
+  const counts = useMemo(
+    () => overviewCounts(equipment, shipments),
+    [equipment, shipments],
+  );
+  const attention = useMemo(() => attentionItems(equipment), [equipment]);
+  const readiness = useMemo(() => readinessByCategory(equipment), [equipment]);
+  const belowMin = useMemo(() => belowMinimumCount(equipment), [equipment]);
+  const upcoming = useMemo(() => upcomingChanges(equipment), [equipment]);
+
+  // The soonest arrival is the one worth a panel; the rest are on Deliveries.
+  const incoming = useMemo(() => [...shipments].sort((a, b) => (
+    new Date(a.expected_delivery || '2999-01-01') - new Date(b.expected_delivery || '2999-01-01')
+  ))[0], [shipments]);
+
+  const goto = (path) => navigate(`${path}?patient=${selectedPatient.id}`);
+
+  const logChange = async (item) => {
+    setBusyId(item.id);
+    setError(null);
+    try {
+      await equipmentService.logChange(item.id, new Date().toISOString());
+      await fetchAll();
+    } catch (err) {
+      // The API refuses a change that would take tracked stock below zero and
+      // says so; surfacing its wording keeps the reason specific.
+      setError(err.message);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  if (loadingPatients) {
+    return <AdminV2Layout><div className="admin-v2-loading">Loading patients…</div></AdminV2Layout>;
+  }
+  if (!selectedPatient) {
+    return (
+      <AdminV2Layout>
+        <div className="admin-v2-loading">Select a patient from the sidebar</div>
+      </AdminV2Layout>
+    );
+  }
+
+  const shownAttention = showAllAttention ? attention : attention.slice(0, 5);
+
+  return (
+    <AdminV2Layout>
+      <div className="admin-v2-page sh-page eo-page">
+        {error && <div className="sh-error" role="alert">{error}</div>}
+
+        <div className="eo-head">
+          <div>
+            <h1 className="sh-title">Equipment overview</h1>
+            <p className="eo-sub">Home equipment, supply readiness, and upcoming care.</p>
+          </div>
+          <div className="eo-head-actions">
+            {canReceive && (
+              <button type="button" className="sh-btn"
+                      onClick={() => goto(incoming
+                        ? `/care/equipment/shipments/${incoming.id}`
+                        : '/care/equipment/shipments')}>
+                <BarcodeIcon size={16} /> Scan / receive
+              </button>
+            )}
+            {canManage && (
+              <button type="button" className="sh-btn" onClick={() => goto('/care/equipment/manage')}>
+                <EquipmentIcon size={16} /> Manage
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Each tile opens what it counted. */}
+        <div className="eo-stats">
+          <button type="button" className="eo-stat" onClick={() => goto('/care/equipment/manage')}>
+            <EquipmentIcon size={22} />
+            <span className="eo-stat-value">{counts.tracked}</span>
+            <span className="eo-stat-label">Tracked</span>
+          </button>
+          <button type="button" className="eo-stat" onClick={() => setShowAllAttention(true)}>
+            <ClockIcon size={22} />
+            <span className="eo-stat-value tone-due">{counts.dueNow}</span>
+            <span className="eo-stat-label">Due now</span>
+          </button>
+          <button type="button" className="eo-stat" onClick={() => goto('/care/equipment/inventory')}>
+            <AlertIcon size={22} />
+            <span className={`eo-stat-value ${counts.lowStock ? 'tone-alert' : ''}`}>
+              {counts.lowStock}
+            </span>
+            <span className="eo-stat-label">Low stock</span>
+          </button>
+          <button type="button" className="eo-stat" onClick={() => goto('/care/equipment/shipments')}>
+            <PackageIcon size={22} />
+            <span className="eo-stat-value tone-accent">{counts.incoming}</span>
+            <span className="eo-stat-label">Incoming</span>
+          </button>
+        </div>
+
+        {loading && equipment.length === 0 ? (
+          <div className="admin-v2-loading">Loading equipment…</div>
+        ) : (
+          <div className="eo-grid">
+            {/* --- Needs attention --- */}
+            <section className="sd-section eo-span">
+              <h2 className="sd-section-title">Needs attention</h2>
+              {attention.length === 0 ? (
+                <div className="sh-empty">
+                  <CheckCircleIcon size={26} />
+                  <p>Nothing due and nothing short.</p>
+                </div>
+              ) : (
+                <>
+                  <ul className="eo-rows">
+                    {shownAttention.map(({ item, lead, reasons }) => (
+                      <li key={item.id} className="eo-row">
+                        <span className="eo-row-icon"><EquipmentIcon size={18} /></span>
+                        <div className="eo-row-text">
+                          <span className="eo-row-name">{item.name}</span>
+                          <span className="eo-row-sub">
+                            {item.scheduled_replacement ? 'Scheduled change' : 'Supply'}
+                            {item.category ? ` · ${item.category}` : ''}
+                          </span>
+                        </div>
+                        <div className="eo-row-flags">
+                          {reasons.map((r) => (
+                            <span key={r} className={`eo-flag tone-${REASON[r].tone}`}>
+                              {REASON[r].label}
+                            </span>
+                          ))}
+                        </div>
+                        <div className="eo-row-qty">
+                          <span className={`eo-qty ${item.quantity === 0 ? 'tone-alert' : ''}`}>
+                            {item.quantity ?? '—'}
+                          </span>
+                          <span className="eo-qty-label">On hand</span>
+                        </div>
+                        {/* Only a scheduled item can have a change logged; a
+                            supply that is merely short is restocked instead. */}
+                        {canChange && item.scheduled_replacement && ['overdue', 'due', 'soon'].includes(lead) ? (
+                          <button type="button" className="sh-btn" disabled={busyId === item.id}
+                                  onClick={() => logChange(item)}>
+                            <EditIcon size={15} />
+                            {busyId === item.id ? 'Saving…' : 'Log change'}
+                          </button>
+                        ) : (
+                          <button type="button" className="sh-btn ghost"
+                                  onClick={() => goto('/care/equipment/shipments')}>
+                            <PlusIcon size={15} /> Order
+                          </button>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                  {attention.length > shownAttention.length && (
+                    <button type="button" className="eo-more"
+                            onClick={() => setShowAllAttention(true)}>
+                      View all {attention.length} attention items
+                      <ChevronRightIcon size={16} />
+                    </button>
+                  )}
+                </>
+              )}
+            </section>
+
+            {/* --- Incoming shipment --- */}
+            <section className="sd-section">
+              <h2 className="sd-section-title">
+                <PackageIcon size={16} /> Incoming shipment
+              </h2>
+              {!incoming ? (
+                <div className="sh-empty">
+                  <PackageIcon size={24} />
+                  <p>Nothing on its way.</p>
+                </div>
+              ) : (
+                <>
+                  <div className="eo-ship-head">
+                    <div>
+                      <p className="eo-ship-supplier">{incoming.supplier_name || 'Supplier not set'}</p>
+                      <p className="eo-ship-id">
+                        Shipment {incoming.order_number || incoming.po_number || `#${incoming.id}`}
+                      </p>
+                    </div>
+                    <span className={`sc-status tone-${statusInfo(incoming.status).tone}`}>
+                      {statusInfo(incoming.status).label}
+                    </span>
+                  </div>
+                  <dl className="eo-ship-facts">
+                    <div>
+                      <dt>Expected</dt>
+                      <dd>{incoming.expected_delivery
+                        ? dayLabel(new Date(incoming.expected_delivery)) : 'Not set'}</dd>
+                    </div>
+                    <div><dt>Items</dt><dd>{incoming.item_count ?? 0}</dd></div>
+                  </dl>
+                  {/* The same rail the Deliveries cards draw. */}
+                  <div className="sc-rail">
+                    {stepStates(incoming).map((s, i) => (
+                      <div key={s.label} className={`sc-step is-${s.state}`}>
+                        {i > 0 && <span className="sc-rail-line" />}
+                        <span className="sc-rail-node" />
+                        <span className="sc-step-label">{s.label}</span>
+                      </div>
+                    ))}
+                  </div>
+                  <button type="button" className="sh-btn"
+                          onClick={() => goto(`/care/equipment/shipments/${incoming.id}`)}>
+                    Open delivery
+                  </button>
+                </>
+              )}
+            </section>
+
+            {/* --- Stock readiness --- */}
+            <section className="sd-section">
+              <h2 className="sd-section-title">Stock readiness</h2>
+              {readiness.length === 0 ? (
+                <p className="sd-hint">
+                  No supply has a reorder point or par level set, so there is nothing
+                  to measure readiness against yet.
+                </p>
+              ) : (
+                <>
+                  <ul className="eo-bars">
+                    {readiness.map((group) => (
+                      <li key={group.category} className="eo-bar-row">
+                        <span className="eo-bar-label">{group.category}</span>
+                        <span className="eo-bar-track">
+                          <span className={`eo-bar-fill ${group.percent < 50 ? 'tone-due' : ''}`}
+                                style={{ width: `${group.percent}%` }} />
+                        </span>
+                        <span className="eo-bar-value">{group.percent}%</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="sd-hint">
+                    Share of each category&rsquo;s supplies stocked to par.
+                  </p>
+                  {belowMin > 0 && (
+                    <p className="eo-warn">
+                      <AlertIcon size={15} />
+                      {belowMin} item{belowMin === 1 ? '' : 's'} below minimum
+                    </p>
+                  )}
+                </>
+              )}
+            </section>
+
+            {/* --- Upcoming changes --- */}
+            <section className="sd-section eo-span">
+              <div className="sd-section-head">
+                <h2 className="sd-section-title">
+                  <CalendarIcon size={16} /> Upcoming changes
+                </h2>
+                <button type="button" className="sh-btn ghost"
+                        onClick={() => goto('/care/schedule')}>
+                  View schedule
+                </button>
+              </div>
+              {upcoming.length === 0 ? (
+                <p className="sd-hint">No scheduled changes in the next 30 days.</p>
+              ) : (
+                <ol className="eo-timeline">
+                  {upcoming.map((group) => (
+                    <li key={group.inDays} className={`eo-tl-step ${group.isToday ? 'is-today' : ''}`}>
+                      <span className="eo-tl-node" />
+                      <span className="eo-tl-date">
+                        {dayLabel(group.date)}
+                        {group.isToday && <span className="eo-tl-today">Today</span>}
+                      </span>
+                      <ul className="eo-tl-items">
+                        {group.items.map((item) => (
+                          <li key={item.id}>
+                            {item.name}
+                            {dueState(item) === 'overdue' && <span className="eo-tl-late">Overdue</span>}
+                          </li>
+                        ))}
+                      </ul>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </section>
+
+            {/* --- Recent activity --- */}
+            <section className="sd-section">
+              <h2 className="sd-section-title">Recent activity</h2>
+              {activity.length === 0 ? (
+                <p className="sd-hint">Nothing recorded yet.</p>
+              ) : (
+                <ul className="eo-activity">
+                  {activity.map((entry) => (
+                    <li key={entry.id}>
+                      <EditIcon size={15} />
+                      <span className="eo-act-text">{entry.equipment_name} changed</span>
+                      <span className="eo-act-when">{stamp(entry.changed_at)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <button type="button" className="sh-btn ghost"
+                      onClick={() => goto('/care/equipment/history')}>
+                Full history
+              </button>
+            </section>
+          </div>
+        )}
+      </div>
+    </AdminV2Layout>
+  );
+};
+
+export default AdminV2EquipmentOverview;

--- a/frontend/src/pages/admin-v2/AdminV2EquipmentOverview.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2EquipmentOverview.test.jsx
@@ -1,0 +1,205 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The overview's claims: the four counts, what lands on the attention list,
+// and that logging a change goes through the endpoint that enforces stock.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('./AdminV2Layout', () => ({ default: ({ children }) => <div>{children}</div> }));
+
+let mockUser = { is_system_admin: true, permissions: [] };
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => ({ user: mockUser }) }));
+
+const patient = { id: 1, first_name: 'Pat', last_name: 'Ient' };
+vi.mock('../../contexts/AdminPatientContext', () => ({
+  useAdminPatient: () => ({
+    patients: [patient], selectedPatient: patient,
+    selectPatient: vi.fn(), loadingPatients: false,
+  }),
+}));
+
+const list = vi.fn();
+const changeHistory = vi.fn();
+const logChange = vi.fn();
+vi.mock('../../services/equipment', () => ({
+  equipmentService: {
+    list: (...a) => list(...a),
+    changeHistory: (...a) => changeHistory(...a),
+    logChange: (...a) => logChange(...a),
+  },
+}));
+
+const listShipments = vi.fn();
+vi.mock('../../services/shipments', () => ({
+  shipmentService: { listShipments: (...a) => listShipments(...a) },
+}));
+
+import AdminV2EquipmentOverview from './AdminV2EquipmentOverview';
+
+// Frozen so "due today" is a fixed question.
+const NOW = new Date('2026-08-19T09:00:00');
+
+const EQUIPMENT = [
+  {
+    id: 1, name: 'Trach tube', category: 'Airway', scheduled_replacement: true,
+    due_date: '2026-08-19', quantity: 4, tracking_level: 'item',
+    reorder_point: 1, par_level: 6,
+  },
+  {
+    id: 2, name: 'Vent tube', category: 'Respiratory', scheduled_replacement: true,
+    due_date: '2026-08-26', quantity: 10, tracking_level: 'item',
+    reorder_point: 2, par_level: 8,
+  },
+  {
+    id: 3, name: 'Mask, trach', category: 'Airway', scheduled_replacement: false,
+    quantity: 0, tracking_level: 'item', reorder_point: 2, par_level: 10,
+  },
+];
+
+const renderPage = () => render(
+  <MemoryRouter><AdminV2EquipmentOverview /></MemoryRouter>,
+);
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(NOW);
+  vi.clearAllMocks();
+  mockUser = { is_system_admin: true, permissions: [] };
+  list.mockResolvedValue(EQUIPMENT);
+  listShipments.mockResolvedValue({ shipments: [] });
+  changeHistory.mockResolvedValue({ history: [] });
+  logChange.mockResolvedValue({ success: true });
+});
+
+afterEach(() => vi.useRealTimers());
+
+const tile = (label) => screen.getByText(label).parentElement.querySelector('.eo-stat-value');
+
+/** The Log change button on a named row — every scheduled item has one. */
+const logChangeButtonFor = (name) => [...document.querySelectorAll('.eo-row')]
+  .find((r) => r.textContent.includes(name))
+  .querySelector('button');
+
+describe('AdminV2EquipmentOverview', () => {
+  it('counts what the four tiles claim', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Tracked')).toBeInTheDocument());
+    expect(tile('Tracked').textContent).toBe('3');
+    expect(tile('Due now').textContent).toBe('1');    // due today; the 26th is not due
+    expect(tile('Low stock').textContent).toBe('2');  // one at zero, one under par
+    expect(tile('Incoming').textContent).toBe('0');
+  });
+
+  it('counts only open shipments as incoming', async () => {
+    listShipments.mockResolvedValue({
+      shipments: [
+        { id: 1, status: 'shipped' },
+        { id: 2, status: 'complete' },   // landed — not incoming
+        { id: 3, status: 'draft' },
+      ],
+    });
+    renderPage();
+    await waitFor(() => expect(tile('Incoming').textContent).toBe('2'));
+  });
+
+  it('leads the attention list with the most urgent thing', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Needs attention')).toBeInTheDocument());
+    const names = [...document.querySelectorAll('.eo-row-name')].map((n) => n.textContent);
+    expect(names[0]).toBe('Mask, trach');   // none on hand outranks a change due today
+    expect(names).toContain('Trach tube');
+  });
+
+  it('offers Log change only for a scheduled item', async () => {
+    renderPage();
+    await waitFor(() => expect(document.querySelector('.eo-row-name')).toBeTruthy());
+    const rows = [...document.querySelectorAll('.eo-row')];
+    const trach = rows.find((r) => r.textContent.includes('Trach tube'));
+    const mask = rows.find((r) => r.textContent.includes('Mask, trach'));
+    expect(trach.textContent).toContain('Log change');
+    // A supply that is merely short is restocked, not "changed".
+    expect(mask.textContent).not.toContain('Log change');
+  });
+
+  it('records a change through the endpoint that enforces stock', async () => {
+    renderPage();
+    await waitFor(() => expect(document.querySelector('.eo-row-name')).toBeTruthy());
+    fireEvent.click(logChangeButtonFor('Trach tube'));
+    await waitFor(() => expect(logChange).toHaveBeenCalledWith(1, expect.any(String)));
+  });
+
+  it('surfaces the API refusal rather than a generic failure', async () => {
+    // The endpoint 409s with the supply's name and count when stock is out.
+    logChange.mockRejectedValue(new Error('Trach tube has 0 on hand.'));
+    renderPage();
+    await waitFor(() => expect(document.querySelector('.eo-row-name')).toBeTruthy());
+    fireEvent.click(logChangeButtonFor('Trach tube'));
+    await waitFor(() => expect(screen.getByRole('alert'))
+      .toHaveTextContent('Trach tube has 0 on hand.'));
+  });
+
+  it('hides Log change from a user without equipment.change', async () => {
+    mockUser = { is_system_admin: false, permissions: ['equipment.read'] };
+    renderPage();
+    await waitFor(() => expect(document.querySelector('.eo-row-name')).toBeTruthy());
+    expect(screen.queryByRole('button', { name: /Log change/ })).not.toBeInTheDocument();
+  });
+
+  it('reports readiness per category, worst first', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Stock readiness')).toBeInTheDocument());
+    const labels = [...document.querySelectorAll('.eo-bar-label')].map((n) => n.textContent);
+    // Airway: 0 of 2 at par. Respiratory: 1 of 1.
+    expect(labels[0]).toBe('Airway');
+    const values = [...document.querySelectorAll('.eo-bar-value')].map((n) => n.textContent);
+    expect(values[0]).toBe('0%');
+  });
+
+  it('says there is nothing to measure when no levels are set', async () => {
+    list.mockResolvedValue([
+      { id: 1, name: 'Thing', quantity: 3, tracking_level: 'item', reorder_point: null, par_level: null },
+    ]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/nothing\s+to measure readiness against/))
+      .toBeInTheDocument());
+  });
+
+  it('groups upcoming changes by day and marks today', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Upcoming changes')).toBeInTheDocument());
+    expect(screen.getByText('Today')).toBeInTheDocument();
+    const dates = [...document.querySelectorAll('.eo-tl-date')].map((n) => n.textContent);
+    expect(dates).toHaveLength(2);
+  });
+
+  it('says so when nothing needs attention', async () => {
+    list.mockResolvedValue([
+      { id: 1, name: 'Fine', quantity: 20, tracking_level: 'item', reorder_point: 2, par_level: 10 },
+    ]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Nothing due and nothing short.'))
+      .toBeInTheDocument());
+  });
+
+  it('surfaces a failed load instead of an empty dashboard', async () => {
+    list.mockRejectedValue(new Error('Boom'));
+    renderPage();
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Boom'));
+  });
+});

--- a/frontend/src/pages/admin-v2/components/equipment-overview.css
+++ b/frontend/src/pages/admin-v2/components/equipment-overview.css
@@ -1,0 +1,423 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Equipment overview. Builds on the shipments page vocabulary (sh-btn,
+ * sd-section, sc-rail) rather than restating it. Dark-only, like the rest of
+ * the vc skin. */
+
+:root:not(.light) .eo-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+:root:not(.light) .eo-sub {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .eo-head-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* --- stat tiles --- */
+
+:root:not(.light) .eo-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+@media (max-width: 720px) {
+  :root:not(.light) .eo-stats { grid-template-columns: repeat(2, 1fr); }
+}
+
+:root:not(.light) .eo-stat {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  align-items: center;
+  gap: 2px 14px;
+  padding: 16px 18px;
+  background: none;
+  border: 0;
+  border-left: 1px solid var(--vc-line-hairline);
+  text-align: left;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+:root:not(.light) .eo-stat:first-child { border-left: 0; }
+:root:not(.light) .eo-stat > svg { grid-row: span 2; }
+:root:not(.light) .eo-stat:hover {
+  background: color-mix(in srgb, var(--vc-text-primary) 5%, transparent);
+}
+:root:not(.light) .eo-stat:focus-visible {
+  outline: 2px solid var(--vc-data-live);
+  outline-offset: -2px;
+}
+
+:root:not(.light) .eo-stat-value {
+  font-family: var(--vc-font-mono);
+  font-size: 1.7rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.05;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .eo-stat-value.tone-due { color: var(--vc-state-due); }
+:root:not(.light) .eo-stat-value.tone-alert { color: var(--vc-state-alert); }
+:root:not(.light) .eo-stat-value.tone-accent { color: var(--vc-data-live); }
+
+:root:not(.light) .eo-stat-label {
+  font-size: 0.63rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+/* --- two-column grid --- */
+
+:root:not(.light) .eo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: start;
+}
+@media (max-width: 900px) {
+  :root:not(.light) .eo-grid { grid-template-columns: 1fr; }
+}
+
+/* Panels that read better full width on a wide screen. */
+:root:not(.light) .eo-span { grid-column: 1; }
+@media (max-width: 900px) {
+  :root:not(.light) .eo-span { grid-column: auto; }
+}
+
+/* --- attention rows --- */
+
+:root:not(.light) .eo-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+:root:not(.light) .eo-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid var(--vc-line-hairline);
+  flex-wrap: wrap;
+}
+:root:not(.light) .eo-row:first-child { border-top: 0; }
+
+:root:not(.light) .eo-row-icon {
+  display: grid;
+  place-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 7px;
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .eo-row-text {
+  flex: 1;
+  min-width: 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+:root:not(.light) .eo-row-name {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .eo-row-sub {
+  font-size: 0.75rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .eo-row-flags { display: flex; gap: 6px; flex-wrap: wrap; }
+
+:root:not(.light) .eo-flag {
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  border: 1px solid currentColor;
+}
+:root:not(.light) .eo-flag.tone-alert { color: var(--vc-state-alert); }
+:root:not(.light) .eo-flag.tone-due { color: var(--vc-state-due); }
+:root:not(.light) .eo-flag.tone-idle { color: var(--vc-text-tertiary); }
+
+:root:not(.light) .eo-row-qty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+  min-width: 58px;
+}
+
+:root:not(.light) .eo-qty {
+  font-family: var(--vc-font-mono);
+  font-size: 1.1rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .eo-qty.tone-alert { color: var(--vc-state-alert); }
+
+:root:not(.light) .eo-qty-label {
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .eo-more {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  padding: 10px 0 0;
+  background: none;
+  border: 0;
+  border-top: 1px solid var(--vc-line-hairline);
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-data-live);
+  cursor: pointer;
+}
+
+/* --- incoming shipment --- */
+
+:root:not(.light) .eo-ship-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+:root:not(.light) .eo-ship-supplier {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .eo-ship-id {
+  margin: 2px 0 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.78rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .eo-ship-facts {
+  display: flex;
+  gap: 26px;
+  margin: 0;
+}
+:root:not(.light) .eo-ship-facts dt {
+  font-size: 0.6rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .eo-ship-facts dd {
+  margin: 3px 0 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.9rem;
+  color: var(--vc-text-primary);
+}
+
+/* --- readiness bars --- */
+
+:root:not(.light) .eo-bars {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+:root:not(.light) .eo-bar-row {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) 2fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+:root:not(.light) .eo-bar-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  overflow-wrap: anywhere;
+}
+
+:root:not(.light) .eo-bar-track {
+  height: 7px;
+  border-radius: 999px;
+  background: var(--vc-bg-raised);
+  overflow: hidden;
+}
+
+:root:not(.light) .eo-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--vc-state-complete);
+}
+/* Under half stocked is worth noticing, so the bar changes role as well as
+ * length — a length alone is hard to judge at a glance. */
+:root:not(.light) .eo-bar-fill.tone-due { background: var(--vc-state-due); }
+
+:root:not(.light) .eo-bar-value {
+  font-family: var(--vc-font-mono);
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--vc-text-primary);
+  min-width: 40px;
+  text-align: right;
+}
+
+:root:not(.light) .eo-warn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--vc-state-due);
+}
+
+/* --- upcoming timeline --- */
+
+:root:not(.light) .eo-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(150px, 1fr);
+  gap: 14px;
+  overflow-x: auto;
+}
+@media (max-width: 720px) {
+  :root:not(.light) .eo-timeline {
+    grid-auto-flow: row;
+    grid-auto-columns: auto;
+  }
+}
+
+:root:not(.light) .eo-tl-step {
+  position: relative;
+  padding-top: 18px;
+  border-top: 1px dashed var(--vc-line-strong);
+}
+
+:root:not(.light) .eo-tl-node {
+  position: absolute;
+  top: -6px;
+  left: 0;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  border: 2px solid var(--vc-state-idle);
+  background: var(--vc-bg-surface);
+}
+:root:not(.light) .eo-tl-step.is-today .eo-tl-node {
+  border-color: var(--vc-state-due);
+  background: var(--vc-state-due);
+}
+:root:not(.light) .eo-tl-step.is-today { border-top-color: var(--vc-state-due); }
+
+:root:not(.light) .eo-tl-date {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--vc-font-mono);
+  font-size: 0.86rem;
+  color: var(--vc-text-primary);
+}
+
+:root:not(.light) .eo-tl-today {
+  font-size: 0.58rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-state-due);
+}
+
+:root:not(.light) .eo-tl-items {
+  list-style: disc;
+  margin: 8px 0 0;
+  padding-left: 18px;
+  font-size: 0.82rem;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .eo-tl-items li { margin-bottom: 3px; }
+
+:root:not(.light) .eo-tl-late {
+  margin-left: 6px;
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-state-alert);
+}
+
+/* --- recent activity --- */
+
+:root:not(.light) .eo-activity {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+:root:not(.light) .eo-activity li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+  border-top: 1px solid var(--vc-line-hairline);
+  color: var(--vc-text-secondary);
+  font-size: 0.85rem;
+}
+:root:not(.light) .eo-activity li:first-child { border-top: 0; }
+
+:root:not(.light) .eo-act-text { flex: 1; color: var(--vc-text-primary); }
+
+:root:not(.light) .eo-act-when {
+  font-family: var(--vc-font-mono);
+  font-size: 0.74rem;
+  white-space: nowrap;
+}

--- a/frontend/src/services/equipment.js
+++ b/frontend/src/services/equipment.js
@@ -39,6 +39,26 @@ export const equipmentService = {
     return asJson(response, 'Failed to fetch supplies');
   },
 
+  /** Change history across equipment, newest first. */
+  async changeHistory({ patientId = null, equipmentId = null, limit = 50 } = {}) {
+    const qs = new URLSearchParams();
+    if (patientId) qs.set('patient_id', patientId);
+    if (equipmentId) qs.set('equipment_id', equipmentId);
+    if (limit) qs.set('limit', limit);
+    const response = await apiFetch(`${config.apiUrl}/api/equipment/history?${qs}`);
+    return asJson(response, 'Failed to fetch equipment history');
+  },
+
+  /** Record a scheduled change. Refused with a 409 when tracked stock is out. */
+  async logChange(equipmentId, changedAt) {
+    const response = await apiFetch(`${config.apiUrl}/api/equipment/${equipmentId}/change`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ changed_at: changedAt }),
+    });
+    return asJson(response, 'Failed to record the change');
+  },
+
   async update(equipmentId, data) {
     const response = await apiFetch(`${config.apiUrl}/api/equipment/${equipmentId}`, {
       method: 'PUT',


### PR DESCRIPTION
`/care/equipment` was the catalogue — a management table on the tab called Overview. It is now the dashboard from the mockup, and the catalogue moves to `/care/equipment/manage` **unchanged**, reached from the Manage button. Nothing is lost, and the tab that says Overview now shows one.

## Every number opens what it counted

The four tiles, the attention list, the readiness bars and the timeline are derived in `lib/equipmentOverview.js` with tests, because they have to agree with the pages they link to.

**Due dates are the server's own rule.** `get_equipment_list` already returns `due_date` as `last_changed + useful_days`, and `get_equipment_due_count` calls an item due when that date is today or past. This matches both rather than inventing a third rule. "Due soon" is a lookahead this page adds and is deliberately **not** counted as due, so the tile agrees with the badge elsewhere.

## Readiness needed a definition, so it has one

The mockup shows `AIRWAY 42%` without saying what the denominator is. Here it is **the share of a category's supplies sitting at or above par** — a count, not a sum of quantities.

That is deliberate: a category mixes boxes of catheters with millilitres of saline, and adding those produces a percentage that means nothing. "How many of these are stocked to plan" is a question the mixed units survive.

Two related refusals to overstate:
- Supplies with no reorder point and no par level are **excluded from both halves** rather than counted as ready — counting them would inflate the bar for items nobody has told the system how to stock. They report `none`, not a reassuring `ok` nobody set.
- A catalogue with no levels at all says there is nothing to measure instead of drawing empty bars.

Categories are whatever the data actually has. The mockup's four are not hardcoded — an install with different categories gets its own.

## Two bugs the tests caught

- **A bare `YYYY-MM-DD` parses as UTC midnight**, which lands on the previous day anywhere west of Greenwich. On its own that was enough to report a change due today as *overdue*.
- **A missing quantity was reading as zero**, so a partial payload manufactured an out-of-stock warning nobody reported. Only a recorded `0` means out.

Both are pinned by tests.

## Notes for review

- **Frontend only.** The data all exists; this assembles it from `/api/equipment`, `/api/shipments` and `/api/equipment/history` rather than adding an endpoint. I considered a canonical `GET /api/equipment/overview` in the spirit of `/api/nutrition/plan`, but the derivation is presentation logic rather than something the server owns, and #135 was already touching the same files.
- **Log change** posts to the endpoint that refuses when tracked stock is exhausted, and surfaces its wording — which names the supply and the count — instead of a generic failure. It is offered only for scheduled items; a supply that is merely short gets restocked, not changed.
- The incoming panel shows the **soonest** arrival only; the rest are on Deliveries. It reuses #134's rail so the two pages cannot disagree about where a shipment is.
- The mockup's tab strip confirmed all five tabs, which settled the open question from #134 — Overview and Alerts stay.
- Rebased onto `dev/main` after #134 and #135 merged; it now carries a single commit and no longer stacks on anything.

## Verification

Frontend **924 pass** (884 from #134 + 40 new) · `npm run lint` clean at `--max-warnings 0` · production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
