### PR TITLE
Rebuild the medication add and edit sheet

### DIFF
--- a/backend/routes/medications.py
+++ b/backend/routes/medications.py
@@ -300,10 +300,17 @@ async def apply_low_stock_days_bulk(data: BulkLowStockDaysRequest, db: Session =
 
 @router.put("/medications/{med_id}")
 async def update_medication_endpoint(med_id: int, data: MedicationUpdate, db: Session = Depends(get_db)):
-    """Update an existing medication."""
-    # Filter out None values
-    update_data = {k: v for k, v in data.model_dump().items() if v is not None}
-    
+    """Update an existing medication.
+
+    Uses exclude_unset rather than dropping None, so a field the caller
+    deliberately cleared is distinguishable from one they did not mention.
+    Dropping None meant the low-stock alert could be set but never turned off,
+    and a prescriber or pharmacy could be attached but never detached -- the
+    request succeeded, the value stayed, and the reloaded form showed the old
+    one back. Same rule the care-task and shipment routes already follow.
+    """
+    update_data = data.model_dump(exclude_unset=True)
+
     success = update_medication(db, med_id, **update_data)
     if not success:
         return JSONResponse(status_code=404, content={"detail": "Medication not found"})

--- a/backend/tests/test_medications_update_clear.py
+++ b/backend/tests/test_medications_update_clear.py
@@ -1,0 +1,98 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""A medication's optional fields can be cleared, not only set.
+
+PUT /api/medications/{id} dropped every None before applying the update, so a
+field the caller deliberately blanked was indistinguishable from one they had
+not mentioned. The low-stock alert could be switched on but never off, and a
+prescriber or pharmacy could be attached but never detached: the request
+answered success, the value stayed, and reloading the form showed it back.
+"""
+
+
+def _make(admin_client, patient, **over):
+    payload = {
+        "name": "Baclofen", "concentration": "10 mg", "quantity": 42,
+        "quantity_unit": "tablets", "instructions": "Give 1 tablet",
+        "start_date": "2026-04-01", "low_stock_threshold": 14,
+        "is_patient_specific": True, "admin_patient_id": patient.id,
+    }
+    payload.update(over)
+    resp = admin_client.post("/api/add/medication", json=payload)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _fetch(db_session, med_id):
+    from schemas.medication import Medication
+    db_session.expire_all()
+    return db_session.query(Medication).filter(Medication.id == med_id).first()
+
+
+def _id_of(created, admin_client, patient):
+    if isinstance(created, dict) and created.get("id"):
+        return created["id"]
+    meds = admin_client.get(f"/api/admin/medications/active?patient_id={patient.id}").json()
+    rows = meds if isinstance(meds, list) else meds.get("medications", [])
+    return rows[-1]["id"]
+
+
+def test_low_stock_alert_can_be_turned_off(admin_client, patient, db_session):
+    med_id = _id_of(_make(admin_client, patient), admin_client, patient)
+    assert _fetch(db_session, med_id).low_stock_threshold == 14
+
+    resp = admin_client.put(f"/api/medications/{med_id}", json={"low_stock_threshold": None})
+    assert resp.status_code == 200
+    assert _fetch(db_session, med_id).low_stock_threshold is None
+
+
+def test_a_field_left_out_is_not_disturbed(admin_client, patient, db_session):
+    """exclude_unset, not "ignore null" — an absent key still means no change."""
+    med_id = _id_of(_make(admin_client, patient), admin_client, patient)
+
+    admin_client.put(f"/api/medications/{med_id}", json={"name": "Baclofen ER"})
+
+    row = _fetch(db_session, med_id)
+    assert row.name == "Baclofen ER"
+    assert row.low_stock_threshold == 14      # untouched
+    assert row.concentration == "10 mg"       # untouched
+
+
+def test_notes_can_be_cleared(admin_client, patient, db_session):
+    med_id = _id_of(_make(admin_client, patient, notes="Watch for drowsiness"),
+                    admin_client, patient)
+    assert _fetch(db_session, med_id).notes == "Watch for drowsiness"
+
+    admin_client.put(f"/api/medications/{med_id}", json={"notes": None})
+    assert _fetch(db_session, med_id).notes is None
+
+
+def test_deactivating_still_works(admin_client, patient, db_session):
+    """active=False is falsy but not None; it must survive either way."""
+    med_id = _id_of(_make(admin_client, patient), admin_client, patient)
+    admin_client.put(f"/api/medications/{med_id}", json={"active": False})
+    assert _fetch(db_session, med_id).active is False
+
+
+def test_end_date_can_be_set_and_cleared(admin_client, patient, db_session):
+    """The API has always accepted end_date; the form never offered it."""
+    med_id = _id_of(_make(admin_client, patient), admin_client, patient)
+
+    admin_client.put(f"/api/medications/{med_id}", json={"end_date": "2026-12-31"})
+    assert _fetch(db_session, med_id).end_date is not None
+
+    admin_client.put(f"/api/medications/{med_id}", json={"end_date": None})
+    assert _fetch(db_session, med_id).end_date is None

--- a/frontend/src/components/medication/MedicationSheet.jsx
+++ b/frontend/src/components/medication/MedicationSheet.jsx
@@ -1,0 +1,501 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Add or edit a medication record.
+//
+// Adding walks three steps, because a new record needs the drug, then what is
+// on hand, then who prescribed it — and nothing can be saved until the first
+// step is answered. Editing shows the same three groups at once, opened on the
+// drug itself and marking what has changed, because an edit is usually one
+// field and the rest is context.
+//
+// Schedules are not edited here in either mode. They are their own records
+// with their own times and doses, and folding them in is how "edit the med"
+// becomes "accidentally rewrite the regimen".
+import { useEffect, useMemo, useState } from 'react';
+import EntityModal, { EmField, EmRow, EmSelect } from '../vc/EntityModal';
+import DisclosureRow from '../vc/DisclosureRow';
+import SegmentedControl from '../vc/SegmentedControl';
+import { AlertIcon, CalendarIcon } from '../Icons';
+import './medication-sheet.css';
+
+// What the record actually holds. There is no dosage-form column (tablet /
+// liquid / capsule), so the unit below is the inventory unit — what you count
+// on the shelf — and is not presented as the drug's form.
+const QUANTITY_UNITS = [
+  { value: 'tablets', label: 'Tablets' },
+  { value: 'capsules', label: 'Capsules' },
+  { value: 'ml', label: 'mL' },
+  { value: 'mg', label: 'mg' },
+  { value: 'units', label: 'Units' },
+  { value: 'patches', label: 'Patches' },
+  { value: 'doses', label: 'Doses' },
+];
+
+// as_needed is a boolean, so these are the two states a record can hold. A
+// medication that is both given on a schedule and available as needed is that
+// boolean plus its schedules — which live elsewhere and are shown, not set.
+const USAGE = [
+  { value: 'scheduled', label: 'Scheduled' },
+  { value: 'prn', label: 'As needed' },
+];
+
+const THRESHOLD_TYPES = [
+  { value: 'quantity', label: 'Amount on hand' },
+  { value: 'days', label: 'Days of supply left' },
+];
+
+const EMPTY = {
+  name: '',
+  concentration: '',
+  quantity: '',
+  quantity_unit: 'tablets',
+  low_stock_threshold: '',
+  low_stock_threshold_type: 'quantity',
+  instructions: '',
+  start_date: '',
+  end_date: '',
+  prescriber_id: '',
+  pharmacy_id: '',
+  notes: '',
+  as_needed: false,
+  is_global: false,
+  active: true,
+};
+
+const asDate = (value) => (value ? String(value).slice(0, 10) : '');
+const numberOrNull = (value) => {
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const fromMedication = (med) => (med ? {
+  name: med.name || '',
+  concentration: med.concentration || '',
+  quantity: med.quantity ?? '',
+  quantity_unit: med.quantity_unit || 'tablets',
+  low_stock_threshold: med.low_stock_threshold ?? '',
+  low_stock_threshold_type: med.low_stock_threshold_type || 'quantity',
+  instructions: med.instructions || '',
+  start_date: asDate(med.start_date),
+  end_date: asDate(med.end_date),
+  prescriber_id: med.prescriber_id ? String(med.prescriber_id) : '',
+  pharmacy_id: med.pharmacy_id ? String(med.pharmacy_id) : '',
+  notes: med.notes || '',
+  as_needed: Boolean(med.as_needed),
+  is_global: Boolean(med.is_global),
+  active: med.active !== false,
+} : { ...EMPTY });
+
+const STEPS = [
+  { key: 'medication', label: 'Medication' },
+  { key: 'stock', label: 'Stock' },
+  { key: 'care', label: 'Care details' },
+];
+
+/** A field whose value differs from the record as saved. */
+function ChangedMark() {
+  return <span className="ms-changed">Changed</span>;
+}
+
+export default function MedicationSheet({
+  open, onOpenChange, medication = null,
+  providers = [], pharmacies = [], scheduleCount = 0,
+  onSave, onViewSchedules,
+}) {
+  const editing = Boolean(medication);
+  const [form, setForm] = useState(EMPTY);
+  const [step, setStep] = useState(0);
+  const [error, setError] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  const initial = useMemo(() => fromMedication(medication), [medication]);
+
+  useEffect(() => {
+    if (!open) return;
+    setForm(initial);
+    setStep(0);
+    setError(null);
+  }, [open, initial]);
+
+  const set = (field) => (event) => setForm((f) => ({ ...f, [field]: event.target.value }));
+
+  const changed = useMemo(() => Object.keys(initial).filter(
+    (key) => String(form[key] ?? '') !== String(initial[key] ?? ''),
+  ), [form, initial]);
+  const isChanged = (field) => editing && changed.includes(field);
+
+  // What the record requires: the API rejects a medication without these.
+  const missing = [
+    !form.name.trim() && 'name',
+    !form.concentration.trim() && 'strength',
+    !form.instructions.trim() && 'instructions',
+    numberOrNull(form.quantity) === null && 'amount on hand',
+    !form.quantity_unit && 'unit',
+    !form.start_date && 'start date',
+  ].filter(Boolean);
+
+  const stepMissing = {
+    medication: missing.filter((m) => ['name', 'strength', 'instructions'].includes(m)),
+    stock: missing.filter((m) => ['amount on hand', 'unit'].includes(m)),
+    care: missing.filter((m) => m === 'start date'),
+  };
+
+  const submit = async (event) => {
+    event.preventDefault();
+    if (missing.length > 0) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave({
+        name: form.name.trim(),
+        concentration: form.concentration.trim(),
+        quantity: numberOrNull(form.quantity) ?? 0,
+        quantity_unit: form.quantity_unit,
+        // Blank means "no alert", which the API now stores rather than
+        // dropping — so turning the alert off works.
+        low_stock_threshold: numberOrNull(form.low_stock_threshold),
+        low_stock_threshold_type: form.low_stock_threshold_type || 'quantity',
+        instructions: form.instructions.trim(),
+        start_date: form.start_date,
+        end_date: form.end_date || null,
+        prescriber_id: form.prescriber_id ? parseInt(form.prescriber_id, 10) : null,
+        pharmacy_id: form.pharmacy_id ? parseInt(form.pharmacy_id, 10) : null,
+        notes: form.notes.trim() || null,
+        as_needed: form.as_needed,
+        ...(editing ? { active: form.active } : { is_global: form.is_global }),
+      });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // --- field groups, shared by both modes ---
+
+  const medicationFields = (
+    <>
+      <EmField label="Medication name" required htmlFor="ms-name">
+        <div className="ms-with-mark">
+          <input id="ms-name" className="em-input" value={form.name}
+                 onChange={set('name')} placeholder="As written on the label" />
+          {isChanged('name') && <ChangedMark />}
+        </div>
+      </EmField>
+
+      <EmField label="Strength" required htmlFor="ms-conc">
+        <div className="ms-with-mark">
+          {/* One field, because the record stores strength as a single string
+              rather than a number and a unit. */}
+          <input id="ms-conc" className="em-input" value={form.concentration}
+                 onChange={set('concentration')} placeholder="e.g. 10 mg, 5 mg/mL" />
+          {isChanged('concentration') && <ChangedMark />}
+        </div>
+      </EmField>
+
+      <EmField label="How is it used?" required>
+        <SegmentedControl
+          options={USAGE}
+          value={form.as_needed ? 'prn' : 'scheduled'}
+          onChange={(v) => setForm((f) => ({ ...f, as_needed: v === 'prn' }))}
+        />
+      </EmField>
+
+      {/* A medication can be both. That is this setting plus its schedules,
+          and schedules are their own records — so it is reported, not set. */}
+      {editing && (
+        <p className="ms-note">
+          {scheduleCount > 0
+            ? `Given on ${scheduleCount} schedule${scheduleCount === 1 ? '' : 's'}.`
+            : 'No schedules yet.'}
+          {onViewSchedules && (
+            <button type="button" className="ms-link" onClick={onViewSchedules}>
+              <CalendarIcon size={14} />
+              {scheduleCount > 0 ? 'View schedules' : 'Add a schedule'}
+            </button>
+          )}
+        </p>
+      )}
+
+      <EmField label="Instructions" required htmlFor="ms-instr">
+        <div className="ms-with-mark">
+          <textarea id="ms-instr" className="em-input" rows={3} value={form.instructions}
+                    onChange={set('instructions')}
+                    placeholder="e.g. Give through G-tube with water flush." />
+          {isChanged('instructions') && <ChangedMark />}
+        </div>
+      </EmField>
+
+      {!editing && (
+        <label className="ms-check">
+          <input type="checkbox" checked={form.is_global}
+                 onChange={(e) => setForm((f) => ({ ...f, is_global: e.target.checked }))} />
+          <span>Available to every patient, not just this one</span>
+        </label>
+      )}
+    </>
+  );
+
+  const stockFields = (
+    <>
+      <EmRow>
+        <EmField label="Amount on hand" required htmlFor="ms-qty">
+          <div className="ms-with-mark">
+            <input id="ms-qty" className="em-input" type="number" min="0" step="0.25"
+                   value={form.quantity} onChange={set('quantity')} />
+            {isChanged('quantity') && <ChangedMark />}
+          </div>
+        </EmField>
+        <EmField label="Counted in" required htmlFor="ms-unit">
+          <EmSelect id="ms-unit" value={form.quantity_unit} onChange={set('quantity_unit')}>
+            {QUANTITY_UNITS.map((u) => (
+              <option key={u.value} value={u.value}>{u.label}</option>
+            ))}
+          </EmSelect>
+        </EmField>
+      </EmRow>
+
+      <EmRow>
+        <EmField label="Warn me below" optional htmlFor="ms-thresh">
+          <input id="ms-thresh" className="em-input" type="number" min="0" step="0.25"
+                 value={form.low_stock_threshold} onChange={set('low_stock_threshold')}
+                 placeholder="Leave blank for no warning" />
+        </EmField>
+        <EmField label="Measured in" optional htmlFor="ms-thresh-type">
+          <EmSelect id="ms-thresh-type" value={form.low_stock_threshold_type}
+                    onChange={set('low_stock_threshold_type')}>
+            {THRESHOLD_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </EmSelect>
+        </EmField>
+      </EmRow>
+    </>
+  );
+
+  const careFields = (
+    <>
+      <EmRow>
+        <EmField label="Started" required htmlFor="ms-start">
+          <input id="ms-start" className="em-input" type="date"
+                 value={form.start_date} onChange={set('start_date')} />
+        </EmField>
+        {/* The API has always accepted an end date, and treats a past one as
+            expired; the form simply never offered it. */}
+        <EmField label="Ends" optional htmlFor="ms-end">
+          <input id="ms-end" className="em-input" type="date"
+                 value={form.end_date} onChange={set('end_date')} />
+        </EmField>
+      </EmRow>
+
+      <EmRow>
+        <EmField label="Prescriber" optional htmlFor="ms-presc">
+          <EmSelect id="ms-presc" value={form.prescriber_id} onChange={set('prescriber_id')}>
+            <option value="">No prescriber</option>
+            {providers.map((p) => (
+              <option key={p.id} value={String(p.id)}>
+                {[p.title, p.first_name, p.last_name].filter(Boolean).join(' ')}
+              </option>
+            ))}
+          </EmSelect>
+        </EmField>
+        <EmField label="Pharmacy" optional htmlFor="ms-pharm">
+          <EmSelect id="ms-pharm" value={form.pharmacy_id} onChange={set('pharmacy_id')}>
+            <option value="">No pharmacy</option>
+            {pharmacies.map((p) => (
+              <option key={p.id} value={String(p.id)}>{p.name}</option>
+            ))}
+          </EmSelect>
+        </EmField>
+      </EmRow>
+
+      <EmField label="Notes" optional htmlFor="ms-notes">
+        <textarea id="ms-notes" className="em-input" rows={2}
+                  value={form.notes} onChange={set('notes')} />
+      </EmField>
+    </>
+  );
+
+  // --- add: three steps ---
+
+  if (!editing) {
+    const current = STEPS[step];
+    const blocked = stepMissing[current.key].length > 0;
+    return (
+      <EntityModal open={open} onOpenChange={onOpenChange} title="Add medication" wide>
+        <form className="em-form" onSubmit={submit}>
+          <p className="ms-sub">
+            Create the medication record first. Schedules are added afterwards.
+          </p>
+
+          <nav className="ms-steps" aria-label="Progress">
+            {STEPS.map((s, i) => (
+              <button key={s.key} type="button"
+                      className={`ms-step ${i === step ? 'is-active' : ''} ${i < step ? 'is-done' : ''}`}
+                      aria-current={i === step ? 'step' : undefined}
+                      onClick={() => setStep(i)}>
+                <span className="ms-step-num">{i + 1}</span>
+                <span className="ms-step-name">{s.label}</span>
+              </button>
+            ))}
+          </nav>
+
+          {error && <div className="em-error">{error}</div>}
+
+          {current.key === 'medication' && medicationFields}
+          {current.key === 'stock' && stockFields}
+          {current.key === 'care' && careFields}
+
+          <div className="ms-foot">
+            <span className={`ms-required ${missing.length ? 'is-missing' : ''}`}>
+              {missing.length > 0
+                ? `Still needed: ${missing.join(', ')}`
+                : 'Everything required is filled in'}
+            </span>
+          </div>
+
+          <div className="em-footer">
+            <button type="button" className="em-cancel"
+                    onClick={() => (step === 0 ? onOpenChange(false) : setStep(step - 1))}>
+              {step === 0 ? 'Cancel' : 'Back'}
+            </button>
+            {step < STEPS.length - 1 ? (
+              <button type="button" className="em-submit" disabled={blocked}
+                      onClick={() => setStep(step + 1)}>
+                Continue to {STEPS[step + 1].label.toLowerCase()}
+              </button>
+            ) : (
+              <button type="submit" className="em-submit"
+                      disabled={missing.length > 0 || saving}>
+                {saving ? 'Saving…' : 'Add medication'}
+              </button>
+            )}
+          </div>
+        </form>
+      </EntityModal>
+    );
+  }
+
+  // --- edit: the three groups at once ---
+
+  const stockSummary = `${form.quantity || 0} ${form.quantity_unit}`
+    + (numberOrNull(form.low_stock_threshold) !== null
+      ? ` · warn below ${form.low_stock_threshold} ${
+        form.low_stock_threshold_type === 'days' ? 'days of supply' : form.quantity_unit}`
+      : ' · no warning set');
+
+  const careSummary = [
+    form.start_date ? `Started ${form.start_date}` : null,
+    providers.find((p) => String(p.id) === form.prescriber_id)
+      ? [providers.find((p) => String(p.id) === form.prescriber_id).title,
+        providers.find((p) => String(p.id) === form.prescriber_id).last_name]
+        .filter(Boolean).join(' ')
+      : null,
+    pharmacies.find((p) => String(p.id) === form.pharmacy_id)?.name || null,
+  ].filter(Boolean).join(' · ') || 'Nothing recorded';
+
+  return (
+    <EntityModal open={open} onOpenChange={onOpenChange} title="Edit medication" wide>
+      <form className="em-form" onSubmit={submit}>
+        <p className="ms-sub">
+          Update the medication record. Schedules are managed separately.
+        </p>
+
+        <div className="ms-summary">
+          <div className="ms-summary-text">
+            <span className="ms-summary-name">{medication.name}</span>
+            <span className="ms-summary-conc">{medication.concentration}</span>
+          </div>
+          <div className="ms-summary-tags">
+            <span className={`ms-tag ${form.active ? 'is-active' : 'is-off'}`}>
+              {form.active ? 'Active' : 'Inactive'}
+            </span>
+            {scheduleCount > 0 && <span className="ms-tag">{scheduleCount} sch</span>}
+            {medication.as_needed && <span className="ms-tag">PRN</span>}
+          </div>
+        </div>
+
+        {error && <div className="em-error">{error}</div>}
+
+        <section className="ms-section">
+          <h3 className="ms-section-title">Medication</h3>
+          {medicationFields}
+        </section>
+
+        <DisclosureRow label="Stock and alerts" summary={stockSummary}>
+          {stockFields}
+        </DisclosureRow>
+
+        <DisclosureRow label="Care details" summary={careSummary}>
+          {careFields}
+        </DisclosureRow>
+
+        <DisclosureRow label="Advanced" summary={form.active ? undefined : 'Inactive'}>
+          <label className="ms-check">
+            <input type="checkbox" checked={!form.active}
+                   onChange={(e) => setForm((f) => ({ ...f, active: !e.target.checked }))} />
+            <span>Deactivate this medication</span>
+          </label>
+          <p className="ms-note">
+            Deactivating keeps the record and its history; it stops appearing in the
+            active list and on the schedule.
+          </p>
+        </DisclosureRow>
+
+        {/* Renaming rewrites how past doses read. The log stores the amount
+            given and refers back to this record for the name and strength, so
+            it does not preserve what they were at the time. */}
+        {(isChanged('name') || isChanged('concentration')) && (
+          <div className="ms-warn" role="status">
+            <AlertIcon size={16} />
+            <span>
+              Past doses show this medication&rsquo;s current name and strength, so
+              changing them changes how earlier logs read.
+            </span>
+          </div>
+        )}
+
+        <div className="ms-foot">
+          <span className={`ms-required ${changed.length ? 'is-dirty' : ''}`}>
+            {changed.length === 0
+              ? 'No changes yet'
+              : `${changed.length} unsaved change${changed.length === 1 ? '' : 's'}`}
+          </span>
+          {medication.updated_at && (
+            <span className="ms-updated">
+              Last updated {new Date(medication.updated_at).toLocaleDateString()}
+            </span>
+          )}
+        </div>
+
+        <div className="em-footer">
+          <button type="button" className="em-cancel" onClick={() => setForm(initial)}
+                  disabled={changed.length === 0}>
+            Discard changes
+          </button>
+          <button type="submit" className="em-submit"
+                  disabled={missing.length > 0 || changed.length === 0 || saving}>
+            {saving ? 'Saving…' : 'Save changes'}
+          </button>
+        </div>
+      </form>
+    </EntityModal>
+  );
+}

--- a/frontend/src/components/medication/MedicationSheet.test.jsx
+++ b/frontend/src/components/medication/MedicationSheet.test.jsx
@@ -1,0 +1,216 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The medication sheet. Medications had no component tests at all, so these
+// also stand in for the add/edit behaviour that moved off the manage page.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import MedicationSheet from './MedicationSheet';
+
+const PROVIDERS = [{ id: 7, title: 'Dr.', first_name: 'Ada', last_name: 'Turek' }];
+const PHARMACIES = [{ id: 3, name: 'CVS Pharmacy' }];
+
+const MED = {
+  id: 42, name: 'Baclofen', concentration: '10 mg', quantity: 42,
+  quantity_unit: 'tablets', low_stock_threshold: 14,
+  low_stock_threshold_type: 'quantity',
+  instructions: 'Give 1 tablet through G-tube with 30 mL water flush.',
+  start_date: '2026-04-01T00:00:00Z', end_date: null,
+  prescriber_id: 7, pharmacy_id: 3, notes: '', as_needed: false,
+  active: true, updated_at: '2026-08-17T10:00:00Z',
+};
+
+const onSave = vi.fn();
+
+const renderSheet = (props = {}) => render(
+  <MedicationSheet
+    open
+    onOpenChange={vi.fn()}
+    providers={PROVIDERS}
+    pharmacies={PHARMACIES}
+    onSave={onSave}
+    {...props}
+  />,
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  onSave.mockResolvedValue(undefined);
+});
+
+describe('adding a medication', () => {
+  it('walks three steps and will not advance without the first', async () => {
+    renderSheet();
+    const advance = screen.getByRole('button', { name: /Continue to stock/i });
+    expect(advance).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Medication name/), { target: { value: 'Baclofen' } });
+    fireEvent.change(screen.getByLabelText(/^Strength/), { target: { value: '10 mg' } });
+    fireEvent.change(screen.getByLabelText(/Instructions/), { target: { value: 'Give 1' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: /Continue to stock/i })).toBeEnabled());
+  });
+
+  it('names what is still missing rather than only disabling the button', () => {
+    renderSheet();
+    expect(screen.getByText(/Still needed:/)).toHaveTextContent('name');
+    expect(screen.getByText(/Still needed:/)).toHaveTextContent('strength');
+  });
+
+  it('sends one payload with the fields the record has', async () => {
+    renderSheet();
+    fireEvent.change(screen.getByLabelText(/Medication name/), { target: { value: 'Baclofen' } });
+    fireEvent.change(screen.getByLabelText(/^Strength/), { target: { value: '10 mg' } });
+    fireEvent.change(screen.getByLabelText(/Instructions/), { target: { value: 'Give 1 tablet' } });
+    fireEvent.click(screen.getByRole('button', { name: /Continue to stock/i }));
+    fireEvent.change(screen.getByLabelText(/Amount on hand/), { target: { value: '42' } });
+    fireEvent.click(screen.getByRole('button', { name: /Continue to care details/i }));
+    fireEvent.change(screen.getByLabelText(/^Started/), { target: { value: '2026-04-01' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add medication' }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const payload = onSave.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      name: 'Baclofen', concentration: '10 mg', quantity: 42,
+      quantity_unit: 'tablets', start_date: '2026-04-01', as_needed: false,
+    });
+    // No dosage-form column exists, so nothing may claim to set one.
+    expect(payload).not.toHaveProperty('form');
+    // active is not accepted on create; is_global drives the scope keys.
+    expect(payload).not.toHaveProperty('active');
+    expect(payload).toHaveProperty('is_global');
+  });
+
+  it('offers scope only when creating, since editing cannot change it', () => {
+    renderSheet();
+    expect(screen.getByText(/Available to every patient/)).toBeInTheDocument();
+  });
+});
+
+describe('editing a medication', () => {
+  it('opens on the record and shows what it is about', () => {
+    renderSheet({ medication: MED, scheduleCount: 3 });
+    expect(screen.getByText('Baclofen')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('3 sch')).toBeInTheDocument();
+  });
+
+  it('starts with nothing to save', () => {
+    renderSheet({ medication: MED });
+    expect(screen.getByText('No changes yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+  });
+
+  it('marks the fields that differ and counts them', () => {
+    renderSheet({ medication: MED });
+    fireEvent.change(screen.getByLabelText(/Medication name/), { target: { value: 'Baclofen ER' } });
+    expect(screen.getByText('1 unsaved change')).toBeInTheDocument();
+    expect(screen.getAllByText('Changed')).toHaveLength(1);
+
+    fireEvent.change(screen.getByLabelText(/^Strength/), { target: { value: '20 mg' } });
+    expect(screen.getByText('2 unsaved changes')).toBeInTheDocument();
+  });
+
+  it('discards back to the saved record', () => {
+    renderSheet({ medication: MED });
+    fireEvent.change(screen.getByLabelText(/Medication name/), { target: { value: 'Something else' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+    expect(screen.getByLabelText(/Medication name/)).toHaveValue('Baclofen');
+    expect(screen.getByText('No changes yet')).toBeInTheDocument();
+  });
+
+  it('warns that renaming changes how past doses read', () => {
+    // The log stores the dose amount and refers back to this record for the
+    // name and strength, so it does NOT keep what they were at the time.
+    renderSheet({ medication: MED });
+    expect(screen.queryByText(/changes how earlier logs read/)).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/Medication name/), { target: { value: 'Baclofen ER' } });
+    expect(screen.getByText(/changes how earlier logs read/)).toBeInTheDocument();
+  });
+
+  it('reports the schedules without offering to edit them here', () => {
+    const onViewSchedules = vi.fn();
+    renderSheet({ medication: MED, scheduleCount: 3, onViewSchedules });
+    expect(screen.getByText(/Given on 3 schedules/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /View schedules/ }));
+    expect(onViewSchedules).toHaveBeenCalled();
+  });
+
+  it('says so when a medication has no schedules yet', () => {
+    renderSheet({ medication: MED, scheduleCount: 0 });
+    expect(screen.getByText(/No schedules yet/)).toBeInTheDocument();
+  });
+
+  it('sends null when the low-stock alert is cleared', async () => {
+    // The API used to drop nulls, so the alert could be set but never unset.
+    renderSheet({ medication: MED });
+    fireEvent.click(screen.getByText('Stock and alerts'));
+    fireEvent.change(screen.getByLabelText(/Warn me below/), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0].low_stock_threshold).toBeNull();
+  });
+
+  it('sends null when a prescriber is detached', async () => {
+    renderSheet({ medication: MED });
+    fireEvent.click(screen.getByText('Care details'));
+    fireEvent.change(screen.getByLabelText(/Prescriber/), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0].prescriber_id).toBeNull();
+  });
+
+  it('offers the end date the API has always accepted', async () => {
+    renderSheet({ medication: MED });
+    fireEvent.click(screen.getByText('Care details'));
+    fireEvent.change(screen.getByLabelText(/^Ends/), { target: { value: '2026-12-31' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0].end_date).toBe('2026-12-31');
+  });
+
+  it('deactivates without deleting', async () => {
+    renderSheet({ medication: MED });
+    fireEvent.click(screen.getByText('Advanced'));
+    fireEvent.click(screen.getByLabelText('Deactivate this medication'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0].active).toBe(false);
+  });
+
+  it('surfaces a save failure instead of closing quietly', async () => {
+    onSave.mockRejectedValue(new Error('Concentration is required'));
+    renderSheet({ medication: MED });
+    fireEvent.change(screen.getByLabelText(/Medication name/), { target: { value: 'Baclofen ER' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    await waitFor(() => expect(screen.getByText('Concentration is required')).toBeInTheDocument());
+  });
+
+  it('does not offer a scope control it cannot apply', () => {
+    // is_global is not on the update model, so editing it would no-op.
+    renderSheet({ medication: MED });
+    expect(screen.queryByText(/Available to every patient/)).not.toBeInTheDocument();
+  });
+
+  it('states usage as the two the record can hold', () => {
+    renderSheet({ medication: MED });
+    // SegmentedControl is a radiogroup, which is the right semantics here.
+    expect(screen.getByRole('radio', { name: 'Scheduled' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'As needed' })).toBeInTheDocument();
+    // "Both" is the boolean plus schedules, which this sheet reports instead.
+    expect(screen.queryByRole('radio', { name: 'Both' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/medication/medication-sheet.css
+++ b/frontend/src/components/medication/medication-sheet.css
@@ -1,0 +1,262 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* The medication add/edit sheet. Uses the EntityModal form vocabulary
+ * (em-input, em-field, em-footer) and adds only what is specific here. */
+
+.ms-sub {
+  margin: -0.25rem 0 0.25rem;
+  font-size: 0.85rem;
+  color: var(--vc-text-secondary);
+}
+
+/* --- add: the step rail --- */
+
+.ms-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 9px;
+  background: var(--vc-bg-raised);
+}
+
+.ms-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 6px;
+  background: none;
+  border: 0;
+  border-radius: 7px;
+  color: var(--vc-text-secondary);
+  cursor: pointer;
+}
+.ms-step:hover { background: color-mix(in srgb, var(--vc-text-primary) 6%, transparent); }
+.ms-step.is-active {
+  background: color-mix(in srgb, var(--vc-data-live) 16%, transparent);
+  color: var(--vc-text-primary);
+}
+.ms-step:focus-visible {
+  outline: 2px solid var(--vc-data-live);
+  outline-offset: -2px;
+}
+
+.ms-step-num {
+  display: grid;
+  place-content: center;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  border: 2px solid var(--vc-state-idle);
+  border-radius: 50%;
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+}
+.ms-step.is-done .ms-step-num,
+.ms-step.is-active .ms-step-num {
+  border-color: var(--vc-data-live);
+  color: var(--vc-data-live);
+}
+.ms-step.is-active .ms-step-num {
+  background: var(--vc-data-live);
+  color: var(--vc-bg-base);
+}
+
+.ms-step-name {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+/* --- edit: the record it is about --- */
+
+.ms-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 12px 14px;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 9px;
+  background: var(--vc-bg-raised);
+}
+
+.ms-summary-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+
+.ms-summary-name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+}
+
+.ms-summary-conc {
+  font-family: var(--vc-font-mono);
+  font-size: 0.8rem;
+  color: var(--vc-text-secondary);
+}
+
+.ms-summary-tags { display: flex; gap: 6px; flex-wrap: wrap; }
+
+.ms-tag {
+  padding: 3px 9px;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 999px;
+  font-family: var(--vc-font-mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  white-space: nowrap;
+}
+.ms-tag.is-active {
+  border-color: var(--vc-state-complete);
+  color: var(--vc-state-complete);
+}
+.ms-tag.is-off {
+  border-color: var(--vc-text-tertiary);
+  color: var(--vc-text-tertiary);
+}
+
+.ms-section { display: flex; flex-direction: column; gap: 0.9rem; }
+
+.ms-section-title {
+  margin: 0;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* --- changed marker --- */
+
+.ms-with-mark { position: relative; }
+
+/* Sits inside the field rather than beside it, so a marked row keeps the
+ * same height as an unmarked one and the form does not jump while typing. */
+.ms-changed {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--vc-state-due) 18%, transparent);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vc-state-due);
+  pointer-events: none;
+}
+
+/* A textarea is taller than one line, so pin the marker to the top of it. */
+.ms-with-mark:has(textarea) .ms-changed {
+  top: 10px;
+  transform: none;
+}
+
+/* Keep text clear of the marker. */
+.ms-with-mark:has(.ms-changed) .em-input { padding-right: 5.5rem; }
+
+/* --- notes, links, checks --- */
+
+.ms-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: -0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--vc-text-secondary);
+}
+
+.ms-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  background: none;
+  border: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--vc-data-live);
+  cursor: pointer;
+}
+.ms-link:hover { text-decoration: underline; }
+
+.ms-check {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.87rem;
+  color: var(--vc-text-primary);
+  cursor: pointer;
+}
+.ms-check input {
+  width: 17px;
+  height: 17px;
+  accent-color: var(--vc-data-live);
+}
+
+/* --- warning --- */
+
+.ms-warn {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 11px 13px;
+  border: 1px solid color-mix(in srgb, var(--vc-state-due) 45%, transparent);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--vc-state-due) 10%, transparent);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--vc-state-due);
+}
+.ms-warn span { color: var(--vc-text-primary); }
+
+/* --- footer status line --- */
+
+.ms-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-top: 4px;
+  border-top: 1px solid var(--vc-line-hairline);
+}
+
+.ms-required {
+  font-size: 0.75rem;
+  color: var(--vc-text-secondary);
+}
+.ms-required.is-missing { color: var(--vc-state-due); }
+.ms-required.is-dirty { color: var(--vc-state-due); font-weight: 600; }
+
+.ms-updated {
+  font-family: var(--vc-font-mono);
+  font-size: 0.7rem;
+  color: var(--vc-text-tertiary);
+}

--- a/frontend/src/pages/admin-v2/AdminV2MedicationsManage.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MedicationsManage.jsx
@@ -18,6 +18,7 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import AdminV2Layout from './AdminV2Layout';
+import MedicationSheet from '../../components/medication/MedicationSheet';
 import { PatientSelectorModal, MedStockBar } from './components';
 import config from '../../config';
 import { useAuth } from '../../contexts/AuthContext';
@@ -40,11 +41,8 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
 import { Alert } from '@/components/ui/alert';
-import { Field, FormRow } from '@/components/ui/field';
+import { Field } from '@/components/ui/field';
 import {
   Select,
   SelectTrigger,
@@ -54,194 +52,6 @@ import {
 } from '@/components/ui/select';
 import './AdminV2.css';
 
-const QUANTITY_UNITS = ['tablets', 'capsules', 'ml', 'mg', 'units', 'puffs', 'drops', 'patches'];
-const UNIT_LABELS = { tablets: 'Tablets', capsules: 'Capsules', ml: 'mL', mg: 'mg', units: 'Units', puffs: 'Puffs', drops: 'Drops', patches: 'Patches' };
-
-// Shared Create/Edit medication form body (edit adds the Status select). Module
-// scope so it isn't recreated each render — a nested component drops input focus.
-function MedicationFormFields({ formData, setFormData, providers, pharmacies, showStatus }) {
-  return (
-    <>
-      <FormRow>
-        <Field label="Medication Name" required htmlFor="med-name">
-          <Input
-            id="med-name"
-            value={formData.name}
-            onChange={e => setFormData({ ...formData, name: e.target.value })}
-            required
-            placeholder="e.g., Lisinopril"
-          />
-        </Field>
-        <Field label="Concentration" required htmlFor="med-concentration">
-          <Input
-            id="med-concentration"
-            value={formData.concentration}
-            onChange={e => setFormData({ ...formData, concentration: e.target.value })}
-            required
-            placeholder="e.g., 10mg"
-          />
-        </Field>
-      </FormRow>
-
-      <FormRow>
-        <Field label="Quantity" required htmlFor="med-quantity">
-          <Input
-            id="med-quantity"
-            type="number"
-            value={formData.quantity}
-            onChange={e => setFormData({ ...formData, quantity: parseFloat(e.target.value) || 0 })}
-            required
-            min="0"
-            step="0.25"
-          />
-        </Field>
-        <Field label="Unit" required>
-          <Select
-            value={formData.quantity_unit}
-            onValueChange={(v) => setFormData({ ...formData, quantity_unit: v })}
-          >
-            <SelectTrigger><SelectValue /></SelectTrigger>
-            <SelectContent>
-              {QUANTITY_UNITS.map(u => (
-                <SelectItem key={u} value={u}>{UNIT_LABELS[u]}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </Field>
-      </FormRow>
-
-      <FormRow>
-        <Field label="Low Stock Alert At" htmlFor="med-low-stock-threshold">
-          <Input
-            id="med-low-stock-threshold"
-            type="number"
-            value={formData.low_stock_threshold ?? ''}
-            onChange={e => setFormData({
-              ...formData,
-              low_stock_threshold: e.target.value === '' ? null : parseFloat(e.target.value),
-            })}
-            min="0"
-            step="0.25"
-            placeholder="Leave blank to disable"
-          />
-        </Field>
-        <Field label="Alert Measured In">
-          <Select
-            value={formData.low_stock_threshold_type || 'quantity'}
-            onValueChange={(v) => setFormData({ ...formData, low_stock_threshold_type: v })}
-          >
-            <SelectTrigger><SelectValue /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="quantity">Quantity on hand</SelectItem>
-              <SelectItem value="days">Days of supply left</SelectItem>
-            </SelectContent>
-          </Select>
-        </Field>
-      </FormRow>
-
-      <FormRow>
-        <Field label="Start Date" required htmlFor="med-start-date">
-          <Input
-            id="med-start-date"
-            type="date"
-            value={formData.start_date}
-            onChange={e => setFormData({ ...formData, start_date: e.target.value })}
-            required
-          />
-        </Field>
-        <Field label="Prescriber">
-          <Select
-            value={formData.prescriber_id ? String(formData.prescriber_id) : '__none__'}
-            onValueChange={(v) => setFormData({ ...formData, prescriber_id: v === '__none__' ? '' : v })}
-          >
-            <SelectTrigger><SelectValue placeholder="-- No Prescriber --" /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__none__">-- No Prescriber --</SelectItem>
-              {providers.map(provider => (
-                <SelectItem key={provider.id} value={String(provider.id)}>
-                  {provider.title ? `${provider.title} ` : ''}{provider.first_name} {provider.last_name}
-                  {provider.specialty ? ` (${provider.specialty})` : ''}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </Field>
-      </FormRow>
-
-      <Field label="Pharmacy">
-        <Select
-          value={formData.pharmacy_id ? String(formData.pharmacy_id) : '__none__'}
-          onValueChange={(v) => setFormData({ ...formData, pharmacy_id: v === '__none__' ? '' : v })}
-        >
-          <SelectTrigger><SelectValue placeholder="-- No Pharmacy --" /></SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__none__">-- No Pharmacy --</SelectItem>
-            {pharmacies.map(pharmacy => (
-              <SelectItem key={pharmacy.id} value={String(pharmacy.id)}>
-                {pharmacy.name}{pharmacy.phone ? ` - ${pharmacy.phone}` : ''}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </Field>
-
-      <Field label="Instructions" required htmlFor="med-instructions">
-        <Textarea
-          id="med-instructions"
-          value={formData.instructions}
-          onChange={e => setFormData({ ...formData, instructions: e.target.value })}
-          placeholder="e.g., Take with food"
-          rows={2}
-          required
-        />
-      </Field>
-
-      <Field label="Notes" htmlFor="med-notes">
-        <Textarea
-          id="med-notes"
-          value={formData.notes}
-          onChange={e => setFormData({ ...formData, notes: e.target.value })}
-          placeholder="Additional notes..."
-          rows={2}
-        />
-      </Field>
-
-      <FormRow>
-        <div className="flex items-center gap-2">
-          <Checkbox
-            id="med-prn"
-            checked={formData.as_needed}
-            onCheckedChange={(c) => setFormData({ ...formData, as_needed: !!c })}
-          />
-          <Label htmlFor="med-prn">PRN (As Needed)</Label>
-        </div>
-        <div className="flex items-center gap-2">
-          <Checkbox
-            id="med-global"
-            checked={formData.is_global}
-            onCheckedChange={(c) => setFormData({ ...formData, is_global: !!c })}
-          />
-          <Label htmlFor="med-global">Global (Available to all patients)</Label>
-        </div>
-      </FormRow>
-
-      {showStatus && (
-        <Field label="Status">
-          <Select
-            value={formData.active ? 'active' : 'inactive'}
-            onValueChange={(v) => setFormData({ ...formData, active: v === 'active' })}
-          >
-            <SelectTrigger><SelectValue /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="active">Active</SelectItem>
-              <SelectItem value="inactive">Inactive</SelectItem>
-            </SelectContent>
-          </Select>
-        </Field>
-      )}
-    </>
-  );
-}
 
 const AdminV2MedicationsManage = () => {
   const { user } = useAuth();
@@ -274,12 +84,11 @@ const AdminV2MedicationsManage = () => {
   const [pharmacies, setPharmacies] = useState([]);
 
   // Modal states
-  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showMedSheet, setShowMedSheet] = useState(false);
   const [showBulkLowStockModal, setShowBulkLowStockModal] = useState(false);
   const [bulkLowStockDays, setBulkLowStockDays] = useState(7);
   const [bulkLowStockSaving, setBulkLowStockSaving] = useState(false);
   const [bulkLowStockResult, setBulkLowStockResult] = useState(null);
-  const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showScheduleModal, setShowScheduleModal] = useState(false);
   const [selectedMedication, setSelectedMedication] = useState(null);
@@ -296,22 +105,6 @@ const AdminV2MedicationsManage = () => {
   const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
   // Form state
-  const [formData, setFormData] = useState({
-    name: '',
-    concentration: '',
-    quantity: 1,
-    quantity_unit: 'tablets',
-    low_stock_threshold: null,
-    low_stock_threshold_type: 'quantity',
-    instructions: '',
-    start_date: new Date().toISOString().split('T')[0],
-    as_needed: false,
-    notes: '',
-    active: true,
-    is_global: false,
-    prescriber_id: '',
-    pharmacy_id: ''
-  });
   const [formError, setFormError] = useState(null);
   const [saving, setSaving] = useState(false);
 
@@ -433,78 +226,46 @@ const AdminV2MedicationsManage = () => {
     setShowPatientModal(false);
   };
 
-  const handleCreateMedication = async (e) => {
-    e.preventDefault();
-    setFormError(null);
-    setSaving(true);
+  // One save path. The two handlers were the same coercion logic twice, and
+  // only the update one failed to map an array-shaped 422 -- rendering the
+  // raw objects as an Alert child, which React refuses.
+  const readError = (data, fallback) => (
+    Array.isArray(data?.detail)
+      ? data.detail.map((d) => d.msg).join(', ')
+      : (data?.detail || fallback)
+  );
 
-    try {
-      const payload = {
-        ...formData,
-        prescriber_id: formData.prescriber_id ? parseInt(formData.prescriber_id) : null,
-        pharmacy_id: formData.pharmacy_id ? parseInt(formData.pharmacy_id) : null,
-        is_patient_specific: !formData.is_global,
-        admin_patient_id: formData.is_global ? null : selectedPatient.id
-      };
-
-      const response = await fetch(`${config.apiUrl}/api/add/medication`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(payload)
-      });
-
-      if (response.ok) {
-        setShowCreateModal(false);
-        resetForm();
-        fetchMedications();
-      } else {
-        const data = await response.json();
-        if (Array.isArray(data.detail)) {
-          setFormError(data.detail.map(err => err.msg).join(', '));
-        } else {
-          setFormError(data.detail || 'Failed to create medication');
-        }
+  const handleSaveMedication = async (payload) => {
+    const creating = !selectedMedication;
+    const url = creating
+      ? `${config.apiUrl}/api/add/medication`
+      : `${config.apiUrl}/api/medications/${selectedMedication.id}`;
+    const body = creating
+      ? {
+        ...payload,
+        is_patient_specific: !payload.is_global,
+        admin_patient_id: payload.is_global ? null : selectedPatient.id,
       }
-    } catch {
-      setFormError('Error connecting to server');
-    } finally {
-      setSaving(false);
+      : payload;
+
+    const response = await fetch(url, {
+      method: creating ? 'POST' : 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      let data = null;
+      try { data = await response.json(); } catch { /* non-JSON body */ }
+      throw new Error(readError(data, creating
+        ? 'Failed to add the medication'
+        : 'Failed to save the medication'));
     }
-  };
 
-  const handleUpdateMedication = async (e) => {
-    e.preventDefault();
-    setFormError(null);
-    setSaving(true);
-
-    try {
-      const payload = {
-        ...formData,
-        prescriber_id: formData.prescriber_id ? parseInt(formData.prescriber_id) : null,
-        pharmacy_id: formData.pharmacy_id ? parseInt(formData.pharmacy_id) : null
-      };
-
-      const response = await fetch(`${config.apiUrl}/api/medications/${selectedMedication.id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(payload)
-      });
-
-      if (response.ok) {
-        setShowEditModal(false);
-        resetForm();
-        fetchMedications();
-      } else {
-        const data = await response.json();
-        setFormError(data.detail || 'Failed to update medication');
-      }
-    } catch {
-      setFormError('Error connecting to server');
-    } finally {
-      setSaving(false);
-    }
+    setShowMedSheet(false);
+    setSelectedMedication(null);
+    fetchMedications();
   };
 
   const handleDeleteMedication = async () => {
@@ -558,24 +319,8 @@ const AdminV2MedicationsManage = () => {
 
   const openEditModal = (medication) => {
     setSelectedMedication(medication);
-    setFormData({
-      name: medication.name,
-      concentration: medication.concentration || '',
-      quantity: medication.quantity,
-      quantity_unit: medication.quantity_unit,
-      low_stock_threshold: medication.low_stock_threshold ?? null,
-      low_stock_threshold_type: medication.low_stock_threshold_type || 'quantity',
-      instructions: medication.instructions || '',
-      start_date: medication.start_date ? medication.start_date.split('T')[0] : new Date().toISOString().split('T')[0],
-      as_needed: medication.as_needed,
-      notes: medication.notes || '',
-      active: medication.active,
-      is_global: medication.is_global || false,
-      prescriber_id: medication.prescriber_id ? String(medication.prescriber_id) : '',
-      pharmacy_id: medication.pharmacy_id ? String(medication.pharmacy_id) : ''
-    });
     setFormError(null);
-    setShowEditModal(true);
+    setShowMedSheet(true);
   };
 
   const openDeleteModal = (medication) => {
@@ -728,29 +473,9 @@ const AdminV2MedicationsManage = () => {
   };
 
   const openCreateModal = () => {
-    resetForm();
-    setShowCreateModal(true);
-  };
-
-  const resetForm = () => {
-    setFormData({
-      name: '',
-      concentration: '',
-      quantity: 1,
-      quantity_unit: 'tablets',
-      low_stock_threshold: null,
-      low_stock_threshold_type: 'quantity',
-      instructions: '',
-      start_date: new Date().toISOString().split('T')[0],
-      as_needed: false,
-      notes: '',
-      active: true,
-      is_global: false,
-      prescriber_id: '',
-      pharmacy_id: ''
-    });
-    setFormError(null);
     setSelectedMedication(null);
+    setFormError(null);
+    setShowMedSheet(true);
   };
 
   // Permission-aware kebab menu for a medication card
@@ -926,27 +651,20 @@ const AdminV2MedicationsManage = () => {
           />
         )}
 
-        {/* Create Medication Modal */}
-        <Dialog open={showCreateModal} onOpenChange={(o) => { if (!o) setShowCreateModal(false); }}>
-          <DialogContent className="sm:max-w-[600px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>Add Medication</DialogTitle>
-            </DialogHeader>
-            <form onSubmit={handleCreateMedication} className="flex flex-col gap-4">
-              {formError && <Alert variant="destructive">{formError}</Alert>}
-              <MedicationFormFields
-                formData={formData}
-                setFormData={setFormData}
-                providers={providers}
-                pharmacies={pharmacies}
-              />
-              <DialogFooter>
-                <Button type="button" variant="secondary" onClick={() => setShowCreateModal(false)}>Cancel</Button>
-                <Button type="submit" disabled={saving}>{saving ? 'Creating...' : 'Add Medication'}</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
+        <MedicationSheet
+          open={showMedSheet}
+          onOpenChange={(o) => { setShowMedSheet(o); if (!o) setSelectedMedication(null); }}
+          medication={selectedMedication}
+          providers={providers}
+          pharmacies={pharmacies}
+          scheduleCount={selectedMedication?.schedule_count
+            ?? (selectedMedication?.schedules || []).length}
+          onSave={handleSaveMedication}
+          onViewSchedules={() => {
+            setShowMedSheet(false);
+            openScheduleModal(selectedMedication);
+          }}
+        />
 
         {/* Bulk Low-Stock Alert Modal */}
         <Dialog open={showBulkLowStockModal} onOpenChange={(o) => { if (!o) setShowBulkLowStockModal(false); }}>
@@ -997,28 +715,6 @@ const AdminV2MedicationsManage = () => {
           </DialogContent>
         </Dialog>
 
-        {/* Edit Medication Modal */}
-        <Dialog open={showEditModal && !!selectedMedication} onOpenChange={(o) => { if (!o) setShowEditModal(false); }}>
-          <DialogContent className="sm:max-w-[600px]" aria-describedby={undefined}>
-            <DialogHeader>
-              <DialogTitle>Edit Medication{selectedMedication ? `: ${selectedMedication.name}` : ''}</DialogTitle>
-            </DialogHeader>
-            <form onSubmit={handleUpdateMedication} className="flex flex-col gap-4">
-              {formError && <Alert variant="destructive">{formError}</Alert>}
-              <MedicationFormFields
-                formData={formData}
-                setFormData={setFormData}
-                providers={providers}
-                pharmacies={pharmacies}
-                showStatus
-              />
-              <DialogFooter>
-                <Button type="button" variant="secondary" onClick={() => setShowEditModal(false)}>Cancel</Button>
-                <Button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save Changes'}</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
 
         {/* Delete Confirmation Modal */}
         <Dialog open={showDeleteModal && !!selectedMedication} onOpenChange={(o) => { if (!o) setShowDeleteModal(false); }}>


### PR DESCRIPTION
Adding walks three steps — the drug, what's on hand, who prescribed it — because a new record needs all three and nothing saves until the first is answered. Editing shows the same three groups at once, opened on the drug, marking which fields differ and counting them, because an edit is usually one field and the rest is context.

## What the mockup asked for that doesn't exist

You warned GPT may have invented fields. It did. None of these are built:

| Mockup | Reality |
|---|---|
| **Form** (Tablet / Liquid / Capsule / Other) | No `form` column anywhere. The nearest thing is `quantity_unit` — the *inventory* unit — so it's labelled "Counted in", not presented as the drug's form. |
| **Archive** | Only `active` exists. Archive would be a new concept. |
| **"by John"** on last-updated | `updated_at` exists; nothing records *who*. The footer gives the date and no name. |
| **#MED-0042** | The id is a plain integer. |
| **Scan label** | No medication barcode scanning exists in the app — every scanner is packing-slip/supply. (`rxnorm_code` and `ndc_code` columns *do* exist but nothing in the UI touches them, so this is a real feature, not a small addition.) |
| **Character counters (250 / 240)** | `instructions` has no max length in the model, so any cap would be invented. |
| **Strength as value + unit** | `concentration` is one string. Splitting it in the UI would imply a structure the record doesn't have. |

### "Both" is subtler than a hallucination

`as_needed` is a boolean — but a medication genuinely *can* be scheduled and as-needed at once, because **nothing filters schedules by that flag**. So "Both" is a real state; it just isn't a third value of the field. It's the boolean *plus* having schedules — and schedules are separate records this sheet deliberately doesn't edit.

Offering "Both" as a third option would promise something the sheet can't do. Instead it reports the schedules ("Given on 3 schedules" / "No schedules yet") next to the two-way control, which is what "both" actually looks like.

## The warning in the mockup is the opposite of the truth

The mockup reassures: *"If you change the medication name or strength, existing logs keep the values recorded at the time."*

**`MedicationLog` stores `medication_id` and `dose_amount` and nothing else about the drug** — the schema comment even says "unit inherited from medication". Past doses render this record's *current* name and strength. Renaming rewrites how history reads.

Shipping that reassurance would tell a caregiver their record is safe when it isn't. The sheet says the accurate thing instead, and only once a name or strength has actually been touched.

**Worth its own decision:** denormalising name/strength onto the log at administration time would make the mockup's promise true. That's a migration plus a write-path change — happy to do it as a follow-up if you want it.

## Three bugs in this path

- **Optional fields could be set but never cleared.** `PUT /api/medications/{id}` dropped every `None` before applying, so turning off the low-stock alert, or detaching a prescriber or pharmacy, silently did nothing — the request answered success and the reloaded form showed the old value back. Now `exclude_unset`, the rule the care-task and shipment routes already follow.
- **A validation error could crash the form.** The update handler didn't map an array-shaped 422 the way create did, so FastAPI's detail array rendered as an Alert child — "Objects are not valid as a React child".
- **The Global checkbox no-opped on edit.** `MedicationUpdate` has no such field, so toggling it did nothing. Scope is create-only now, where it works.

## Also

- **`end_date` is now reachable.** The API has always accepted it, and the active-list query already treats a past one as expired — the form simply never offered it.
- The two payload builders and the two copies of the form defaults collapse to one each. The manage page drops from 1,249 to 945 lines.

## Verification

Backend **674 pass**, 1 skipped (669 baseline + 5 new) · frontend **1003 pass** (985 + 18 new) · lint clean at `--max-warnings 0` · build succeeds.

The backend tests were checked against the unfixed route: **3 of the 5 fail without it**; the two that pass are the controls (an untouched field stays untouched, and `active: false` — falsy but not `None` — was never affected).

Medications had **no component tests at all** before this. The 18 new ones stand in for the add/edit behaviour that moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
