### PR TITLE
Equipment history rebuilt as one timeline

### DIFF
--- a/backend/crud/equipment.py
+++ b/backend/crud/equipment.py
@@ -794,6 +794,54 @@ def get_equipment_count_history(db: Session, equipment_id: int, limit: int = 50,
         return []
 
 
+def get_recent_counts(db: Session, patient_id=None, account_id=None, limit: int = 100,
+                      start_date=None, end_date=None):
+    """Stocktakes across every supply, newest first.
+
+    The per-supply history has existed since the count log landed, but nothing
+    could ask "what stock was adjusted lately" without walking each supply in
+    turn. The history timeline needs exactly that, so this is the count log's
+    equivalent of the change log's global feed.
+
+    The supply's name and the person who counted are resolved here rather than
+    left as ids for the caller to look up one at a time.
+    """
+    try:
+        from models.users import User
+        query = (
+            db.query(EquipmentCountLog, Equipment.name, User.full_name)
+            .join(Equipment, EquipmentCountLog.equipment_id == Equipment.id)
+            .outerjoin(User, EquipmentCountLog.counted_by == User.id)
+        )
+        query = _scope_equipment(query, account_id)
+        if patient_id is not None:
+            query = query.filter(or_(Equipment.patient_id == patient_id,
+                                     Equipment.patient_id.is_(None)))
+        if start_date is not None:
+            query = query.filter(EquipmentCountLog.counted_at >= start_date)
+        if end_date is not None:
+            query = query.filter(EquipmentCountLog.counted_at <= end_date)
+
+        rows = query.order_by(EquipmentCountLog.counted_at.desc()).limit(limit).all()
+        return [
+            {
+                'id': c.id,
+                'equipment_id': c.equipment_id,
+                'equipment_name': name,
+                'quantity_before': c.quantity_before,
+                'quantity_after': c.quantity_after,
+                'note': c.note,
+                'counted_by': c.counted_by,
+                'counted_by_name': full_name,
+                'counted_at': c.counted_at.isoformat() if c.counted_at else None,
+            }
+            for c, name, full_name in rows
+        ]
+    except Exception as e:
+        logger.error(f"Error fetching recent counts: {e}")
+        return []
+
+
 def add_equipment_alias(db: Session, equipment_id: int, item_number: str, supplier_id=None, raw_description=None, account_id=None):
     """Attach a provider item number to a supply. Returns the alias id, or None."""
     try:

--- a/backend/routes/equipment.py
+++ b/backend/routes/equipment.py
@@ -46,7 +46,7 @@ from crud.equipment import (
     update_equipment, update_equipment_category, delete_equipment,
     delete_equipment_category, search_equipment, get_equipment_due_count,
     catalog_import, set_equipment_count, get_equipment_count_history,
-    add_equipment_alias, delete_equipment_alias
+    add_equipment_alias, delete_equipment_alias, get_recent_counts
 )
 
 logger = logging.getLogger("app")
@@ -113,12 +113,34 @@ async def api_catalog_import(
     )
 
 
+@router.get("/counts", dependencies=[Depends(require_permission("equipment.read"))])
+async def api_get_recent_counts(
+    patient_id: Optional[int] = None,
+    limit: int = 100,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    db: Session = Depends(get_db),
+    account_id: Optional[int] = Depends(get_optional_account_id),
+):
+    """Stocktakes across every supply, newest first.
+
+    The sibling /{equipment_id}/counts answers "what happened to this supply";
+    this answers "what stock was adjusted lately", which the history timeline
+    needs without walking each supply in turn.
+    """
+    return {"counts": get_recent_counts(
+        db, patient_id=patient_id, account_id=account_id, limit=limit,
+        start_date=start_date, end_date=end_date,
+    )}
+
+
 @router.post("/{equipment_id}/change", dependencies=[Depends(require_permission("equipment.change"))])
 async def api_log_equipment_change(
     equipment_id: int,
     data: EquipmentChangeLog,
     db: Session = Depends(get_db),
     account_id: Optional[int] = Depends(get_optional_account_id),
+    current_user=Depends(get_optional_user),
 ):
     """Log a change and update last_changed."""
 
@@ -149,7 +171,12 @@ async def api_log_equipment_change(
             "unit_of_measure": equipment.unit_of_measure,
         })
 
-    success = log_equipment_change(db, equipment_id, data.changed_at, account_id=account_id)
+    # The column has always existed; nothing filled it, so every change in
+    # the log is unattributed and the history cannot say who did it.
+    success = log_equipment_change(
+        db, equipment_id, data.changed_at, account_id=account_id,
+        changed_by=current_user.id if current_user else None,
+    )
     return {"success": success}
 
 
@@ -286,18 +313,33 @@ async def api_get_all_equipment_history(
             query = query.filter(EquipmentChangeLogSchema.changed_at <= end_date)
         
         changes = query.order_by(desc(EquipmentChangeLogSchema.changed_at)).limit(limit).all()
-        
+
+        # Resolve the names once rather than a query per row: the previous
+        # loop re-fetched the equipment for every change, and left changed_by
+        # as a bare user id the caller could do nothing with.
+        from models.users import User
+        equipment_ids = {c.equipment_id for c in changes}
+        user_ids = {c.changed_by for c in changes if c.changed_by}
+        names = dict(
+            db.query(Equipment.id, Equipment.name)
+            .filter(Equipment.id.in_(equipment_ids)).all()
+        ) if equipment_ids else {}
+        users = dict(
+            db.query(User.id, User.full_name)
+            .filter(User.id.in_(user_ids)).all()
+        ) if user_ids else {}
+
         result = []
         for change in changes:
-            equipment = db.query(Equipment).filter(Equipment.id == change.equipment_id).first()
             result.append({
                 'id': change.id,
                 'equipment_id': change.equipment_id,
-                'equipment_name': equipment.name if equipment else 'Unknown',
+                'equipment_name': names.get(change.equipment_id, 'Unknown'),
                 'patient_id': change.patient_id,
                 'changed_at': change.changed_at.isoformat() if change.changed_at else None,
                 'notes': change.notes,
                 'changed_by': change.changed_by,
+                'changed_by_name': users.get(change.changed_by),
                 'created_at': change.created_at.isoformat() if change.created_at else None
             })
         

--- a/backend/tests/test_equipment_history_feeds.py
+++ b/backend/tests/test_equipment_history_feeds.py
@@ -1,0 +1,125 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The two feeds the equipment history timeline reads.
+
+GET /api/equipment/counts is new: the count log had only a per-supply
+history, so nothing could ask what stock was adjusted lately without walking
+every supply in turn.
+
+Both feeds now resolve the person's name. The change feed previously returned
+changed_by as a bare user id, which the timeline cannot render, and re-queried
+the equipment row once per change to get its name.
+"""
+
+
+def _make(cl, patient, **over):
+    payload = {
+        "name": "Trach tube", "quantity": 5, "scheduled_replacement": False,
+        "patient_id": patient.id,
+    }
+    payload.update(over)
+    resp = cl.post("/api/equipment", json=payload)
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+# --- The new global stocktake feed ---------------------------------------
+
+def test_counts_feed_spans_every_supply(admin_client, patient):
+    a = _make(admin_client, patient, name="Catheter")
+    b = _make(admin_client, patient, name="Gauze")
+    admin_client.post(f"/api/equipment/{a}/count", json={"quantity": 2, "note": "Used"})
+    admin_client.post(f"/api/equipment/{b}/count", json={"quantity": 9})
+
+    rows = admin_client.get("/api/equipment/counts").json()["counts"]
+    assert {r["equipment_name"] for r in rows} >= {"Catheter", "Gauze"}
+
+
+def test_counts_feed_carries_the_before_and_after(admin_client, patient):
+    eid = _make(admin_client, patient, name="Catheter", quantity=4)
+    admin_client.post(f"/api/equipment/{eid}/count", json={"quantity": 0, "note": "Used"})
+
+    row = next(r for r in admin_client.get("/api/equipment/counts").json()["counts"]
+               if r["equipment_id"] == eid)
+    assert row["quantity_before"] == 4
+    assert row["quantity_after"] == 0
+    assert row["note"] == "Used"
+
+
+def test_counts_feed_names_who_counted(admin_client, patient, admin_user):
+    eid = _make(admin_client, patient)
+    admin_client.post(f"/api/equipment/{eid}/count", json={"quantity": 3})
+
+    row = admin_client.get("/api/equipment/counts").json()["counts"][0]
+    assert row["counted_by_name"] == admin_user.full_name
+
+
+def test_counts_feed_is_newest_first(admin_client, patient):
+    eid = _make(admin_client, patient)
+    admin_client.post(f"/api/equipment/{eid}/count", json={"quantity": 1})
+    admin_client.post(f"/api/equipment/{eid}/count", json={"quantity": 7})
+
+    rows = admin_client.get("/api/equipment/counts").json()["counts"]
+    assert rows[0]["quantity_after"] == 7
+
+
+def test_counts_feed_respects_limit(admin_client, patient):
+    eid = _make(admin_client, patient)
+    for q in range(1, 5):
+        admin_client.post(f"/api/equipment/{eid}/count", json={"quantity": q})
+    assert len(admin_client.get("/api/equipment/counts?limit=2").json()["counts"]) == 2
+
+
+def test_counts_feed_is_gated(limited_client):
+    # admin_client and limited_client share one TestClient whose header the
+    # later fixture overwrites, so a gating test must not ask for both.
+    assert limited_client.get("/api/equipment/counts").status_code == 403
+
+
+def test_counts_path_is_not_read_as_an_equipment_id(admin_client, patient):
+    """Declared before /{equipment_id}, so "counts" stays a literal path."""
+    _make(admin_client, patient)
+    assert admin_client.get("/api/equipment/counts").status_code == 200
+
+
+# --- The change feed now names the person --------------------------------
+
+def test_change_feed_names_who_changed_it(admin_client, patient, admin_user):
+    eid = _make(admin_client, patient, scheduled_replacement=True,
+                last_changed="2026-08-01T00:00:00Z", useful_days=30)
+    admin_client.post(f"/api/equipment/{eid}/change",
+                      json={"changed_at": "2026-08-19T00:00:00Z"})
+
+    row = admin_client.get("/api/equipment/history").json()["history"][0]
+    assert row["changed_by_name"] == admin_user.full_name
+    assert row["equipment_name"] == "Trach tube"
+
+
+def test_change_feed_survives_a_change_with_no_user(admin_client, patient, db_session):
+    """changed_by is nullable; the name comes back as null, not an error."""
+    eid = _make(admin_client, patient, scheduled_replacement=True,
+                last_changed="2026-08-01T00:00:00Z", useful_days=30)
+    from schemas.equipment_change_log import EquipmentChangeLog
+    from datetime import datetime, timezone
+    db_session.add(EquipmentChangeLog(
+        equipment_id=eid, patient_id=patient.id,
+        changed_at=datetime.now(timezone.utc), changed_by=None,
+        created_at=datetime.now(timezone.utc),
+    ))
+    db_session.commit()
+
+    rows = admin_client.get("/api/equipment/history").json()["history"]
+    assert any(r["changed_by_name"] is None for r in rows)

--- a/frontend/src/lib/equipmentHistory.js
+++ b/frontend/src/lib/equipmentHistory.js
@@ -1,0 +1,242 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Three separate records — scheduled changes, stocktakes, and deliveries —
+// read as one history, because that is how the day actually went.
+//
+// Each source keeps its own vocabulary in its own table; this is the one
+// place that translates them into a single event shape, so the timeline does
+// not learn three dialects the way the old pages learned two.
+//
+// On grouping: several changes logged by one person on one day are shown as
+// one entry. That is a *display* grouping and is worded as one ("3 changes
+// logged by John"), not as a claim they were performed as a single action —
+// nothing in the schema records that association, since changes are logged
+// one item at a time. If that association is ever worth asserting, it wants a
+// real id on the row, the way nutrition's event_group_id replaced re-merging
+// output rows by a time window.
+
+export const EVENT_TYPES = [
+  { value: 'all', label: 'All' },
+  { value: 'change', label: 'Changes' },
+  { value: 'delivery', label: 'Deliveries' },
+  { value: 'stock', label: 'Stock' },
+  { value: 'note', label: 'Notes' },
+];
+
+export const RANGES = [
+  { value: 30, label: 'Last 30 days' },
+  { value: 90, label: 'Last 90 days' },
+  { value: 365, label: 'Last year' },
+  { value: 0, label: 'Everything' },
+];
+
+const dayKey = (value) => {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+};
+
+/** One scheduled change becomes one event; the caller groups them after. */
+function changeEvents(changes = []) {
+  return changes.map((c) => ({
+    id: `change-${c.id}`,
+    kind: 'change',
+    at: c.changed_at,
+    who: c.changed_by_name || null,
+    title: c.equipment_name || 'Equipment',
+    note: c.notes || null,
+    equipmentId: c.equipment_id,
+  }));
+}
+
+/**
+ * A stocktake. Which direction it went is the point, so it is resolved here
+ * rather than left for the row to work out from two numbers.
+ */
+function stockEvents(counts = []) {
+  return counts.map((c) => {
+    const before = c.quantity_before ?? 0;
+    const after = c.quantity_after ?? 0;
+    return {
+      id: `stock-${c.id}`,
+      kind: 'stock',
+      at: c.counted_at,
+      who: c.counted_by_name || null,
+      title: c.equipment_name || 'Supply',
+      note: c.note || null,
+      equipmentId: c.equipment_id,
+      before,
+      after,
+      delta: after - before,
+      direction: after === before ? 'same' : (after > before ? 'up' : 'down'),
+    };
+  });
+}
+
+/**
+ * A delivery enters the history when it actually landed, not when it was
+ * created — a draft raised in June and received in August belongs in August.
+ * Shipments that never landed are left out entirely rather than dated by
+ * something that is not an arrival.
+ */
+function deliveryEvents(shipments = []) {
+  return shipments
+    .map((s) => {
+      const at = s.actual_delivery || s.finalized_at;
+      if (!at) return null;
+      return {
+        id: `delivery-${s.id}`,
+        kind: 'delivery',
+        at,
+        who: null,
+        title: s.supplier_name || 'Delivery',
+        reference: s.order_number || s.po_number || `#${s.id}`,
+        itemCount: s.item_count ?? 0,
+        status: s.status,
+        shipmentId: s.id,
+      };
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Changes by one person on one day collapse into a single entry.
+ *
+ * Deliberately keyed on the calendar day and the person, not on a tolerance
+ * around a timestamp: a window would be a rule invented here, and this is a
+ * grouping for reading, not a claim about how the work was done.
+ */
+export function groupChanges(events = []) {
+  const groups = new Map();
+  const out = [];
+  for (const event of events) {
+    if (event.kind !== 'change') { out.push(event); continue; }
+    const key = `${dayKey(event.at)}|${event.who || 'unknown'}`;
+    if (!groups.has(key)) {
+      const group = {
+        id: `changeset-${key}`,
+        kind: 'change',
+        at: event.at,
+        who: event.who,
+        items: [],
+      };
+      groups.set(key, group);
+      out.push(group);
+    }
+    const group = groups.get(key);
+    group.items.push(event);
+    // The set is dated by its most recent change.
+    if (new Date(event.at) > new Date(group.at)) group.at = event.at;
+  }
+  return out;
+}
+
+/** Does this event carry something somebody wrote down? */
+export const hasNote = (event) => Boolean(
+  event.note || (event.items || []).some((i) => i.note),
+);
+
+/**
+ * Filter by the chips. 'note' is not a source of its own — it is any event
+ * that carries a written note, which is why it can overlap the others.
+ */
+export function filterEvents(events = [], { type = 'all', search = '' } = {}) {
+  const needle = search.trim().toLowerCase();
+  return events.filter((event) => {
+    if (type === 'note' && !hasNote(event)) return false;
+    if (type !== 'all' && type !== 'note' && event.kind !== type) return false;
+    if (!needle) return true;
+    const haystack = [
+      event.title, event.reference, event.note, event.who,
+      ...(event.items || []).flatMap((i) => [i.title, i.note]),
+    ];
+    return haystack.some((v) => String(v || '').toLowerCase().includes(needle));
+  });
+}
+
+/** Events on or after the cutoff. A range of 0 means everything. */
+export function withinRange(events = [], days = 90, today = new Date()) {
+  if (!days) return events;
+  const cutoff = new Date(today);
+  cutoff.setDate(cutoff.getDate() - days);
+  return events.filter((e) => new Date(e.at) >= cutoff);
+}
+
+/** The merged timeline, newest first. */
+export function buildTimeline({ changes = [], counts = [], shipments = [] } = {}) {
+  const merged = [
+    ...changeEvents(changes),
+    ...stockEvents(counts),
+    ...deliveryEvents(shipments),
+  ].filter((e) => e.at && !Number.isNaN(new Date(e.at).getTime()));
+
+  merged.sort((a, b) => new Date(b.at) - new Date(a.at));
+  return groupChanges(merged);
+}
+
+/** Events bucketed by calendar day, newest day first, for the date gutter. */
+export function byDay(events = []) {
+  const days = new Map();
+  for (const event of events) {
+    const key = dayKey(event.at);
+    if (!key) continue;
+    if (!days.has(key)) days.set(key, { key, date: new Date(event.at), events: [] });
+    days.get(key).events.push(event);
+  }
+  return [...days.values()].sort((a, b) => b.date - a.date);
+}
+
+/** "12 events · May 21–Aug 19" — the span actually shown. */
+export function timelineSummary(events = []) {
+  if (events.length === 0) return { count: 0, from: null, to: null };
+  const times = events.map((e) => new Date(e.at)).sort((a, b) => a - b);
+  return { count: events.length, from: times[0], to: times[times.length - 1] };
+}
+
+/** One row per event, for the CSV export. */
+export function toCsvRows(events = []) {
+  const rows = [['When', 'Type', 'What', 'Detail', 'Who']];
+  for (const event of events) {
+    if (event.kind === 'change' && event.items) {
+      // A set exports as its members: a row that says "3 changes" is not
+      // something a spreadsheet can do anything with.
+      for (const item of event.items) {
+        rows.push([item.at, 'Change', item.title, item.note || '', item.who || '']);
+      }
+      continue;
+    }
+    if (event.kind === 'stock') {
+      rows.push([event.at, 'Stock', event.title,
+        `${event.before} → ${event.after}${event.note ? ` (${event.note})` : ''}`,
+        event.who || '']);
+      continue;
+    }
+    rows.push([event.at, 'Delivery', event.title,
+      `${event.reference} · ${event.itemCount} items`, event.who || '']);
+  }
+  return rows;
+}
+
+export function toCsv(events = []) {
+  return toCsvRows(events)
+    .map((row) => row.map((cell) => {
+      const value = String(cell ?? '');
+      return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+    }).join(','))
+    .join('\n');
+}

--- a/frontend/src/lib/equipmentHistory.test.js
+++ b/frontend/src/lib/equipmentHistory.test.js
@@ -1,0 +1,242 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildTimeline, groupChanges, filterEvents, withinRange, byDay,
+  timelineSummary, hasNote, toCsvRows, toCsv,
+} from './equipmentHistory';
+
+const TODAY = new Date('2026-08-19T12:00:00');
+
+const CHANGES = [
+  { id: 1, equipment_id: 10, equipment_name: 'Vent tube', changed_at: '2026-06-26T00:21:00', changed_by_name: 'John' },
+  { id: 2, equipment_id: 11, equipment_name: 'Trach tube', changed_at: '2026-06-26T00:22:00', changed_by_name: 'John' },
+  { id: 3, equipment_id: 12, equipment_name: 'Humidification chamber', changed_at: '2026-06-26T00:23:00', changed_by_name: 'John', notes: 'Replaced early' },
+];
+
+const COUNTS = [
+  {
+    id: 5, equipment_id: 20, equipment_name: 'Connector STRT Two Base',
+    quantity_before: 4, quantity_after: 0, note: 'Used / corrected count',
+    counted_by_name: 'Mary', counted_at: '2026-08-19T10:42:00',
+  },
+];
+
+const SHIPMENTS = [
+  {
+    id: 30, supplier_name: 'Pediatric Home Service', order_number: '78599210',
+    status: 'complete', item_count: 18, actual_delivery: '2026-08-04T14:15:00',
+  },
+  // Never landed — belongs to no day on this timeline.
+  { id: 31, supplier_name: 'Other', status: 'draft', item_count: 2 },
+];
+
+const build = () => buildTimeline({ changes: CHANGES, counts: COUNTS, shipments: SHIPMENTS });
+
+describe('buildTimeline', () => {
+  it('merges the three records into one list, newest first', () => {
+    const events = build();
+    expect(events.map((e) => e.kind)).toEqual(['stock', 'delivery', 'change']);
+  });
+
+  it('dates a delivery by when it landed, not when it was raised', () => {
+    const [, delivery] = build();
+    expect(delivery.at).toBe('2026-08-04T14:15:00');
+  });
+
+  it('leaves out a shipment that never arrived', () => {
+    // A draft has no arrival date; dating it by anything else would be a guess.
+    expect(build().some((e) => e.shipmentId === 31)).toBe(false);
+  });
+
+  it('drops events with an unusable timestamp rather than sorting them oddly', () => {
+    const events = buildTimeline({
+      changes: [{ id: 9, equipment_name: 'Broken', changed_at: 'not a date' }],
+    });
+    expect(events).toEqual([]);
+  });
+
+  it('resolves which way a stocktake went', () => {
+    const [stock] = build();
+    expect(stock.before).toBe(4);
+    expect(stock.after).toBe(0);
+    expect(stock.delta).toBe(-4);
+    expect(stock.direction).toBe('down');
+  });
+
+  it('calls a stocktake that changed nothing "same", not a rise', () => {
+    const [stock] = buildTimeline({
+      counts: [{ id: 1, quantity_before: 5, quantity_after: 5, counted_at: '2026-08-19T10:00:00' }],
+    });
+    expect(stock.direction).toBe('same');
+    expect(stock.delta).toBe(0);
+  });
+});
+
+describe('groupChanges', () => {
+  it('collapses one person\'s changes on one day into a single entry', () => {
+    const events = build();
+    const set = events.find((e) => e.kind === 'change');
+    expect(set.items).toHaveLength(3);
+    expect(set.who).toBe('John');
+  });
+
+  it('dates the set by its most recent change', () => {
+    const set = build().find((e) => e.kind === 'change');
+    expect(set.at).toBe('2026-06-26T00:23:00');
+  });
+
+  it('keeps different people apart on the same day', () => {
+    const events = groupChanges([
+      { id: 'a', kind: 'change', at: '2026-06-26T01:00:00', who: 'John' },
+      { id: 'b', kind: 'change', at: '2026-06-26T02:00:00', who: 'Mary' },
+    ]);
+    expect(events).toHaveLength(2);
+  });
+
+  it('keeps the same person apart across days', () => {
+    // The grouping is per calendar day, not a tolerance around a time —
+    // 23:59 and 00:01 are different days and stay separate entries.
+    const events = groupChanges([
+      { id: 'a', kind: 'change', at: '2026-06-26T23:59:00', who: 'John' },
+      { id: 'b', kind: 'change', at: '2026-06-27T00:01:00', who: 'John' },
+    ]);
+    expect(events).toHaveLength(2);
+  });
+
+  it('groups unattributed changes together rather than dropping them', () => {
+    const events = groupChanges([
+      { id: 'a', kind: 'change', at: '2026-06-26T01:00:00', who: null },
+      { id: 'b', kind: 'change', at: '2026-06-26T02:00:00', who: null },
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0].items).toHaveLength(2);
+  });
+
+  it('leaves other kinds untouched', () => {
+    const events = groupChanges([{ id: 's', kind: 'stock', at: '2026-08-19T10:00:00' }]);
+    expect(events[0].kind).toBe('stock');
+    expect(events[0].items).toBeUndefined();
+  });
+});
+
+describe('filterEvents', () => {
+  it('filters by kind', () => {
+    expect(filterEvents(build(), { type: 'stock' })).toHaveLength(1);
+    expect(filterEvents(build(), { type: 'delivery' })).toHaveLength(1);
+    expect(filterEvents(build(), { type: 'all' })).toHaveLength(3);
+  });
+
+  it('treats notes as a cross-cutting filter, not a fourth source', () => {
+    // The stocktake and one change both carry a note; both should survive.
+    const noted = filterEvents(build(), { type: 'note' });
+    expect(noted.map((e) => e.kind).sort()).toEqual(['change', 'stock']);
+  });
+
+  it('searches inside a change set, not just its heading', () => {
+    // The set's own title is empty; the supply name lives on its members.
+    const found = filterEvents(build(), { search: 'trach' });
+    expect(found).toHaveLength(1);
+    expect(found[0].kind).toBe('change');
+  });
+
+  it('searches the delivery reference and supplier', () => {
+    expect(filterEvents(build(), { search: '78599210' })).toHaveLength(1);
+    expect(filterEvents(build(), { search: 'pediatric' })).toHaveLength(1);
+  });
+
+  it('is case-insensitive and ignores surrounding space', () => {
+    expect(filterEvents(build(), { search: '  MARY ' })).toHaveLength(1);
+  });
+});
+
+describe('withinRange', () => {
+  it('keeps only what falls inside the window', () => {
+    expect(withinRange(build(), 30, TODAY).map((e) => e.kind)).toEqual(['stock', 'delivery']);
+  });
+
+  it('keeps everything when the range is off', () => {
+    expect(withinRange(build(), 0, TODAY)).toHaveLength(3);
+  });
+});
+
+describe('byDay', () => {
+  it('buckets events by calendar day, newest day first', () => {
+    const days = byDay(build());
+    expect(days).toHaveLength(3);
+    expect(days[0].events[0].kind).toBe('stock');
+  });
+
+  it('puts several events on one day into the same bucket', () => {
+    const days = byDay([
+      { id: 1, at: '2026-08-19T09:00:00' },
+      { id: 2, at: '2026-08-19T17:00:00' },
+    ]);
+    expect(days).toHaveLength(1);
+    expect(days[0].events).toHaveLength(2);
+  });
+});
+
+describe('timelineSummary', () => {
+  it('reports the count and the span actually shown', () => {
+    const { count, from, to } = timelineSummary(build());
+    expect(count).toBe(3);
+    expect(from.getMonth()).toBe(5);  // June
+    expect(to.getMonth()).toBe(7);    // August
+  });
+
+  it('says nothing rather than an empty range', () => {
+    expect(timelineSummary([])).toEqual({ count: 0, from: null, to: null });
+  });
+});
+
+describe('hasNote', () => {
+  it('finds a note on the event or on a member of a set', () => {
+    expect(hasNote({ note: 'x' })).toBe(true);
+    expect(hasNote({ items: [{ note: null }, { note: 'y' }] })).toBe(true);
+    expect(hasNote({ items: [{ note: null }] })).toBe(false);
+    expect(hasNote({})).toBe(false);
+  });
+});
+
+describe('csv export', () => {
+  it('exports a change set as its members, not as a summary row', () => {
+    const rows = toCsvRows(build());
+    const changeRows = rows.filter((r) => r[1] === 'Change');
+    expect(changeRows).toHaveLength(3);
+    expect(changeRows.map((r) => r[2])).toContain('Trach tube');
+  });
+
+  it('spells out what a stocktake did', () => {
+    const row = toCsvRows(build()).find((r) => r[1] === 'Stock');
+    expect(row[3]).toBe('4 → 0 (Used / corrected count)');
+  });
+
+  it('quotes cells containing commas or quotes', () => {
+    const csv = toCsv([{
+      kind: 'stock', at: '2026-08-19T10:00:00', title: 'Tube, large',
+      before: 1, after: 2, note: 'said "ok"', who: 'Mary',
+    }]);
+    expect(csv).toContain('"Tube, large"');
+    expect(csv).toContain('"1 → 2 (said ""ok"")"');
+  });
+
+  it('starts with a header row', () => {
+    expect(toCsvRows([])[0]).toEqual(['When', 'Type', 'What', 'Detail', 'Who']);
+  });
+});

--- a/frontend/src/pages/admin-v2/AdminV2EquipmentHistory.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2EquipmentHistory.jsx
@@ -15,326 +15,318 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+// Equipment history: changes, deliveries and stock activity as one timeline.
+//
+// The page used to show the change log alone, which meant a supply could go
+// from four on hand to zero, or a box of eighteen items could arrive, and
+// neither appeared in the thing called History. All three records are read
+// together here; the merging rules live in lib/equipmentHistory.js.
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import AdminV2Layout from './AdminV2Layout';
-import config from '../../config';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
 import {
-  EquipmentIcon,
-  XIcon,
-  ClockIcon
+  EquipmentIcon, PackageIcon, SearchIcon, ChevronRightIcon,
+  ChevronDownIcon, FileTextIcon, WrenchIcon,
 } from '../../components/Icons';
-import { Button } from '@/components/ui/button';
-import { Alert } from '@/components/ui/alert';
+import ChipGroup from '../../components/vc/ChipGroup';
+import { equipmentService } from '../../services/equipment';
+import { shipmentService } from '../../services/shipments';
+import { statusInfo } from '../../lib/shipmentStatus';
+import {
+  EVENT_TYPES, RANGES, buildTimeline, filterEvents, withinRange, byDay,
+  timelineSummary, toCsv,
+} from '../../lib/equipmentHistory';
 import './AdminV2.css';
+import './components/shipments-page.css';
+import './components/equipment-overview.css';
+import './components/equipment-history.css';
+
+const time = (value) => new Date(value).toLocaleTimeString(undefined, {
+  hour: 'numeric', minute: '2-digit',
+});
+const dayHeading = (date, today) => {
+  const same = date.toDateString() === today.toDateString();
+  if (same) return 'Today';
+  return date.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
+};
+const spanLabel = (from, to) => {
+  if (!from) return null;
+  const fmt = (d) => d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return from.toDateString() === to.toDateString() ? fmt(from) : `${fmt(from)}–${fmt(to)}`;
+};
 
 const AdminV2EquipmentHistory = () => {
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { 
-    patients, 
-    selectedPatient: contextPatient, 
-    selectPatient: setContextPatient,
-    loadingPatients 
+  const {
+    patients, selectedPatient: contextPatient,
+    selectPatient: setContextPatient, loadingPatients,
   } = useAdminPatient();
-  
-  // Use context patient as the source of truth
   const selectedPatient = contextPatient;
-  
-  // Equipment list for filter dropdown
-  const [equipment, setEquipment] = useState([]);
-  
-  // History data state
-  const [history, setHistory] = useState([]);
+
+  const [changes, setChanges] = useState([]);
+  const [counts, setCounts] = useState([]);
+  const [shipments, setShipments] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  
-  // Filter state
-  const [equipmentFilter, setEquipmentFilter] = useState('');
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
-  const [limit, setLimit] = useState(50);
 
-  // Check URL params for patient ID or use context patient
+  const [type, setType] = useState('all');
+  const [search, setSearch] = useState('');
+  const [range, setRange] = useState(90);
+  const [collapsed, setCollapsed] = useState({});
+
   useEffect(() => {
     const patientId = searchParams.get('patient');
     if (patientId && patients.length > 0) {
-      const patient = patients.find(p => p.id === parseInt(patientId));
-      if (patient && patient.id !== contextPatient?.id) {
-        setContextPatient(patient);
-      }
+      const patient = patients.find((p) => p.id === parseInt(patientId, 10));
+      if (patient && patient.id !== contextPatient?.id) setContextPatient(patient);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way URL→context sync; adding contextPatient would re-run on selection change and revert it to the stale URL param
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way URL→context sync; adding contextPatient would re-run on selection change and revert it to the stale URL param
   }, [searchParams, patients, loadingPatients]);
 
-  // Update URL when context patient changes
   useEffect(() => {
     if (contextPatient && searchParams.get('patient') !== String(contextPatient.id)) {
       setSearchParams({ patient: contextPatient.id });
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way context→URL sync; runs only when the selection changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-way context→URL sync; runs only when the selection changes
   }, [contextPatient]);
 
-  // Fetch equipment and history when patient is selected
-  useEffect(() => {
-    if (selectedPatient) {
-      fetchEquipment();
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helper is recreated each render; effect is keyed on patient change only
-  }, [selectedPatient]);
-
-  // Fetch history when filters change
-  useEffect(() => {
-    if (selectedPatient) {
-      fetchHistory();
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch helper is recreated each render; effect is keyed on patient/filter changes only
-  }, [selectedPatient, equipmentFilter, startDate, endDate, limit]);
-
-  const fetchEquipment = async () => {
+  const fetchAll = useCallback(async () => {
     if (!selectedPatient) return;
-    
+    setLoading(true);
+    setError(null);
     try {
-      const response = await fetch(`${config.apiUrl}/api/equipment?patient_id=${selectedPatient.id}`, {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setEquipment(data);
-      }
+      const [history, stock, ships] = await Promise.all([
+        equipmentService.changeHistory({ patientId: selectedPatient.id, limit: 200 }),
+        equipmentService.recentCounts({ patientId: selectedPatient.id, limit: 200 }),
+        shipmentService.listShipments({ patient_id: selectedPatient.id, is_template: false }),
+      ]);
+      setChanges(history.history || []);
+      setCounts(stock.counts || []);
+      setShipments(ships.shipments || []);
     } catch (err) {
-      console.error('Error fetching equipment:', err);
-    }
-  };
-
-  const fetchHistory = async () => {
-    if (!selectedPatient) return;
-    
-    try {
-      setLoading(true);
-      setError(null);
-      
-      const params = new URLSearchParams();
-      params.append('limit', limit.toString());
-      params.append('patient_id', selectedPatient.id.toString());
-      
-      if (equipmentFilter) {
-        params.append('equipment_id', equipmentFilter);
-      }
-      if (startDate) {
-        params.append('start_date', startDate);
-      }
-      if (endDate) {
-        params.append('end_date', endDate);
-      }
-      
-      const response = await fetch(
-        `${config.apiUrl}/api/equipment/history?${params.toString()}`,
-        { credentials: 'include' }
-      );
-
-      if (response.ok) {
-        const data = await response.json();
-        setHistory(data.history || []);
-      } else {
-        setError('Failed to load history');
-      }
-    } catch (err) {
-      setError('Error connecting to server');
-      console.error('Error fetching history:', err);
+      setError(err.message);
     } finally {
       setLoading(false);
     }
+  }, [selectedPatient]);
+
+  useEffect(() => { fetchAll(); }, [fetchAll]);
+
+  const today = new Date();
+  const timeline = useMemo(
+    () => buildTimeline({ changes, counts, shipments }),
+    [changes, counts, shipments],
+  );
+  const visible = useMemo(
+    () => filterEvents(withinRange(timeline, range, today), { type, search }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `today` is recreated each render; the window only moves when the range does
+    [timeline, range, type, search],
+  );
+  const days = useMemo(() => byDay(visible), [visible]);
+  const summary = useMemo(() => timelineSummary(visible), [visible]);
+
+  const goto = (path) => navigate(`${path}?patient=${selectedPatient.id}`);
+
+  const exportCsv = () => {
+    // Exports what is on screen, not the whole log — otherwise the file and
+    // the page disagree about what "this history" means.
+    const blob = new Blob([toCsv(visible)], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `equipment-history-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
-  const handleClearFilters = () => {
-    setEquipmentFilter('');
-    setStartDate('');
-    setEndDate('');
-    setLimit(50);
-  };
-
-  // Group history by day
-  const groupHistoryByDay = (historyItems) => {
-    const groups = {};
-    
-    historyItems.forEach(item => {
-      const dateObj = new Date(item.changed_at);
-      const dayKey = dateObj.toLocaleDateString(undefined, { 
-        weekday: 'long', 
-        year: 'numeric', 
-        month: 'long', 
-        day: 'numeric' 
-      });
-      
-      if (!groups[dayKey]) groups[dayKey] = [];
-      groups[dayKey].push(item);
-    });
-    
-    return groups;
-  };
-
-  const groupedHistory = groupHistoryByDay(history);
-  const sortedDays = Object.keys(groupedHistory).sort((a, b) => new Date(b) - new Date(a));
-
-  const hasActiveFilters = equipmentFilter || startDate || endDate || limit !== 50;
-
-  // Loading state
   if (loadingPatients) {
+    return <AdminV2Layout><div className="admin-v2-loading">Loading patients…</div></AdminV2Layout>;
+  }
+  if (!selectedPatient) {
     return (
       <AdminV2Layout>
-        <div className="admin-v2-loading">Loading patients...</div>
+        <div className="admin-v2-loading">Select a patient from the sidebar</div>
       </AdminV2Layout>
     );
   }
 
+  const renderEvent = (event) => {
+    if (event.kind === 'stock') {
+      const rose = event.direction === 'up';
+      return (
+        <article className="eh-card kind-stock">
+          <header className="eh-card-head">
+            <span className="eh-kind">Stock adjustment</span>
+            <span className="eh-time">{time(event.at)}</span>
+          </header>
+          <p className="eh-line">
+            <strong>{event.title}</strong> changed{' '}
+            <span className="eh-num">{event.before}</span>
+            {' → '}
+            <span className={`eh-num ${rose ? 'is-up' : 'is-down'}`}>{event.after}</span>
+            {' on hand'}
+          </p>
+          <p className="eh-meta">
+            {event.who ? `by ${event.who}` : 'by an unrecorded user'}
+            {event.note ? ` · ${event.note}` : ''}
+          </p>
+          {event.equipmentId && (
+            <button type="button" className="eh-link" onClick={() => goto('/care/equipment/manage')}>
+              View supply <ChevronRightIcon size={15} />
+            </button>
+          )}
+        </article>
+      );
+    }
+
+    if (event.kind === 'delivery') {
+      const info = statusInfo(event.status);
+      return (
+        <article className="eh-card kind-delivery">
+          <header className="eh-card-head">
+            <span className="eh-kind">Shipment received</span>
+            <span className="eh-time">{time(event.at)}</span>
+          </header>
+          <p className="eh-line">
+            <strong>{event.title}</strong> · {event.reference}
+            <span className={`sc-status tone-${info.tone} eh-status`}>{info.label}</span>
+          </p>
+          <p className="eh-meta">{event.itemCount} items</p>
+          <button type="button" className="eh-link"
+                  onClick={() => goto(`/care/equipment/shipments/${event.shipmentId}`)}>
+            View shipment <ChevronRightIcon size={15} />
+          </button>
+        </article>
+      );
+    }
+
+    // A change set. One change is stated as one change, not as a set of one.
+    const items = event.items || [];
+    const single = items.length === 1;
+    const isCollapsed = collapsed[event.id];
+    return (
+      <article className="eh-card kind-change">
+        <header className="eh-card-head">
+          <span className="eh-kind">{single ? 'Scheduled change' : 'Scheduled changes'}</span>
+          <span className="eh-time">
+            {time(event.at)}
+            {!single && (
+              <button type="button" className="eh-toggle"
+                      aria-expanded={!isCollapsed}
+                      aria-label={isCollapsed ? 'Show the items' : 'Hide the items'}
+                      onClick={() => setCollapsed((c) => ({ ...c, [event.id]: !c[event.id] }))}>
+                <ChevronDownIcon size={16} />
+              </button>
+            )}
+          </span>
+        </header>
+        <p className="eh-line">
+          {single
+            ? <strong>{items[0].title}</strong>
+            : `${items.length} equipment items changed`}
+        </p>
+        {/* Worded as what it is: several changes logged by one person on one
+            day. Nothing records that they were done as a single action. */}
+        <p className="eh-meta">
+          {event.who ? `logged by ${event.who}` : 'logged by an unrecorded user'}
+        </p>
+        {!single && !isCollapsed && (
+          <ul className="eh-set">
+            {items.map((item, i) => (
+              <li key={item.id}>
+                <span className="eh-set-num">{i + 1}</span>
+                <span className="eh-set-name">{item.title}</span>
+                {item.note && <span className="eh-set-note">{item.note}</span>}
+                <span className="eh-set-tag">Changed</span>
+              </li>
+            ))}
+          </ul>
+        )}
+        {single && items[0].note && <p className="eh-meta">{items[0].note}</p>}
+      </article>
+    );
+  };
+
   return (
     <AdminV2Layout>
-      <div className="admin-v2-page">
-        {selectedPatient ? (
-          <>
-            {/* Filter Bar */}
-            <div className="history-filter-bar">
-              <div className="history-filter-row">
-                {/* Equipment Filter */}
-                <div className="history-filter-group">
-                  <label>Equipment</label>
-                  <select
-                    value={equipmentFilter}
-                    onChange={e => setEquipmentFilter(e.target.value)}
-                    className="history-filter-select"
-                  >
-                    <option value="">All Equipment</option>
-                    {equipment.map(equip => (
-                      <option key={equip.id} value={equip.id}>{equip.name}</option>
-                    ))}
-                  </select>
-                </div>
+      <div className="admin-v2-page sh-page eh-page">
+        {error && <div className="sh-error" role="alert">{error}</div>}
 
-                {/* Start Date */}
-                <div className="history-filter-group">
-                  <label>From</label>
-                  <input
-                    type="date"
-                    value={startDate}
-                    onChange={e => setStartDate(e.target.value)}
-                    className="history-filter-input"
-                  />
-                </div>
+        <div className="eo-head">
+          <div>
+            <h1 className="sh-title">Equipment history</h1>
+            <p className="eo-sub">Changes, deliveries, and inventory activity.</p>
+          </div>
+          <button type="button" className="sh-btn" onClick={exportCsv}
+                  disabled={visible.length === 0}>
+            <FileTextIcon size={16} /> Export
+          </button>
+        </div>
 
-                {/* End Date */}
-                <div className="history-filter-group">
-                  <label>To</label>
-                  <input
-                    type="date"
-                    value={endDate}
-                    onChange={e => setEndDate(e.target.value)}
-                    className="history-filter-input"
-                  />
-                </div>
+        <div className="eh-controls">
+          <div className="sh-search">
+            <SearchIcon size={16} />
+            <input type="text" value={search} aria-label="Search history"
+                   placeholder="Search equipment, supplier or note"
+                   onChange={(e) => setSearch(e.target.value)} />
+          </div>
+          <label className="eh-range">
+            <span className="eh-range-label">Range</span>
+            <select className="em-input" value={range} aria-label="Date range"
+                    onChange={(e) => setRange(Number(e.target.value))}>
+              {RANGES.map((r) => (
+                <option key={r.value} value={r.value}>{r.label}</option>
+              ))}
+            </select>
+          </label>
+        </div>
 
-                {/* Limit */}
-                <div className="history-filter-group">
-                  <label>Show</label>
-                  <select
-                    value={limit}
-                    onChange={e => setLimit(parseInt(e.target.value))}
-                    className="history-filter-select"
-                  >
-                    <option value={25}>25 records</option>
-                    <option value={50}>50 records</option>
-                    <option value={100}>100 records</option>
-                    <option value={200}>200 records</option>
-                  </select>
-                </div>
+        <ChipGroup options={EVENT_TYPES} value={type} onChange={setType}
+                   label="Show" scroll />
 
-                {/* Clear Filters */}
-                {hasActiveFilters && (
-                  <div className="tw">
-                    <Button variant="secondary" size="sm" onClick={handleClearFilters} title="Clear all filters">
-                      <XIcon size={14} /> Clear
-                    </Button>
-                  </div>
-                )}
-              </div>
-            </div>
+        <p className="eh-summary">
+          {summary.count} event{summary.count === 1 ? '' : 's'}
+          {summary.from && ` · ${spanLabel(summary.from, summary.to)}`}
+        </p>
 
-            {/* Results Count */}
-            <div className="admin-v2-results-count">
-              Showing {history.length} record{history.length !== 1 ? 's' : ''}
-            </div>
-
-            {/* History Content */}
-            {loading ? (
-              <div className="admin-v2-loading">Loading history...</div>
-            ) : error ? (
-              <div className="tw"><Alert variant="destructive">{error}</Alert></div>
-            ) : history.length === 0 ? (
-              <div className="admin-v2-empty-state">
-                <ClockIcon size={48} />
-                <h3>No History Found</h3>
-                <p className="admin-v2-text-muted">
-                  {hasActiveFilters
-                    ? 'No records match the selected filters'
-                    : 'No equipment changes have been recorded yet'}
-                </p>
-                {hasActiveFilters && (
-                  <div className="tw">
-                    <Button onClick={handleClearFilters}>Clear Filters</Button>
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div className="admin-v2-history-list">
-                {sortedDays.map(dayKey => (
-                  <div key={dayKey} className="admin-v2-history-day">
-                    <div className="admin-v2-history-day-header">
-                      <h3>{dayKey}</h3>
-                      <span className="admin-v2-history-day-count">
-                        {groupedHistory[dayKey].length} change{groupedHistory[dayKey].length !== 1 ? 's' : ''}
-                      </span>
-                    </div>
-                    
-                    <div className="admin-v2-history-items">
-                      {groupedHistory[dayKey].map((item, idx) => (
-                        <div key={item.id || idx} className="admin-v2-history-item">
-                          <div className="admin-v2-history-item-icon">
-                            <EquipmentIcon size={20} />
-                          </div>
-                          <div className="admin-v2-history-item-content">
-                            <div className="admin-v2-history-item-main">
-                              <span className="admin-v2-history-item-name">
-                                {item.equipment_name}
-                              </span>
-                              <span className="admin-v2-history-item-action">
-                                Changed
-                              </span>
-                            </div>
-                            <div className="admin-v2-history-item-meta">
-                              <span className="admin-v2-history-item-time">
-                                {new Date(item.changed_at).toLocaleTimeString(undefined, {
-                                  hour: 'numeric',
-                                  minute: '2-digit',
-                                  hour12: true
-                                })}
-                              </span>
-                              {item.notes && (
-                                <span className="admin-v2-history-item-notes">
-                                  {item.notes}
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </>
+        {loading && timeline.length === 0 ? (
+          <div className="admin-v2-loading">Loading history…</div>
+        ) : days.length === 0 ? (
+          <div className="sh-empty">
+            <EquipmentIcon size={26} />
+            <p>
+              {search || type !== 'all'
+                ? 'Nothing matches that.'
+                : 'Nothing recorded in this period.'}
+            </p>
+          </div>
         ) : (
-          <div className="admin-v2-loading">Select a patient from the sidebar</div>
+          <ol className="eh-timeline">
+            {days.map((day) => (
+              <li key={day.key} className="eh-day">
+                <div className="eh-day-rail">
+                  <span className={`eh-day-label ${
+                    day.date.toDateString() === today.toDateString() ? 'is-today' : ''}`}>
+                    {dayHeading(day.date, today)}
+                  </span>
+                </div>
+                <div className="eh-day-events">
+                  {day.events.map((event) => (
+                    <div key={event.id} className={`eh-event kind-${event.kind}`}>
+                      <span className="eh-node" aria-hidden="true">
+                        {event.kind === 'delivery' && <PackageIcon size={16} />}
+                        {event.kind === 'stock' && <PackageIcon size={16} />}
+                        {event.kind === 'change' && <WrenchIcon size={16} />}
+                      </span>
+                      {renderEvent(event)}
+                    </div>
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ol>
         )}
       </div>
     </AdminV2Layout>

--- a/frontend/src/pages/admin-v2/AdminV2EquipmentHistory.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2EquipmentHistory.test.jsx
@@ -1,0 +1,185 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The history timeline: that all three records appear, that the change set is
+// worded as a grouping rather than a claim, and that the filters narrow it.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('./AdminV2Layout', () => ({ default: ({ children }) => <div>{children}</div> }));
+
+const patient = { id: 1, first_name: 'Pat', last_name: 'Ient' };
+vi.mock('../../contexts/AdminPatientContext', () => ({
+  useAdminPatient: () => ({
+    patients: [patient], selectedPatient: patient,
+    selectPatient: vi.fn(), loadingPatients: false,
+  }),
+}));
+
+const changeHistory = vi.fn();
+const recentCounts = vi.fn();
+vi.mock('../../services/equipment', () => ({
+  equipmentService: {
+    changeHistory: (...a) => changeHistory(...a),
+    recentCounts: (...a) => recentCounts(...a),
+  },
+}));
+
+const listShipments = vi.fn();
+vi.mock('../../services/shipments', () => ({
+  shipmentService: { listShipments: (...a) => listShipments(...a) },
+}));
+
+import AdminV2EquipmentHistory from './AdminV2EquipmentHistory';
+
+const NOW = new Date('2026-08-19T12:00:00');
+
+const CHANGES = [
+  { id: 1, equipment_id: 10, equipment_name: 'Vent tube', changed_at: '2026-08-18T00:21:00', changed_by_name: 'John' },
+  { id: 2, equipment_id: 11, equipment_name: 'Trach tube', changed_at: '2026-08-18T00:22:00', changed_by_name: 'John' },
+  { id: 3, equipment_id: 12, equipment_name: 'Humidification chamber', changed_at: '2026-08-18T00:23:00', changed_by_name: 'John' },
+];
+
+const COUNTS = [{
+  id: 5, equipment_id: 20, equipment_name: 'Connector STRT Two Base',
+  quantity_before: 4, quantity_after: 0, note: 'Used / corrected count',
+  counted_by_name: 'Mary', counted_at: '2026-08-19T10:42:00',
+}];
+
+const SHIPMENTS = [{
+  id: 30, supplier_name: 'Pediatric Home Service', order_number: '78599210',
+  status: 'complete', item_count: 18, actual_delivery: '2026-08-04T14:15:00',
+}];
+
+const renderPage = () => render(
+  <MemoryRouter><AdminV2EquipmentHistory /></MemoryRouter>,
+);
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(NOW);
+  vi.clearAllMocks();
+  changeHistory.mockResolvedValue({ history: CHANGES });
+  recentCounts.mockResolvedValue({ counts: COUNTS });
+  listShipments.mockResolvedValue({ shipments: SHIPMENTS });
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe('AdminV2EquipmentHistory', () => {
+  it('shows all three records, not just the change log', async () => {
+    // The old page showed changes alone, so a stocktake or an arriving box
+    // never appeared in the thing called History.
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Stock adjustment')).toBeInTheDocument());
+    expect(screen.getByText('Shipment received')).toBeInTheDocument();
+    expect(screen.getByText('Scheduled changes')).toBeInTheDocument();
+  });
+
+  it('states what a stocktake did, in both directions', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Stock adjustment')).toBeInTheDocument());
+    const card = document.querySelector('.kind-stock .eh-line');
+    expect(card.textContent).toContain('changed 4 → 0 on hand');
+    expect(screen.getByText(/by Mary/)).toBeInTheDocument();
+  });
+
+  it('words a change set as a grouping, not as one action', async () => {
+    // Nothing records that the three were done together; the page must not
+    // say they were.
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Scheduled changes')).toBeInTheDocument());
+    expect(screen.getByText('3 equipment items changed')).toBeInTheDocument();
+    expect(screen.getByText('logged by John')).toBeInTheDocument();
+    expect(screen.queryByText(/changed together/)).not.toBeInTheDocument();
+  });
+
+  it('lists the items inside a set, and can hide them', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Trach tube')).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText('Hide the items'));
+    expect(screen.queryByText('Trach tube')).not.toBeInTheDocument();
+  });
+
+  it('states a single change as one change, not a set of one', async () => {
+    changeHistory.mockResolvedValue({ history: [CHANGES[0]] });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Scheduled change')).toBeInTheDocument());
+    expect(screen.queryByText(/1 equipment items/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Hide the items')).not.toBeInTheDocument();
+  });
+
+  it('says how many events and over what span', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/3 events ·/)).toBeInTheDocument());
+  });
+
+  it('narrows to one kind with the chips', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Stock adjustment')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'Deliveries' }));
+    await waitFor(() => expect(screen.queryByText('Stock adjustment')).not.toBeInTheDocument());
+    expect(screen.getByText('Shipment received')).toBeInTheDocument();
+  });
+
+  it('searches inside a change set, not only its heading', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Stock adjustment')).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText('Search history'), { target: { value: 'trach' } });
+    await waitFor(() => expect(screen.queryByText('Stock adjustment')).not.toBeInTheDocument());
+    expect(screen.getByText('Scheduled changes')).toBeInTheDocument();
+  });
+
+  it('drops events outside the chosen range', async () => {
+    listShipments.mockResolvedValue({
+      shipments: [{ ...SHIPMENTS[0], actual_delivery: '2026-01-04T14:15:00' }],
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Stock adjustment')).toBeInTheDocument());
+    expect(screen.queryByText('Shipment received')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Date range'), { target: { value: '0' } });
+    await waitFor(() => expect(screen.getByText('Shipment received')).toBeInTheDocument());
+  });
+
+  it('heads the current day as Today', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Today')).toBeInTheDocument());
+  });
+
+  it('says so when a filter matches nothing', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Stock adjustment')).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText('Search history'), { target: { value: 'zzzz' } });
+    await waitFor(() => expect(screen.getByText('Nothing matches that.')).toBeInTheDocument());
+  });
+
+  it('surfaces a failed load instead of an empty timeline', async () => {
+    recentCounts.mockRejectedValue(new Error('Boom'));
+    renderPage();
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Boom'));
+  });
+
+  it('disables Export when there is nothing on screen', async () => {
+    changeHistory.mockResolvedValue({ history: [] });
+    recentCounts.mockResolvedValue({ counts: [] });
+    listShipments.mockResolvedValue({ shipments: [] });
+    renderPage();
+    await waitFor(() => expect(screen.getByRole('button', { name: /Export/ })).toBeDisabled());
+  });
+});

--- a/frontend/src/pages/admin-v2/components/equipment-history.css
+++ b/frontend/src/pages/admin-v2/components/equipment-history.css
@@ -1,0 +1,269 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Equipment history timeline. Builds on the shipments/overview vocabulary
+ * (sh-btn, sh-search, sh-empty) rather than restating it. Dark-only. */
+
+:root:not(.light) .eh-controls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+:root:not(.light) .eh-controls .sh-search { flex: 1; min-width: 220px; }
+
+:root:not(.light) .eh-range {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+:root:not(.light) .eh-range-label {
+  font-size: 0.6rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .eh-range select { min-width: 160px; }
+
+:root:not(.light) .eh-summary {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* --- timeline --- */
+
+:root:not(.light) .eh-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+:root:not(.light) .eh-day {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  gap: 12px;
+}
+@media (max-width: 640px) {
+  :root:not(.light) .eh-day { grid-template-columns: 1fr; gap: 6px; }
+}
+
+:root:not(.light) .eh-day-rail { padding-top: 14px; }
+
+:root:not(.light) .eh-day-label {
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+:root:not(.light) .eh-day-label.is-today { color: var(--vc-state-due); }
+
+:root:not(.light) .eh-day-events {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 12px;
+}
+
+/* --- one event: node in a gutter, card beside it --- */
+
+:root:not(.light) .eh-event {
+  position: relative;
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  align-items: start;
+  gap: 10px;
+}
+
+/* The rule joining consecutive events. Drawn from the node downward so it
+ * never runs past the last card. */
+:root:not(.light) .eh-event::before {
+  content: '';
+  position: absolute;
+  left: 21px;
+  top: 42px;
+  bottom: -12px;
+  width: 2px;
+  background: var(--vc-line-hairline);
+}
+:root:not(.light) .eh-day-events > .eh-event:last-child::before { display: none; }
+
+:root:not(.light) .eh-node {
+  display: grid;
+  place-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+  border: 1px solid currentColor;
+  background: var(--vc-bg-surface);
+  z-index: 1;
+}
+
+/* Type carries the colour, so the kind is legible before the label is read.
+ * Each also has a distinct icon and a written kind, so colour is never the
+ * only thing saying what an event is. */
+:root:not(.light) .eh-event.kind-stock .eh-node { color: var(--vc-state-due); }
+:root:not(.light) .eh-event.kind-delivery .eh-node { color: var(--vc-state-complete); }
+:root:not(.light) .eh-event.kind-change .eh-node { color: var(--vc-data-live); }
+
+:root:not(.light) .eh-card {
+  padding: 12px 14px;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+}
+
+:root:not(.light) .eh-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+:root:not(.light) .eh-kind {
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+:root:not(.light) .kind-stock .eh-kind { color: var(--vc-state-due); }
+:root:not(.light) .kind-delivery .eh-kind { color: var(--vc-state-complete); }
+:root:not(.light) .kind-change .eh-kind { color: var(--vc-data-live); }
+
+:root:not(.light) .eh-time {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--vc-font-mono);
+  font-size: 0.75rem;
+  color: var(--vc-text-secondary);
+  white-space: nowrap;
+}
+
+:root:not(.light) .eh-toggle {
+  display: grid;
+  place-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: 5px;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+:root:not(.light) .eh-toggle:hover {
+  background: color-mix(in srgb, var(--vc-text-primary) 8%, transparent);
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .eh-toggle[aria-expanded='false'] svg { transform: rotate(-90deg); }
+
+:root:not(.light) .eh-line {
+  margin: 8px 0 0;
+  font-size: 0.95rem;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .eh-line strong { font-weight: 600; }
+
+:root:not(.light) .eh-num {
+  font-family: var(--vc-font-mono);
+  font-variant-numeric: tabular-nums;
+}
+:root:not(.light) .eh-num.is-down { color: var(--vc-state-due); }
+:root:not(.light) .eh-num.is-up { color: var(--vc-state-complete); }
+
+:root:not(.light) .eh-status { margin-left: 10px; }
+
+:root:not(.light) .eh-meta {
+  margin: 4px 0 0;
+  font-size: 0.8rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .eh-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 10px;
+  padding: 0;
+  background: none;
+  border: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-data-live);
+  cursor: pointer;
+}
+:root:not(.light) .eh-link:hover { text-decoration: underline; }
+
+/* --- the items inside a change set --- */
+
+:root:not(.light) .eh-set {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 4px;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-raised);
+}
+
+:root:not(.light) .eh-set li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 9px;
+  font-size: 0.87rem;
+  color: var(--vc-text-primary);
+}
+:root:not(.light) .eh-set li + li { border-top: 1px solid var(--vc-line-hairline); }
+
+:root:not(.light) .eh-set-num {
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  color: var(--vc-text-tertiary);
+  min-width: 14px;
+}
+
+:root:not(.light) .eh-set-name { flex: 1; }
+
+:root:not(.light) .eh-set-note {
+  font-size: 0.78rem;
+  color: var(--vc-text-secondary);
+}
+
+:root:not(.light) .eh-set-tag {
+  font-family: var(--vc-font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-data-live);
+  white-space: nowrap;
+}

--- a/frontend/src/services/equipment.js
+++ b/frontend/src/services/equipment.js
@@ -49,6 +49,15 @@ export const equipmentService = {
     return asJson(response, 'Failed to fetch equipment history');
   },
 
+  /** Stocktakes across every supply, newest first. */
+  async recentCounts({ patientId = null, limit = 100 } = {}) {
+    const qs = new URLSearchParams();
+    if (patientId) qs.set('patient_id', patientId);
+    if (limit) qs.set('limit', limit);
+    const response = await apiFetch(`${config.apiUrl}/api/equipment/counts?${qs}`);
+    return asJson(response, 'Failed to fetch stock activity');
+  },
+
   /** Record a scheduled change. Refused with a 409 when tracked stock is out. */
   async logChange(equipmentId, changedAt) {
     const response = await apiFetch(`${config.apiUrl}/api/equipment/${equipmentId}/change`, {


### PR DESCRIPTION
History showed the **change log alone**. A supply could go from four on hand to zero, or a box of eighteen items could arrive, and neither appeared in the thing called History. All three records now read as one timeline, translated into a single event shape in `lib/equipmentHistory.js` rather than the page learning three dialects.

## Two things had to exist first

**`GET /api/equipment/counts` is new.** The count log has only ever had a per-supply history (`/{equipment_id}/counts`), so nothing could ask *what stock was adjusted lately* without walking every supply in turn. This is the count log's equivalent of the change log's global feed.

**Nothing recorded who logged a change.** The route never passed `changed_by`, so every row in `equipment_change_log` is unattributed — the mockup's "by John" was unachievable. It now passes the signed-in user. Rows written before this stay null and are shown as *"logged by an unrecorded user"* rather than blamed on somebody.

While there: the change feed re-queried the equipment row **once per change** to get its name, and returned `changed_by` as a bare user id the UI could do nothing with. Both names are now resolved in one query each.

## On grouping — the thing worth reviewing

The mockup shows *"3 equipment items changed together"*. **Nothing in the schema records that association.** Changes are logged one item at a time from a single-item modal; there is no bulk path, so timestamps land seconds apart and "together" would be inferred, not known.

Per your call, this groups a person's changes **on one calendar day** into one entry and words it as what it is — *"3 equipment items changed", "logged by John"* — never "changed together". A test asserts that phrasing does not appear.

Two deliberate details:
- **Keyed on the calendar day and the person**, not a tolerance around a timestamp. A window would be a rule invented here and tuned to the data; a day is a rule you can state. This is the same trap nutrition's `event_group_id` replaced — four places re-merging rows by a 3-minute window with four different rules — so it is not reintroduced.
- **A single change reads as one change**, not a set of one.

If that association is ever worth asserting, it wants a real id on the row plus a bulk "log these together" action — its own change, offered as a follow-up rather than smuggled in here.

## Other judgement calls

- **A delivery enters the timeline when it landed**, not when it was raised — a draft opened in June and received in August belongs in August. One that never arrived is left out rather than dated by something that is not an arrival.
- **Notes is a cross-cutting filter**, not a fourth source: any event carrying a written note. That is why it can overlap the other chips.
- **Export writes what is on screen**, not the whole log, so the file and the page agree about what "this history" means. A change set exports as its members — a row saying "3 changes" is not something a spreadsheet can use.
- Colour marks the event kind, but every event also carries a distinct icon and a written kind, so colour is never the only thing saying what something is.

## Verification

Backend **669 pass**, 1 skipped (660 baseline + 9 new) · frontend **965 pass** (924 + 41 new) · `npm run lint` clean at `--max-warnings 0` · production build succeeds.

One test initially failed for a reason worth recording: `admin_client` and `limited_client` are the **same** TestClient with its auth header overwritten, so a gating test that requests both silently asserts nothing. That test now takes only the limited client, with a comment saying why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
