### PR TITLE
Stop fabricating durations for unclosed monitoring alerts

### DIFF
--- a/backend/routes/reports.py
+++ b/backend/routes/reports.py
@@ -26,7 +26,7 @@ from zoneinfo import ZoneInfo
 from db import get_db
 from dependencies import require_read_access
 from crud.scheduling import get_scheduled_medications, get_scheduled_care_tasks
-from utils.datetime_utils import resolve_tz_for_patient
+from utils.datetime_utils import resolve_tz_for_patient, make_utc
 
 
 def _pg_tz(db: Session, patient_id: int) -> str:
@@ -607,16 +607,28 @@ async def overnight_summary(
     oxygen_highest_flow = 0
 
     for a in alert_rows:
-        end_t = a.end_time or utc_end
-        duration = (end_t - a.start_time).total_seconds() / 60
-        duration = round(duration, 1)
-        total_alert_minutes += duration
-        if duration > longest_alert_minutes:
-            longest_alert_minutes = duration
+        # start_time/end_time are timestamptz, so the driver hands back aware
+        # datetimes while the window bounds are naive UTC. Normalise before
+        # any arithmetic — subtracting the two kinds raises.
+        start_t = make_utc(a.start_time)
+        end_t = make_utc(a.end_time) if a.end_time else None
+
+        # An alert with no end_time was never closed. The episode itself is
+        # real, but its length is not knowable: the sensor data usually shows
+        # the desat recovered minutes later while the row stayed open, so
+        # running it to the end of the window would invent hours of alert
+        # time. Count the episode, leave the duration unknown, and keep it
+        # out of the totals.
+        duration = round((end_t - start_t).total_seconds() / 60, 1) if end_t else None
+        if duration is not None:
+            total_alert_minutes += duration
+            if duration > longest_alert_minutes:
+                longest_alert_minutes = duration
 
         if a.oxygen_used:
             oxygen_episodes += 1
-            oxygen_total_minutes += duration
+            if duration is not None:
+                oxygen_total_minutes += duration
             if a.oxygen_highest and a.oxygen_highest > oxygen_highest_flow:
                 oxygen_highest_flow = a.oxygen_highest
 
@@ -624,6 +636,7 @@ async def overnight_summary(
             "start_time": a.start_time.isoformat(),
             "end_time": a.end_time.isoformat() if a.end_time else None,
             "duration_minutes": duration,
+            "unclosed": end_t is None,
             "spo2_min": a.spo2_min,
             "spo2_max": a.spo2_max,
             "bpm_min": a.bpm_min,
@@ -917,6 +930,10 @@ async def overnight_summary(
             "total": len(alert_items),
             "total_duration_minutes": round(total_alert_minutes, 1),
             "longest_duration_minutes": round(longest_alert_minutes, 1),
+            # How many of those episodes have no end_time, and so contribute
+            # nothing to the durations above. Lets the UI say the totals cover
+            # only part of the night instead of silently under-reporting.
+            "unclosed": sum(1 for i in alert_items if i["unclosed"]),
             "items": alert_items,
         },
         "oxygen": {
@@ -1263,7 +1280,12 @@ async def weekly_summary(
         SELECT
             date(start_time AT TIME ZONE '{tz_name}') AS day,
             COUNT(*) AS cnt,
-            SUM(EXTRACT(EPOCH FROM (COALESCE(end_time, NOW()) - start_time)) / 60)::float AS total_min,
+            -- Unclosed alerts (end_time IS NULL) are counted in cnt but
+            -- excluded from the duration: COALESCE(..., NOW()) charged the
+            -- day for every minute since the row was opened, which for a
+            -- months-old orphan is a wildly inflated total.
+            SUM(EXTRACT(EPOCH FROM (end_time - start_time)) / 60)::float AS total_min,
+            SUM(CASE WHEN end_time IS NULL THEN 1 ELSE 0 END) AS unclosed,
             SUM(CASE WHEN spo2_alarm_triggered THEN 1 ELSE 0 END) AS spo2_alarms,
             SUM(CASE WHEN hr_alarm_triggered THEN 1 ELSE 0 END) AS hr_alarms,
             SUM(CASE WHEN external_alarm_triggered THEN 1 ELSE 0 END) AS ext_alarms
@@ -1280,6 +1302,7 @@ async def weekly_summary(
         "hr_alarm": sum(r.hr_alarms for r in alert_summary_rows),
         "external": sum(r.ext_alarms for r in alert_summary_rows),
     }
+    alert_unclosed = sum(r.unclosed for r in alert_summary_rows)
     alert_daily = [{"date": str(r.day), "count": r.cnt} for r in alert_summary_rows]
 
     # --- Equipment due ---
@@ -1347,6 +1370,7 @@ async def weekly_summary(
         "alerts": {
             "total": alert_total,
             "total_duration_minutes": round(alert_total_min, 1),
+            "unclosed": alert_unclosed,
             "by_type": alert_by_type,
             "daily_counts": alert_daily,
         },

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -126,3 +126,105 @@ def test_read_restricted_blocked(client, admin_user, account, patient):
 
 def test_requires_auth(client):
     assert client.get("/api/reports/weekly-summary", params={"patient_id": 1}).status_code == 401
+
+
+def _alert(patient_id, start, end=None, **kw):
+    """A monitoring alert row. end=None is an alert that was never closed —
+    the reader restarts mid-episode and the closing write never lands."""
+    from schemas.monitoring_alert import MonitoringAlert
+    return MonitoringAlert(
+        patient_id=patient_id, start_time=start, end_time=end,
+        created_at=start, spo2_min=kw.pop("spo2_min", 88), **kw,
+    )
+
+
+def test_overnight_survives_an_unclosed_alert(admin_client, db_session, patient):
+    """An alert with no end_time used to 500 the whole page. start_time is
+    timestamptz, so the driver returns an aware datetime, while the window
+    bounds are naive UTC — the `end_time or utc_end` fallback subtracted one
+    from the other and raised 'can't subtract offset-naive and offset-aware
+    datetimes'. One orphaned row took out the entire night's report."""
+    from datetime import datetime, timezone
+
+    db_session.add(_alert(patient.id, datetime(2026, 6, 2, 3, 0, tzinfo=timezone.utc)))
+    db_session.commit()
+
+    resp = admin_client.get("/api/reports/overnight", params={
+        "patient_id": patient.id, "report_date": "2026-06-01",
+    })
+    assert resp.status_code == 200, resp.text
+
+
+def test_overnight_counts_unclosed_alert_but_not_its_duration(admin_client, db_session, patient):
+    """The episode is real so it stays in the count, but its length is not
+    knowable. Running it to the end of the window would have charged this
+    night ~9 hours of alert time for a desat that recovered in minutes."""
+    from datetime import datetime, timedelta, timezone
+
+    closed_start = datetime(2026, 6, 2, 2, 0, tzinfo=timezone.utc)
+    db_session.add_all([
+        _alert(patient.id, closed_start, closed_start + timedelta(minutes=3)),
+        _alert(patient.id, datetime(2026, 6, 2, 3, 0, tzinfo=timezone.utc)),  # never closed
+    ])
+    db_session.commit()
+
+    resp = admin_client.get("/api/reports/overnight", params={
+        "patient_id": patient.id, "report_date": "2026-06-01",
+    })
+    assert resp.status_code == 200, resp.text
+    alerts = resp.json()["alerts"]
+
+    assert alerts["total"] == 2                      # both episodes counted
+    assert alerts["unclosed"] == 1
+    assert alerts["total_duration_minutes"] == 3.0   # only the closed one
+    assert alerts["longest_duration_minutes"] == 3.0
+
+    unclosed = [i for i in alerts["items"] if i["unclosed"]]
+    assert len(unclosed) == 1
+    assert unclosed[0]["duration_minutes"] is None
+    assert unclosed[0]["end_time"] is None
+
+
+def test_overnight_unclosed_alert_does_not_inflate_oxygen_minutes(admin_client, db_session, patient):
+    """Same rule for the oxygen tile: the episode counts, the minutes don't."""
+    from datetime import datetime, timezone
+
+    db_session.add(_alert(
+        patient.id, datetime(2026, 6, 2, 3, 0, tzinfo=timezone.utc),
+        oxygen_used=True, oxygen_highest=2.0,
+    ))
+    db_session.commit()
+
+    resp = admin_client.get("/api/reports/overnight", params={
+        "patient_id": patient.id, "report_date": "2026-06-01",
+    })
+    assert resp.status_code == 200, resp.text
+    oxygen = resp.json()["oxygen"]
+    assert oxygen["episodes"] == 1
+    assert oxygen["total_minutes"] == 0
+    assert oxygen["highest_flow"] == 2.0
+
+
+def test_weekly_summary_excludes_unclosed_alerts_from_duration(admin_client, db_session, patient):
+    """The weekly total ran unclosed alerts to NOW(), so a months-old orphan
+    reported more alert minutes than there are minutes in the week."""
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    closed_start = now - timedelta(days=1)
+    db_session.add_all([
+        _alert(patient.id, closed_start, closed_start + timedelta(minutes=5)),
+        _alert(patient.id, now - timedelta(days=2)),  # never closed
+    ])
+    db_session.commit()
+
+    resp = admin_client.get("/api/reports/weekly-summary", params={"patient_id": patient.id})
+    assert resp.status_code == 200, resp.text
+    alerts = resp.json()["alerts"]
+
+    assert alerts["total"] == 2
+    assert alerts["unclosed"] == 1
+    assert alerts["total_duration_minutes"] == 5.0
+    # A week only holds 10080 minutes; the old COALESCE(end_time, NOW()) put
+    # roughly 2880 of them here on its own.
+    assert alerts["total_duration_minutes"] < 10080

--- a/frontend/src/pages/admin-v2/AdminV2ReportsOvernight.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2ReportsOvernight.jsx
@@ -457,6 +457,12 @@ const AdminV2ReportsOvernight = () => {
             <div className="ovn-card-sub">
               {formatMinutes(data.alerts.total_duration_minutes)} across {eps.length}
               {eps.length === 1 ? ' episode' : ' episodes'} · longest {formatMinutes(data.alerts.longest_duration_minutes)}
+              {/* Episodes that never got an end time have no duration, so the
+                  figures above cover only the rest. Say so rather than let the
+                  total read as the whole night. */}
+              {data.alerts.unclosed > 0 && (
+                <> · {data.alerts.unclosed} never closed, not counted in the time</>
+              )}
             </div>
             <div className="rpt-table-wrap">
               <table className="rpt-table">

--- a/frontend/src/pages/admin-v2/AdminV2ReportsOvernight.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2ReportsOvernight.test.jsx
@@ -225,6 +225,27 @@ describe('AdminV2ReportsOvernight', () => {
     expect(await screen.findByText('No pulse-ox readings in this window')).toBeInTheDocument();
   });
 
+  it('shows an episode with no end time without inventing a duration', async () => {
+    body = payload({
+      alerts: {
+        total: 2, total_duration_minutes: 3, longest_duration_minutes: 3, unclosed: 1,
+        items: [
+          { start_time: '2026-08-18T03:13:00Z', end_time: '2026-08-18T03:16:00Z',
+            duration_minutes: 3, spo2_min: 88, spo2_max: 95, bpm_min: 70, bpm_max: 90,
+            oxygen_used: false, oxygen_highest: null, unclosed: false },
+          { start_time: '2026-08-19T03:06:00Z', end_time: null,
+            duration_minutes: null, spo2_min: 81, spo2_max: 95, bpm_min: 70, bpm_max: 90,
+            oxygen_used: false, oxygen_highest: null, unclosed: true },
+        ],
+      },
+    });
+    setup();
+    // Both episodes listed, and the total says what it left out rather than
+    // quietly reading as the whole night.
+    expect(await screen.findByText(/2 episodes/)).toBeInTheDocument();
+    expect(screen.getByText(/1 never closed, not counted in the time/)).toBeInTheDocument();
+  });
+
   it('surfaces a failed report', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url) => {
       if (String(url).includes('/api/settings')) return { ok: true, json: async () => SETTINGS };


### PR DESCRIPTION
## Summary
- 36 `monitoring_alerts` rows have `end_time IS NULL` (alert-closing write never landed); reports previously fabricated durations for them — overnight ran the alert to the end of the window, weekly's `COALESCE(end_time, NOW())` once reported 13,894 min of alert time in a 168-hour week.
- Episode is now still counted, but its duration is left unknown (`duration_minutes: null`, `unclosed: true`) and excluded from `total_duration_minutes`, `longest_duration_minutes`, and oxygen minutes, in both the overnight and weekly summaries.
- Overnight UI appends "N never closed, not counted in the time" when applicable.
- Root cause of why rows aren't closed is still open — this only fixes the reporting-side fabrication.

## Test plan
- [ ] `backend/tests/test_reports.py` covers unclosed-alert handling in overnight and weekly summaries
- [ ] `frontend/src/pages/admin-v2/AdminV2ReportsOvernight.test.jsx` covers the "never closed" UI copy
- [ ] Manual: view overnight report for a night with an orphaned alert row, confirm totals no longer include it and the "never closed" note appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B599mEt9oUqjMEzvUSNKDe