### PR TITLE
An alert ends when the readings say so, not when monitoring comes back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ cookies.txt
 .env.docker
 docs/*
 !docs/refactor-orm-split.md
+!docs/alert-subsystem-handoff.md
 
 # Personal strategy/brainstorm notes — not for the repo
 remote-access-brainstorm.md

--- a/backend/alembic/versions/047_monitoring_alert_end_source.py
+++ b/backend/alembic/versions/047_monitoring_alert_end_source.py
@@ -1,0 +1,72 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Record how a monitoring alert's end_time was arrived at
+
+Revision ID: 047_monitoring_alert_end_source
+Revises: 046_shipment_account_scope
+Create Date: 2026-08-19
+
+An alert's end_time used to be a bare timestamp with no indication of where it
+came from, which mattered once we started reconstructing ends from the stored
+pulse-ox stream: "we watched them recover" and "the sensor stopped and we
+stopped knowing" are different clinical statements and should not look alike.
+
+end_source carries that. Existing rows stay NULL, meaning "closed before this
+was tracked" -- a real and distinct state, and the flag the reconstruction pass
+uses to know which rows it has already considered. Backfilling 'live' onto them
+would assert something we cannot verify, including onto the rows we know are
+wrong.
+
+end_time_superseded holds whatever value a reconstruction replaced, so an
+overwritten clinical record is never silently lost.
+
+The partial index matches the sweeper's every-five-minutes predicate exactly;
+it holds only currently-open alerts, which is approximately none of them.
+
+Note for anyone querying alerts against their samples: end_time is stamped from
+a timestamp captured before the sample row is written, so the sample that
+triggered the close can land a few hundred microseconds AFTER end_time. A plain
+BETWEEN start_time AND end_time silently drops it. Widen the upper bound.
+"""
+from typing import Sequence, Union
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = '047_monitoring_alert_end_source'
+down_revision: Union[str, None] = '046_shipment_account_scope'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('monitoring_alerts', sa.Column('end_source', sa.String(), nullable=True))
+    op.add_column(
+        'monitoring_alerts',
+        sa.Column('end_time_superseded', sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index(
+        'ix_monitoring_alerts_open',
+        'monitoring_alerts',
+        ['start_time'],
+        postgresql_where=sa.text('end_time IS NULL AND end_source IS NULL'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_monitoring_alerts_open', table_name='monitoring_alerts')
+    op.drop_column('monitoring_alerts', 'end_time_superseded')
+    op.drop_column('monitoring_alerts', 'end_source')

--- a/backend/crud/alert_closure.py
+++ b/backend/crud/alert_closure.py
@@ -1,0 +1,516 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Working out when a monitoring alert actually ended.
+
+The live engine (modules/state_module.py) closes an alert by watching samples
+arrive. That only works while samples keep arriving: if the reader is unplugged
+or the process restarts mid-episode, the row is stranded open forever. And its
+recovery timer measured plain wall-clock between two normal samples, so when a
+sensor came off mid-recovery and the stream resumed hours later, the first
+sample on resume satisfied "30 seconds have passed" and the alert was recorded
+as having lasted those hours.
+
+This module reconstructs the end from the stored pulse-ox stream instead, and
+defines the single rule that both it and the live engine follow:
+
+    An alert ends at the earlier of
+      recovery         -- RECOVERY_SECONDS of contiguous all-normal samples
+      monitoring ended -- the last valid sample before the stream goes quiet
+
+"Valid" excludes the -1 sentinel a pulse oximeter emits when the probe is off.
+That exclusion is what makes one rule cover two different-looking failures: if
+the reader dies the samples stop, and if the probe comes off the samples keep
+arriving but carry no reading. Measured on real data, probe-off runs reach 9.8
+hours. Counting them as data would say the patient was in alarm that whole time.
+
+A trap worth knowing before writing any query that joins alerts to their
+samples: end_time is stamped from a timestamp captured before the sample row is
+written, so the sample that triggered a close can land a few hundred
+microseconds AFTER end_time. A plain BETWEEN start_time AND end_time drops it.
+Widen the bound -- see SCAN_EPSILON_SECONDS.
+"""
+import logging
+from datetime import timedelta
+from typing import NamedTuple, Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from utils.datetime_utils import make_utc, utc_now
+
+logger = logging.getLogger("crud.alert_closure")
+
+
+# --- The rule -------------------------------------------------------------
+
+# Matches the live engine's long-standing behaviour: values must read normal
+# for this long before the episode counts as over.
+RECOVERY_SECONDS = 30
+
+# Silence, measured in *valid* samples, that means monitoring stopped rather
+# than that the patient stayed well. Cadence is a rock-steady 2s (p50 and p99
+# alike), so this is 60 consecutive missing samples -- never mere jitter. It
+# also sits above all but 3.6% of observed probe-off runs, so re-seating a
+# sensor does not routinely split one episode in two. The value is not load
+# bearing for reconstructing historical rows: the discontinuities in the bad
+# data run to thousands of seconds, so anything from 60s to 3000s picks out the
+# same rows. It tunes live fragmentation only.
+GAP_SECONDS = 120
+
+# A hole this long inside an otherwise-normal stretch means the stretch is not
+# evidence of continuous normality, so the recovery countdown restarts.
+CONTINUITY_SECONDS = 10
+
+# A reading frozen at the same (spo2, bpm) for longer than this, while in
+# alarm, is a stuck sensor rather than an unending desaturation.
+STUCK_SENSOR_SECONDS = 60
+STUCK_SENSOR_MAX_DELTA_SECONDS = 10
+
+# How far past the start we are willing to look before giving up. A genuinely
+# longer episode is left alone rather than truncated to fit.
+MAX_LOOKAHEAD_MINUTES = 120
+MAX_SCAN_SAMPLES = 5000
+
+# Alert start/end timestamps and their triggering samples are written by
+# different statements, so they can disagree by well under a second in either
+# direction. Widen window bounds by this much to keep the boundary samples.
+SCAN_EPSILON_SECONDS = 2
+
+
+# --- Provenance vocabulary, stored in monitoring_alerts.end_source ---------
+
+LIVE_RECOVERY = "live_recovery"
+LIVE_GAP = "live_gap"
+INFERRED_RECOVERY = "inferred_recovery"
+INFERRED_MONITORING_ENDED = "inferred_monitoring_ended"
+INFERRED_NO_DATA = "inferred_no_data"
+
+# Outcomes that mean "the end was reconstructed, not observed". Reports use the
+# 'inferred' prefix rather than this tuple, but keep them in step.
+INFERRED_PREFIX = "inferred"
+
+OUTCOME_TO_SOURCE = {
+    "recovery": INFERRED_RECOVERY,
+    "monitoring_ended": INFERRED_MONITORING_ENDED,
+    "no_data": INFERRED_NO_DATA,
+}
+
+
+class Thresholds(NamedTuple):
+    min_spo2: int
+    max_spo2: int
+    min_bpm: int
+    max_bpm: int
+
+
+class AlertEndInference(NamedTuple):
+    end_time: Optional[object]  # aware datetime, or None meaning "do not close"
+    outcome: str                # recovery | monitoring_ended | no_data | indeterminate
+    detail: str
+    samples_scanned: int
+
+
+def load_thresholds(db: Session) -> Thresholds:
+    """The alarm limits the live engine uses.
+
+    Deliberately the lowercase setting keys seeded in main.py. crud/monitoring
+    reads uppercase ones that have never matched anything, so it has always
+    silently used its own defaults; do not copy that.
+    """
+    from crud.settings import get_setting
+    return Thresholds(
+        int(get_setting(db, 'min_spo2', 90)),
+        int(get_setting(db, 'max_spo2', 100)),
+        int(get_setting(db, 'min_bpm', 55)),
+        int(get_setting(db, 'max_bpm', 155)),
+    )
+
+
+def classify_sample(spo2, bpm, thresholds: Thresholds) -> str:
+    """One sample as 'disconnected', 'alarm' or 'normal'.
+
+    Byte-for-byte the live engine's alarm test, so the two cannot drift.
+    """
+    if spo2 is None or bpm is None or spo2 <= 0 or bpm <= 0:
+        return "disconnected"
+    if (spo2 < thresholds.min_spo2 or spo2 > thresholds.max_spo2
+            or bpm < thresholds.min_bpm or bpm > thresholds.max_bpm):
+        return "alarm"
+    return "normal"
+
+
+_SCAN_SQL = text("""
+    SELECT timestamp, spo2, bpm
+    FROM pulse_ox_data
+    WHERE patient_id = :pid
+      AND timestamp > :scan_from
+      AND timestamp <= :scan_to
+      AND spo2 > 0 AND bpm > 0
+    ORDER BY timestamp
+    LIMIT :max_samples
+""")
+
+_NEXT_VALID_SQL = text("""
+    SELECT MIN(timestamp) AS ts
+    FROM pulse_ox_data
+    WHERE patient_id = :pid AND timestamp > :after
+      AND spo2 > 0 AND bpm > 0
+""")
+
+
+def infer_alert_end(
+    db: Session,
+    *,
+    patient_id: int,
+    start_time,
+    thresholds: Optional[Thresholds] = None,
+    max_lookahead_minutes: int = MAX_LOOKAHEAD_MINUTES,
+    gap_seconds: int = GAP_SECONDS,
+    recovery_seconds: int = RECOVERY_SECONDS,
+    continuity_seconds: int = CONTINUITY_SECONDS,
+) -> AlertEndInference:
+    """Reconstruct when an episode that started at start_time actually ended."""
+    if thresholds is None:
+        thresholds = load_thresholds(db)
+
+    start = make_utc(start_time)
+    epsilon = timedelta(seconds=SCAN_EPSILON_SECONDS)
+
+    def result(end, outcome, detail, scanned):
+        # The scan deliberately reaches back before start_time to catch the
+        # sample that opened the alert, so an end drawn from "the last sample
+        # we saw" can land a hair earlier than the start. An episode cannot end
+        # before it began; the shortest honest answer is zero.
+        if end is not None and end < start:
+            end = start
+        return AlertEndInference(end, outcome, detail, scanned)
+
+    rows = db.execute(_SCAN_SQL, {
+        "pid": patient_id,
+        # The sample that opened the alert is written just before the alert
+        # itself, so it sits fractionally earlier than start_time.
+        "scan_from": start - epsilon,
+        "scan_to": start + timedelta(minutes=max_lookahead_minutes),
+        "max_samples": MAX_SCAN_SAMPLES,
+    }).all()
+
+    if not rows:
+        return result(start, "no_data", "no samples after the start", 0)
+
+    prev_valid = start
+    recovery_start = None
+    frozen_since = None
+    frozen_key = None
+
+    for row in rows:
+        ts = make_utc(row.timestamp)
+        # Boundary samples can predate start_time by a hair; never let that
+        # read as a negative gap.
+        since_prev = max((ts - prev_valid).total_seconds(), 0.0)
+
+        # 1. The stream went quiet. Everything after the silence describes a
+        #    later state of the world, not this episode, so stop at the last
+        #    thing we actually saw.
+        if since_prev > gap_seconds:
+            return result(
+                prev_valid, "monitoring_ended",
+                f"no valid samples for {since_prev:.0f}s", len(rows),
+            )
+
+        kind = classify_sample(row.spo2, row.bpm, thresholds)
+
+        if kind == "alarm":
+            recovery_start = None
+            # 2. A reading that has not moved at all is the sensor stuck, not a
+            #    desaturation that never lifts.
+            key = (row.spo2, row.bpm)
+            if frozen_key == key and since_prev < STUCK_SENSOR_MAX_DELTA_SECONDS:
+                if (ts - frozen_since).total_seconds() > STUCK_SENSOR_SECONDS:
+                    return result(
+                        frozen_since, "monitoring_ended", "stuck_sensor", len(rows),
+                    )
+            else:
+                frozen_key, frozen_since = key, ts
+        else:
+            frozen_key, frozen_since = None, None
+            # 3. Normal. A hole inside the stretch means it is not continuous
+            #    evidence, so start counting again from here.
+            if recovery_start is None or since_prev > continuity_seconds:
+                recovery_start = ts
+            elif (ts - recovery_start).total_seconds() >= recovery_seconds:
+                return result(ts, "recovery", "sustained recovery", len(rows))
+
+        prev_valid = ts
+
+    # Ran out of samples without concluding anything. If the scan was truncated
+    # we simply did not look far enough to say.
+    if len(rows) >= MAX_SCAN_SAMPLES:
+        return result(None, "indeterminate", "scan truncated", len(rows))
+
+    # Is there anything at all beyond where we stopped? This is what keeps the
+    # lookahead bound from turning "the sensor came off for a fortnight" into
+    # "we cannot tell" -- a gap is a gap however far away the next sample is.
+    nxt = db.execute(_NEXT_VALID_SQL, {"pid": patient_id, "after": prev_valid}).scalar()
+    if nxt is None:
+        return result(
+            prev_valid, "monitoring_ended", "stream ends here", len(rows),
+        )
+    silence = (make_utc(nxt) - prev_valid).total_seconds()
+    if silence > gap_seconds:
+        return result(
+            prev_valid, "monitoring_ended",
+            f"no valid samples for {silence:.0f}s", len(rows),
+        )
+
+    # Continuous data for the whole lookahead without ever recovering. That is
+    # a real, long episode (or a fault this rule does not model); either way,
+    # truncating it to the bound would be inventing an answer.
+    return result(
+        None, "indeterminate", "no recovery within the lookahead", len(rows),
+    )
+
+
+def close_alert_with_inference(db: Session, alert, *, thresholds=None) -> dict:
+    """Reconstruct and write one alert's end. Returns what happened."""
+    from crud.monitoring import update_monitoring_alert
+
+    inference = infer_alert_end(
+        db, patient_id=alert.patient_id, start_time=alert.start_time,
+        thresholds=thresholds,
+    )
+    result = {
+        "id": alert.id,
+        "patient_id": alert.patient_id,
+        "start_time": make_utc(alert.start_time).isoformat(),
+        "old_end_time": make_utc(alert.end_time).isoformat() if alert.end_time else None,
+        "new_end_time": inference.end_time.isoformat() if inference.end_time else None,
+        "outcome": inference.outcome,
+        "detail": inference.detail,
+        "samples_scanned": inference.samples_scanned,
+        "closed": False,
+    }
+    if inference.end_time is None:
+        return result
+
+    minutes = (inference.end_time - make_utc(alert.start_time)).total_seconds() / 60
+    result["new_minutes"] = round(minutes, 2)
+    update_monitoring_alert(
+        db, alert.id,
+        end_time=inference.end_time,
+        end_source=OUTCOME_TO_SOURCE[inference.outcome],
+    )
+    result["closed"] = True
+    result["end_source"] = OUTCOME_TO_SOURCE[inference.outcome]
+    return result
+
+
+# --- The sweep: alerts the live engine can no longer reach -----------------
+
+GRACE_MINUTES = 20
+SWEEP_BATCH_LIMIT = 50
+
+
+_OPEN_ALERTS_SQL = text("""
+    SELECT id, patient_id, start_time, end_time
+    FROM monitoring_alerts
+    WHERE end_time IS NULL AND end_source IS NULL AND start_time < :older_than
+    ORDER BY start_time
+    LIMIT :limit
+""")
+
+
+def find_open_alerts(db: Session, *, older_than, limit: int):
+    """Alerts still open past the grace period and not yet given up on.
+
+    Raw SQL rather than the ORM: we need four columns, and going through the
+    mapper would drag in the whole Patient relationship graph for nothing.
+    """
+    return db.execute(_OPEN_ALERTS_SQL, {"older_than": older_than, "limit": limit}).all()
+
+
+def sweep_open_alerts(
+    db: Session, *, now=None, grace_minutes: int = GRACE_MINUTES,
+    limit: int = SWEEP_BATCH_LIMIT, dry_run: bool = False,
+) -> dict:
+    """Close alerts nothing else can close.
+
+    The grace period keeps us off episodes the live engine still owns. It is
+    not what makes this safe, though: an alert that is genuinely still running
+    has neither recovered nor gone quiet, so the reconstruction returns
+    'indeterminate' and the row is left exactly as it was.
+    """
+    now = make_utc(now) if now else utc_now()
+    cutoff = now - timedelta(minutes=grace_minutes)
+    thresholds = load_thresholds(db)
+
+    summary = {
+        "examined": 0, "closed": 0, "indeterminate": 0,
+        "by_outcome": {}, "items": [],
+    }
+    for alert in find_open_alerts(db, older_than=cutoff, limit=limit):
+        summary["examined"] += 1
+        try:
+            if dry_run:
+                inference = infer_alert_end(
+                    db, patient_id=alert.patient_id, start_time=alert.start_time,
+                    thresholds=thresholds,
+                )
+                item = {
+                    "id": alert.id,
+                    "start_time": make_utc(alert.start_time).isoformat(),
+                    "new_end_time": (inference.end_time.isoformat()
+                                     if inference.end_time else None),
+                    "outcome": inference.outcome,
+                    "detail": inference.detail,
+                    "closed": False,
+                }
+            else:
+                item = close_alert_with_inference(db, alert, thresholds=thresholds)
+        except Exception as e:  # one bad row must not starve the rest
+            logger.exception("[alert_closure] alert %s failed to sweep", alert.id)
+            db.rollback()
+            summary["items"].append({"id": alert.id, "error": str(e)})
+            continue
+
+        summary["items"].append(item)
+        outcome = item["outcome"]
+        summary["by_outcome"][outcome] = summary["by_outcome"].get(outcome, 0) + 1
+        if outcome == "indeterminate":
+            summary["indeterminate"] += 1
+            if not dry_run:
+                # Record that we looked and could not tell, so the next tick
+                # does not rescan it forever. The row stays open and still
+                # reports as unclosed; the maintenance endpoint can retry it.
+                _mark_indeterminate(db, alert.id)
+        elif item.get("closed"):
+            summary["closed"] += 1
+
+    return summary
+
+
+def _mark_indeterminate(db: Session, alert_id: int) -> None:
+    from crud.monitoring import update_monitoring_alert
+    update_monitoring_alert(db, alert_id, end_source="indeterminate")
+
+
+# --- The resweep: ends that were written across a silence ------------------
+
+# Selects rows whose recorded end was stamped after the stream had already gone
+# quiet -- proof the value was written across a stretch where nothing was being
+# measured. Both terms are needed: depending on how the sub-second ordering
+# fell, the silence shows up either as a hole inside the window or as a stretch
+# between the last sample and end_time. Checking only the first misses a fifth
+# of them.
+_IMPLAUSIBLE_SQL = text("""
+    WITH windowed AS (
+        SELECT a.id, a.patient_id, a.start_time, a.end_time,
+               p.timestamp,
+               LAG(p.timestamp) OVER (PARTITION BY a.id ORDER BY p.timestamp) AS prev_ts
+        FROM monitoring_alerts a
+        JOIN pulse_ox_data p
+          ON p.patient_id = a.patient_id
+         AND p.timestamp >  a.start_time - make_interval(secs => :epsilon)
+         AND p.timestamp <= a.end_time   + make_interval(secs => :epsilon)
+         AND p.spo2 > 0 AND p.bpm > 0
+        WHERE a.end_time IS NOT NULL AND a.end_source IS NULL
+    ),
+    agg AS (
+        SELECT id, patient_id, start_time, end_time,
+               COUNT(*) AS valid_samples,
+               MAX(EXTRACT(EPOCH FROM (timestamp - prev_ts))) AS max_gap,
+               EXTRACT(EPOCH FROM (end_time - MAX(timestamp))) AS silence_before_close
+        FROM windowed
+        GROUP BY id, patient_id, start_time, end_time
+    )
+    SELECT id, patient_id, start_time, end_time, valid_samples,
+           COALESCE(max_gap, 0) AS max_gap,
+           COALESCE(silence_before_close, 0) AS silence_before_close
+    FROM agg
+    WHERE GREATEST(COALESCE(max_gap, 0), COALESCE(silence_before_close, 0)) > :gap_seconds
+    ORDER BY start_time
+""")
+
+
+def resweep_implausible_closures(
+    db: Session, *, thresholds=None, gap_seconds: int = GAP_SECONDS,
+    dry_run: bool = True, limit: Optional[int] = None,
+) -> dict:
+    """Correct ends that were stamped after the stream had already gone quiet.
+
+    Selection is by evidence of a silence, never by duration: a long alert is
+    not by itself wrong, but an end written across a stretch with no data is.
+    Corrections may only ever shorten -- the failure being undone always
+    overstates, so a rule that cannot lengthen cannot invent alert time.
+    """
+    from crud.monitoring import update_monitoring_alert
+
+    if thresholds is None:
+        thresholds = load_thresholds(db)
+
+    rows = db.execute(_IMPLAUSIBLE_SQL, {
+        "epsilon": SCAN_EPSILON_SECONDS, "gap_seconds": gap_seconds,
+    }).all()
+    if limit:
+        rows = rows[:limit]
+
+    summary = {"selected": len(rows), "rewritten": 0, "skipped": 0, "items": []}
+    for row in rows:
+        start = make_utc(row.start_time)
+        old_end = make_utc(row.end_time)
+        inference = infer_alert_end(
+            db, patient_id=row.patient_id, start_time=row.start_time,
+            thresholds=thresholds,
+        )
+        item = {
+            "id": row.id,
+            "start_time": start.isoformat(),
+            "old_end_time": old_end.isoformat(),
+            "old_minutes": round((old_end - start).total_seconds() / 60, 2),
+            "outcome": inference.outcome,
+            "detail": inference.detail,
+            "rewritten": False,
+        }
+
+        # Never blank an end we already have, and never push one later.
+        if inference.end_time is None:
+            item["skipped_reason"] = "indeterminate"
+        elif inference.end_time >= old_end:
+            item["skipped_reason"] = "would not shorten"
+        else:
+            item["new_end_time"] = inference.end_time.isoformat()
+            item["new_minutes"] = round(
+                (inference.end_time - start).total_seconds() / 60, 2)
+            if not dry_run:
+                update_monitoring_alert(
+                    db, row.id,
+                    end_time=inference.end_time,
+                    end_source=OUTCOME_TO_SOURCE[inference.outcome],
+                    end_time_superseded=old_end,
+                )
+                logger.warning(
+                    "[alert_closure] alert %s end %s -> %s (%.1f min -> %.1f min, %s)",
+                    row.id, old_end.isoformat(), inference.end_time.isoformat(),
+                    item["old_minutes"], item["new_minutes"], inference.detail,
+                )
+            item["rewritten"] = True
+
+        if item["rewritten"]:
+            summary["rewritten"] += 1
+        else:
+            summary["skipped"] += 1
+        summary["items"].append(item)
+
+    return summary

--- a/backend/crud/monitoring.py
+++ b/backend/crud/monitoring.py
@@ -179,7 +179,8 @@ def clear_external_alarm(db: Session, device_id):
 def update_monitoring_alert(db: Session, alert_id, end_time=None, end_data_id=None, spo2=None, bpm=None,
                            spo2_alarm_triggered=None, hr_alarm_triggered=None,
                            external_alarm_triggered=None, oxygen_used=None,
-                           oxygen_highest=None, oxygen_unit=None):
+                           oxygen_highest=None, oxygen_unit=None,
+                           end_source=None, end_time_superseded=None):
     """
     Update an existing monitoring alert
 
@@ -195,6 +196,8 @@ def update_monitoring_alert(db: Session, alert_id, end_time=None, end_data_id=No
         oxygen_used (int): Whether oxygen was used
         oxygen_highest (float): Highest oxygen level used
         oxygen_unit (str): Unit of oxygen measurement
+        end_source (str): How end_time was arrived at (see crud.alert_closure)
+        end_time_superseded (datetime): An end_time this call is replacing
 
     Returns:
         bool: True if successful, False otherwise
@@ -260,6 +263,12 @@ def update_monitoring_alert(db: Session, alert_id, end_time=None, end_data_id=No
         if oxygen_unit is not None:
             update_fields[MonitoringAlert.oxygen_unit] = oxygen_unit
 
+        if end_source is not None:
+            update_fields[MonitoringAlert.end_source] = end_source
+
+        if end_time_superseded is not None:
+            update_fields[MonitoringAlert.end_time_superseded] = end_time_superseded
+
         if not update_fields:
             logger.warning("No fields to update for alert")
             return True
@@ -270,6 +279,9 @@ def update_monitoring_alert(db: Session, alert_id, end_time=None, end_data_id=No
         logger.info(f"Updated monitoring alert #{alert_id}")
         return True
     except Exception as e:
+        # Without the rollback the session stays in an aborted transaction, so
+        # a single bad row would poison every later one in a sweep.
+        db.rollback()
         logger.error(f"Error updating monitoring alert: {e}")
         return False
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -360,6 +360,12 @@ async def startup_event():
     asyncio.create_task(ha_listener_loop())
     logger.info("[main] Home Assistant listener started")
 
+    # 9. Close monitoring alerts the live engine can no longer reach (the
+    #    reader stopped, or this process restarted mid-episode).
+    from modules.alert_sweeper import alert_sweep_loop
+    asyncio.create_task(alert_sweep_loop())
+    logger.info("[main] Alert sweeper started")
+
     logger.info("[main] Event-driven system startup complete")
 
 

--- a/backend/modules/alert_sweeper.py
+++ b/backend/modules/alert_sweeper.py
@@ -1,0 +1,68 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Background pass that closes monitoring alerts nothing else can close.
+
+The live engine in state_module only runs when a sample arrives. That is fine
+while the reader is streaming, but it means an episode interrupted by an
+unplugged reader, a disconnected patient or a process restart can never be
+closed by it -- after a restart the engine has forgotten the alert exists at
+all, since it tracked it only in memory. Those rows would stay open forever,
+and reports would either drop them or invent a length for them.
+
+So the two mechanisms cover different failures and neither replaces the other:
+the gap rule inside the live engine handles a stream that resumes with a hole
+in it, and this loop handles a stream that never resumes.
+
+Assumes a single instance, like environment.poller does. startup_event fires
+once (serve.py runs the HTTPS listener with lifespan off precisely so it
+cannot fire twice) and uvicorn runs one worker. Two of these would both scan;
+the writes are idempotent, so the cost would be wasted work rather than wrong
+data, but it is worth knowing before adding workers.
+"""
+import asyncio
+import logging
+
+from db import get_db
+from crud.alert_closure import sweep_open_alerts
+
+logger = logging.getLogger("alert_sweeper")
+
+TICK_SECONDS = 300
+ERROR_RETRY_SECONDS = 60
+
+
+async def alert_sweep_loop():
+    """Startup task (see main.py): close stranded alerts forever."""
+    logger.info("[alert_sweeper] Sweep loop started")
+    while True:
+        try:
+            # Sleep first: nothing here is urgent, and a stranded row only
+            # matters by the time someone reads a report.
+            await asyncio.sleep(TICK_SECONDS)
+            db = next(get_db())
+            try:
+                result = sweep_open_alerts(db)
+                if result["examined"]:
+                    logger.info(
+                        "[alert_sweeper] examined=%s closed=%s indeterminate=%s %s",
+                        result["examined"], result["closed"],
+                        result["indeterminate"], result["by_outcome"],
+                    )
+            finally:
+                db.close()
+        except Exception as e:
+            logger.error(f"[alert_sweeper] Sweep loop error: {e}")
+            await asyncio.sleep(ERROR_RETRY_SECONDS)

--- a/backend/modules/state_module.py
+++ b/backend/modules/state_module.py
@@ -18,15 +18,19 @@
 State module - manages centralized application state and handles database operations.
 """
 import asyncio
-from datetime import datetime
 from typing import Dict, Any, Optional
 import logging
 
 from bus import EventBus
 from events import (
-    SensorUpdate, VitalSignRecorded, AlertTriggered, AlertResolved, 
+    SensorUpdate, VitalSignRecorded, AlertTriggered, AlertResolved,
     MedicationDue, CareTaskDue, EventSource
 )
+from crud.alert_closure import (
+    CONTINUITY_SECONDS, GAP_SECONDS, RECOVERY_SECONDS,
+    LIVE_GAP, LIVE_RECOVERY, classify_sample,
+)
+from utils.datetime_utils import make_utc, utc_now
 
 logger = logging.getLogger("state_module")
 
@@ -47,6 +51,10 @@ class StateModule:
         self.alert_thresholds_exceeded = False
         self.alert_start_data_id = None
         self.alert_recovery_start_time = None
+        # Last sample that carried an actual reading. The gap that ends a
+        # stranded alert is measured from here, not from the last sample of any
+        # kind, so that a probe streaming -1 counts as silence.
+        self.alert_last_valid_sample_time = None
         
         # Pulse ox data caching for alerts
         self.pulse_ox_cache = []
@@ -159,8 +167,10 @@ class StateModule:
             bpm = pulse_ox_data.get("bpm")
             perfusion = pulse_ox_data.get("perfusion")
 
-            # Cache the data
-            timestamp = datetime.now()
+            # Cache the data. Aware UTC: start_time is written with utc_now(),
+            # and a naive local end_time would disagree with it by the offset
+            # the moment this runs anywhere that is not on UTC.
+            timestamp = utc_now()
             data_point = {
                 "timestamp": timestamp,
                 "spo2": spo2,
@@ -211,32 +221,54 @@ class StateModule:
           ALARM → thresholds exceeded → ALARM (continue, reset recovery timer)
           ALARM → thresholds normal   → RECOVERING (start 30s timer)
           RECOVERING → thresholds exceeded → ALARM (cancel recovery)
-          RECOVERING → 30s elapsed        → IDLE (end alert)
+          RECOVERING → 30s continuous     → IDLE (end alert)
+          ALARM/RECOVERING → stream goes quiet → IDLE (end at last valid sample)
+
+        The recovery countdown insists on *continuous* samples. It used to
+        compare plain wall-clock between the first normal reading and any later
+        one, so a sensor that came off mid-recovery and returned hours later
+        satisfied "30 seconds have passed" on its first sample back, and the
+        episode went into the record as having lasted those hours.
         """
         try:
             def _load_thresholds():
-                from crud.settings import get_setting
+                from crud.alert_closure import load_thresholds
                 from state_manager import get_db_session
                 with get_db_session() as db:
-                    return (
-                        int(get_setting(db, 'min_spo2', 90)),
-                        int(get_setting(db, 'max_spo2', 100)),
-                        int(get_setting(db, 'min_bpm', 55)),
-                        int(get_setting(db, 'max_bpm', 155)),
-                    )
+                    return load_thresholds(db)
 
-            min_spo2, max_spo2, min_bpm, max_bpm = await asyncio.to_thread(_load_thresholds)
+            thresholds = await asyncio.to_thread(_load_thresholds)
+            kind = classify_sample(spo2, bpm, thresholds)
+            prev_valid = self.alert_last_valid_sample_time
 
-            is_disconnected = (spo2 == -1) or (bpm == -1)
+            # The stream went quiet. Whatever arrives now describes a later
+            # state of the world, not this episode, so close at the last thing
+            # we actually saw and let this sample be judged as if idle.
+            #
+            # This runs before the disconnected check on purpose: when a probe
+            # comes off, rows keep arriving at full cadence carrying -1, so the
+            # sample stream has no hole in it at all. Only the *valid* samples
+            # stop, which is why the gap is measured on those.
+            if (self.current_alert_id is not None and prev_valid is not None
+                    and (timestamp - prev_valid).total_seconds() > GAP_SECONDS):
+                logger.info(
+                    f"Alert {self.current_alert_id}: no valid samples for "
+                    f"{(timestamp - prev_valid).total_seconds():.0f}s, "
+                    f"ending at the last one"
+                )
+                await self._end_pulse_ox_alert(prev_valid, end_source=LIVE_GAP)
 
-            if is_disconnected:
-                # Don't start or end alerts while disconnected; just keep logging if active
+            if kind == "disconnected":
+                # No reading to judge. Deliberately does not advance
+                # alert_last_valid_sample_time, so a long probe-off eventually
+                # trips the gap above rather than sitting here forever. It does
+                # break any recovery in progress: a stretch we could not see is
+                # not evidence the patient stayed well.
+                self.alert_recovery_start_time = None
                 return
 
-            # Evaluate current thresholds
-            spo2_alarm = spo2 is not None and (spo2 < min_spo2 or spo2 > max_spo2)
-            bpm_alarm = bpm is not None and (bpm < min_bpm or bpm > max_bpm)
-            thresholds_exceeded = spo2_alarm or bpm_alarm
+            self.alert_last_valid_sample_time = timestamp
+            thresholds_exceeded = kind == "alarm"
 
             if self.current_alert_id is None:
                 # --- IDLE ---
@@ -250,15 +282,19 @@ class StateModule:
                     self.alert_recovery_start_time = None
                     self.event_data_points.append(data_point)
                 else:
-                    # Values normal — start or continue recovery countdown
-                    if self.alert_recovery_start_time is None:
+                    # Values normal — start or continue recovery countdown.
+                    # A hole in the stream restarts it: the stretch either side
+                    # is not one continuous run of normal readings.
+                    broken = (prev_valid is not None
+                              and (timestamp - prev_valid).total_seconds() > CONTINUITY_SECONDS)
+                    if self.alert_recovery_start_time is None or broken:
                         self.alert_recovery_start_time = timestamp
-                        logger.info(f"Alert {self.current_alert_id}: values normal, starting 30s recovery timer")
+                        logger.info(f"Alert {self.current_alert_id}: values normal, starting {RECOVERY_SECONDS}s recovery timer")
                     else:
                         elapsed = (timestamp - self.alert_recovery_start_time).total_seconds()
-                        if elapsed >= 30:
-                            logger.info(f"Alert {self.current_alert_id}: 30s recovery complete, ending alert")
-                            await self._end_pulse_ox_alert(timestamp)
+                        if elapsed >= RECOVERY_SECONDS:
+                            logger.info(f"Alert {self.current_alert_id}: {RECOVERY_SECONDS}s recovery complete, ending alert")
+                            await self._end_pulse_ox_alert(timestamp, end_source=LIVE_RECOVERY)
 
         except Exception as e:
             logger.error(f"Error checking pulse ox thresholds: {e}")
@@ -323,21 +359,28 @@ class StateModule:
         except Exception as e:
             logger.error(f"Error starting pulse ox alert: {e}")
 
-    async def _end_pulse_ox_alert(self, timestamp):
-        """End the current pulse oximeter alert."""
+    async def _end_pulse_ox_alert(self, timestamp, end_source=LIVE_RECOVERY):
+        """End the current pulse oximeter alert.
+
+        end_source records how we arrived at this end time, so a reader can
+        tell an episode we watched resolve from one we closed because the
+        sensor stopped reporting.
+        """
         try:
             from state_manager import get_db_session
             from crud.monitoring import update_monitoring_alert
 
             if self.current_alert_id:
                 alert_id = self.current_alert_id
+                end_time = make_utc(timestamp)
 
                 def _sync_end_alert():
                     with get_db_session() as db:
                         update_monitoring_alert(
                             db=db,
                             alert_id=alert_id,
-                            end_time=timestamp.isoformat(),
+                            end_time=end_time,
+                            end_source=end_source,
                         )
 
                 await asyncio.to_thread(_sync_end_alert)
@@ -351,7 +394,7 @@ class StateModule:
                 )
                 await self.event_bus.publish(alert_event, topic="alerts.resolved")
 
-                logger.info(f"Pulse ox alert {alert_id} automatically resolved (end_time set)")
+                logger.info(f"Pulse ox alert {alert_id} automatically resolved ({end_source})")
 
                 # Reset tracking
                 self.current_alert_id = None

--- a/backend/routes/reports.py
+++ b/backend/routes/reports.py
@@ -592,7 +592,7 @@ async def overnight_summary(
         SELECT id, start_time, end_time,
                spo2_min, spo2_max, bpm_min, bpm_max,
                spo2_alarm_triggered, hr_alarm_triggered,
-               oxygen_used, oxygen_highest, acknowledged
+               oxygen_used, oxygen_highest, acknowledged, end_source
         FROM monitoring_alerts
         WHERE patient_id = :pid
           AND start_time >= :start AND start_time < :end
@@ -637,6 +637,10 @@ async def overnight_summary(
             "end_time": a.end_time.isoformat() if a.end_time else None,
             "duration_minutes": duration,
             "unclosed": end_t is None,
+            # The end was reconstructed from the sensor stream rather than
+            # watched happening, so the duration is an estimate.
+            "end_inferred": bool(a.end_source) and a.end_source.startswith("inferred"),
+            "end_source": a.end_source,
             "spo2_min": a.spo2_min,
             "spo2_max": a.spo2_max,
             "bpm_min": a.bpm_min,
@@ -934,6 +938,9 @@ async def overnight_summary(
             # nothing to the durations above. Lets the UI say the totals cover
             # only part of the night instead of silently under-reporting.
             "unclosed": sum(1 for i in alert_items if i["unclosed"]),
+            # Of the episodes above, how many have an end we worked out after
+            # the fact. They do count toward the times, unlike unclosed ones.
+            "inferred": sum(1 for i in alert_items if i["end_inferred"]),
             "items": alert_items,
         },
         "oxygen": {
@@ -1286,6 +1293,7 @@ async def weekly_summary(
             -- months-old orphan is a wildly inflated total.
             SUM(EXTRACT(EPOCH FROM (end_time - start_time)) / 60)::float AS total_min,
             SUM(CASE WHEN end_time IS NULL THEN 1 ELSE 0 END) AS unclosed,
+            SUM(CASE WHEN end_source LIKE 'inferred%' THEN 1 ELSE 0 END) AS inferred,
             SUM(CASE WHEN spo2_alarm_triggered THEN 1 ELSE 0 END) AS spo2_alarms,
             SUM(CASE WHEN hr_alarm_triggered THEN 1 ELSE 0 END) AS hr_alarms,
             SUM(CASE WHEN external_alarm_triggered THEN 1 ELSE 0 END) AS ext_alarms
@@ -1303,6 +1311,7 @@ async def weekly_summary(
         "external": sum(r.ext_alarms for r in alert_summary_rows),
     }
     alert_unclosed = sum(r.unclosed for r in alert_summary_rows)
+    alert_inferred = sum(r.inferred for r in alert_summary_rows)
     alert_daily = [{"date": str(r.day), "count": r.cnt} for r in alert_summary_rows]
 
     # --- Equipment due ---
@@ -1371,6 +1380,7 @@ async def weekly_summary(
             "total": alert_total,
             "total_duration_minutes": round(alert_total_min, 1),
             "unclosed": alert_unclosed,
+            "inferred": alert_inferred,
             "by_type": alert_by_type,
             "daily_counts": alert_daily,
         },

--- a/backend/routes/system.py
+++ b/backend/routes/system.py
@@ -60,6 +60,15 @@ class VacuumRequest(BaseModel):
     table: str | None = None
 
 
+class AlertClosureRequest(BaseModel):
+    # Preview by default: this rewrites clinical records, so the first call
+    # should always be one an operator can read before anything changes.
+    dry_run: bool = True
+    include_open: bool = True
+    include_closed: bool = True
+    limit: int | None = Field(None, ge=1, le=1000)
+
+
 @router.get("/health")
 def system_health_overview(
     db: Session = Depends(get_db),
@@ -94,6 +103,34 @@ def compress(
         return system_health.compress_old_chunks(db, body.table, body.older_than_days)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/maintenance/alert-closures")
+def alert_closures(
+    body: AlertClosureRequest,
+    db: Session = Depends(get_db),
+    _: User = Depends(_require_system_admin),
+):
+    """Reconstruct monitoring-alert end times from the pulse-ox stream.
+
+    Two populations: alerts still open that the live engine can no longer
+    reach, and alerts whose recorded end was stamped after the stream had
+    already gone quiet. Both are worked out from the stored samples; see
+    crud.alert_closure for the rule.
+    """
+    from crud import alert_closure
+
+    out = {"thresholds": alert_closure.load_thresholds(db)._asdict()}
+    if body.include_open:
+        out["open"] = alert_closure.sweep_open_alerts(
+            db, limit=body.limit or alert_closure.SWEEP_BATCH_LIMIT,
+            dry_run=body.dry_run,
+        )
+    if body.include_closed:
+        out["mis_closed"] = alert_closure.resweep_implausible_closures(
+            db, dry_run=body.dry_run, limit=body.limit,
+        )
+    return out
 
 
 @router.post("/maintenance/vacuum")

--- a/backend/schemas/monitoring_alert.py
+++ b/backend/schemas/monitoring_alert.py
@@ -25,6 +25,13 @@ class MonitoringAlert(Base):
     patient_id = Column(Integer, ForeignKey('patients.id'), nullable=False)
     start_time = Column(TIMESTAMP(timezone=True), nullable=False)
     end_time = Column(TIMESTAMP(timezone=True))
+    # How end_time was arrived at: 'live_*' means the engine watched it happen,
+    # 'inferred_*' means it was reconstructed from the stored pulse-ox stream.
+    # NULL means the row was closed before provenance was tracked.
+    end_source = Column(String)
+    # The end_time a reconstruction replaced, kept so an overwritten clinical
+    # value is never simply lost.
+    end_time_superseded = Column(TIMESTAMP(timezone=True))
     start_data_id = Column(Integer)
     end_data_id = Column(Integer)
     acknowledged = Column(Boolean, default=False)

--- a/backend/tests/test_alert_closure.py
+++ b/backend/tests/test_alert_closure.py
@@ -1,0 +1,451 @@
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Reconstructing when a monitoring alert actually ended.
+
+The shapes tested here are taken from real rows that went wrong in the live
+database, so each one names the failure it stands for.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from crud.alert_closure import (
+    GAP_SECONDS, RECOVERY_SECONDS, Thresholds,
+    classify_sample, infer_alert_end, load_thresholds,
+    resweep_implausible_closures, sweep_open_alerts,
+)
+
+THRESHOLDS = Thresholds(90, 100, 55, 155)
+START = datetime(2026, 6, 2, 3, 0, tzinfo=timezone.utc)
+
+
+def _samples(db, patient_id, runs):
+    """Write pulse-ox rows.
+
+    `runs` is a list of (offset_seconds, count, spo2, bpm) laid down at the 2s
+    cadence a real reader produces.
+    """
+    from schemas.pulse_ox_data import PulseOxData
+    rows = []
+    for offset, count, spo2, bpm in runs:
+        for i in range(count):
+            ts = START + timedelta(seconds=offset + i * 2)
+            rows.append(PulseOxData(
+                patient_id=patient_id, timestamp=ts,
+                spo2=spo2, bpm=bpm, pa=2.0, created_at=ts,
+            ))
+    db.add_all(rows)
+    db.commit()
+    return rows
+
+
+def _alert(db, patient_id, start=START, end=None, **kw):
+    from schemas.monitoring_alert import MonitoringAlert
+    a = MonitoringAlert(
+        patient_id=patient_id, start_time=start, end_time=end,
+        created_at=start, spo2_min=kw.pop("spo2_min", 88), **kw,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def _restless_alarm(count):
+    """Out-of-range readings that keep moving, at the usual 2s cadence.
+
+    Values vary so the run is not read as a stuck sensor, and the cadence is
+    unbroken so it is not read as monitoring having stopped -- leaving "still
+    going" as the only honest conclusion.
+    """
+    return [(i * 2, 1, 80 + (i % 5), 80 + (i % 3)) for i in range(count)]
+
+
+def _infer(db, patient):
+    return infer_alert_end(
+        db, patient_id=patient.id, start_time=START, thresholds=THRESHOLDS,
+    )
+
+
+# --- classification --------------------------------------------------------
+
+@pytest.mark.parametrize("spo2,bpm,expected", [
+    (97, 80, "normal"),
+    (88, 80, "alarm"),       # below min_spo2
+    (97, 40, "alarm"),       # below min_bpm
+    (-1, -1, "disconnected"),
+    (-1, 80, "disconnected"),  # one dead channel is enough
+    (0, 80, "disconnected"),
+    (None, None, "disconnected"),
+])
+def test_classify_sample(spo2, bpm, expected):
+    assert classify_sample(spo2, bpm, THRESHOLDS) == expected
+
+
+def test_thresholds_come_from_the_lowercase_settings_keys(db_session):
+    """crud/monitoring reads uppercase keys that match nothing; we must not."""
+    from crud.settings import save_setting
+    save_setting(db_session, "min_spo2", 85, "int", "test")
+    db_session.commit()
+    assert load_thresholds(db_session).min_spo2 == 85
+
+
+# --- the recovery rule -----------------------------------------------------
+
+def test_recovery_ends_once_the_values_have_held_for_thirty_seconds(db_session, patient):
+    # 30s of desat, then normal for well over the recovery window.
+    _samples(db_session, patient.id, [(0, 15, 88, 80), (30, 40, 97, 80)])
+
+    got = _infer(db_session, patient)
+
+    assert got.outcome == "recovery"
+    # The countdown starts at the first normal sample (offset 30) and completes
+    # RECOVERY_SECONDS later.
+    assert (got.end_time - START).total_seconds() == pytest.approx(
+        30 + RECOVERY_SECONDS, abs=2)
+
+
+def test_a_brief_normal_blip_does_not_end_the_alert(db_session, patient):
+    """Values touching normal for a moment is not the episode resolving."""
+    _samples(db_session, patient.id, [
+        (0, 5, 88, 80),
+        (10, 2, 97, 80),     # 4s of normal, nowhere near enough
+        (14, 5, 88, 80),
+        (24, 40, 97, 80),    # the real recovery
+    ])
+
+    got = _infer(db_session, patient)
+
+    assert got.outcome == "recovery"
+    assert (got.end_time - START).total_seconds() == pytest.approx(
+        24 + RECOVERY_SECONDS, abs=2)
+
+
+def test_a_hole_in_the_stream_restarts_the_recovery_countdown(db_session, patient):
+    """Twenty seconds of normal, a hole, then normal again is not fifty."""
+    _samples(db_session, patient.id, [
+        (0, 5, 88, 80),
+        (10, 10, 97, 80),    # 20s of normal, then nothing for 40s
+        (70, 40, 97, 80),
+    ])
+
+    got = _infer(db_session, patient)
+
+    assert got.outcome == "recovery"
+    # Counted from the second run, not from the first.
+    assert (got.end_time - START).total_seconds() == pytest.approx(
+        70 + RECOVERY_SECONDS, abs=2)
+
+
+# --- monitoring stopping ---------------------------------------------------
+
+def test_ends_at_the_last_sample_before_a_gap(db_session, patient):
+    """Alert 1308's shape: data stops, and resumes thirteen hours later.
+
+    Reading the first sample after the gap as the recovery would put this
+    episode at thirteen hours; it was about a minute.
+    """
+    _samples(db_session, patient.id, [
+        (0, 15, 88, 80),                 # 30s of desat, then silence
+        (13 * 3600, 40, 97, 80),
+    ])
+
+    got = _infer(db_session, patient)
+
+    assert got.outcome == "monitoring_ended"
+    assert (got.end_time - START).total_seconds() == pytest.approx(28, abs=2)
+
+
+def test_the_alert_2220_shape_a_recovery_cut_short_by_a_gap(db_session, patient):
+    """The row that was recorded as 381.7 minutes long.
+
+    Twenty-two seconds of normal readings -- short of the thirty the rule
+    wants -- then the sensor came off for six hours. The old engine took the
+    first sample on its return as proof the patient had been well all along.
+    """
+    _samples(db_session, patient.id, [
+        (0, 1, 89, 92),          # the desat: a single sample
+        (2, 12, 90, 90),         # 22s of normal, then nothing
+        (6 * 3600, 40, 95, 85),
+    ])
+
+    got = _infer(db_session, patient)
+
+    assert got.outcome == "monitoring_ended"
+    minutes = (got.end_time - START).total_seconds() / 60
+    assert minutes < 1, f"expected well under a minute, got {minutes:.1f}"
+
+
+def test_a_long_disconnect_run_counts_as_a_gap(db_session, patient):
+    """A probe left off streams -1 at full cadence: rows, but no readings.
+
+    Nothing here is a hole in the *sample* stream, so a gap rule measured on
+    the last row of any kind would never fire and the alert would be recorded
+    as lasting the whole probe-off.
+    """
+    _samples(db_session, patient.id, [
+        (0, 15, 88, 80),
+        (30, 900, -1, -1),       # 30 minutes of nothing-readings
+        (1830, 40, 97, 80),
+    ])
+
+    got = _infer(db_session, patient)
+
+    assert got.outcome == "monitoring_ended"
+    assert (got.end_time - START).total_seconds() == pytest.approx(28, abs=2)
+
+
+def test_a_short_disconnect_blip_does_not_end_the_alert(db_session, patient):
+    """A momentary probe re-seat should not chop the episode in two."""
+    _samples(db_session, patient.id, [
+        (0, 15, 88, 80),
+        (30, 5, -1, -1),         # 10s of probe-off, far short of the gap
+        (40, 5, 88, 80),         # still desaturating
+        (50, 40, 97, 80),
+    ])
+
+    got = _infer(db_session, patient)
+
+    assert got.outcome == "recovery"
+    assert (got.end_time - START).total_seconds() == pytest.approx(
+        50 + RECOVERY_SECONDS, abs=2)
+
+
+def test_a_stream_that_simply_ends_closes_at_the_last_sample(db_session, patient):
+    """Ids 143/573: two normal samples, then no data for seventeen days.
+
+    A gap is only visible when a later sample exists to measure against, so a
+    stream that just stops needs its own answer rather than falling through to
+    "cannot tell".
+    """
+    _samples(db_session, patient.id, [(0, 22, 88, 80), (44, 2, 90, 99)])
+
+    got = _infer(db_session, patient)
+
+    assert got.outcome == "monitoring_ended"
+    assert (got.end_time - START).total_seconds() == pytest.approx(46, abs=2)
+
+
+def test_a_stuck_sensor_bounds_the_alert(db_session, patient):
+    """A reading frozen at one value is a fault, not an endless desaturation."""
+    _samples(db_session, patient.id, [(0, 900, 88, 70)])
+
+    got = _infer(db_session, patient)
+
+    assert got.outcome == "monitoring_ended"
+    assert got.detail == "stuck_sensor"
+    assert (got.end_time - START).total_seconds() < 120
+
+
+def test_no_samples_at_all_gives_a_zero_length_episode(db_session, patient):
+    got = _infer(db_session, patient)
+
+    assert got.outcome == "no_data"
+    assert got.end_time == START
+
+
+def test_an_episode_still_running_is_left_alone(db_session, patient):
+    """Unbroken, genuinely out-of-range readings past the lookahead bound.
+
+    Truncating this at the bound would be inventing an answer, so the row must
+    stay open rather than be given a plausible-looking end. The readings vary
+    so this is not mistaken for a stuck sensor, and the stream continues past
+    the bound so it is not mistaken for monitoring having stopped.
+    """
+    _samples(db_session, patient.id, _restless_alarm(400))
+
+    got = infer_alert_end(
+        db_session, patient_id=patient.id, start_time=START,
+        thresholds=THRESHOLDS, max_lookahead_minutes=10,
+    )
+
+    assert got.outcome == "indeterminate"
+    assert got.end_time is None
+
+
+def test_an_end_can_never_land_before_the_start(db_session, patient):
+    """The scan reaches back before start_time to catch the opening sample."""
+    _samples(db_session, patient.id, [(-2, 1, 88, 80), (3600, 10, 97, 80)])
+
+    got = _infer(db_session, patient)
+
+    assert got.end_time >= START
+
+
+# --- the sweep -------------------------------------------------------------
+
+def test_the_sweep_closes_a_stranded_alert_and_records_how(db_session, patient):
+    _samples(db_session, patient.id, [(0, 15, 88, 80), (30, 40, 97, 80)])
+    alert = _alert(db_session, patient.id)
+
+    summary = sweep_open_alerts(db_session, now=START + timedelta(hours=2))
+
+    assert summary["closed"] == 1
+    db_session.refresh(alert)
+    assert alert.end_time is not None
+    assert alert.end_source == "inferred_recovery"
+    assert alert.end_time.tzinfo is not None
+
+
+def test_the_sweep_leaves_alerts_inside_the_grace_window_alone(db_session, patient):
+    """An episode the live engine may still be managing is not ours to close."""
+    _samples(db_session, patient.id, [(0, 15, 88, 80), (30, 40, 97, 80)])
+    alert = _alert(db_session, patient.id)
+
+    summary = sweep_open_alerts(db_session, now=START + timedelta(minutes=5))
+
+    assert summary["examined"] == 0
+    db_session.refresh(alert)
+    assert alert.end_time is None
+
+
+def test_the_sweep_gives_up_visibly_rather_than_guessing(db_session, patient):
+    """An alert it cannot resolve stays open, but is marked so it is not
+    rescanned every five minutes forever."""
+    # Unbroken alarm readings running past the two-hour lookahead, so the scan
+    # genuinely reaches its bound with nothing concluded.
+    _samples(db_session, patient.id, _restless_alarm(3700))
+    alert = _alert(db_session, patient.id)
+
+    first = sweep_open_alerts(db_session, now=START + timedelta(hours=3))
+    assert first["indeterminate"] == 1
+    db_session.refresh(alert)
+    assert alert.end_time is None
+    assert alert.end_source == "indeterminate"
+
+    second = sweep_open_alerts(db_session, now=START + timedelta(hours=3))
+    assert second["examined"] == 0
+
+
+def test_the_sweep_respects_its_batch_limit(db_session, patient):
+    _samples(db_session, patient.id, [(0, 15, 88, 80), (30, 40, 97, 80)])
+    for i in range(4):
+        _alert(db_session, patient.id, start=START + timedelta(seconds=i))
+
+    summary = sweep_open_alerts(db_session, now=START + timedelta(hours=2), limit=2)
+
+    assert summary["examined"] == 2
+
+
+def test_the_sweep_ignores_alerts_that_are_already_closed(db_session, patient):
+    _samples(db_session, patient.id, [(0, 15, 88, 80), (30, 40, 97, 80)])
+    _alert(db_session, patient.id, end=START + timedelta(minutes=3))
+
+    assert sweep_open_alerts(db_session, now=START + timedelta(hours=2))["examined"] == 0
+
+
+# --- correcting ends written across a silence ------------------------------
+
+def _mis_closed(db, patient):
+    """Alert 2220's shape, recorded as ending when monitoring came back."""
+    _samples(db, patient.id, [
+        (0, 1, 89, 92), (2, 12, 90, 90), (6 * 3600, 40, 95, 85),
+    ])
+    return _alert(db, patient.id, end=START + timedelta(hours=6, seconds=2))
+
+
+def test_an_end_written_across_a_silence_is_shortened(db_session, patient):
+    alert = _mis_closed(db_session, patient)
+
+    summary = resweep_implausible_closures(db_session, dry_run=False)
+
+    assert summary["rewritten"] == 1
+    db_session.refresh(alert)
+    assert (alert.end_time - START).total_seconds() / 60 < 1
+    assert alert.end_source == "inferred_monitoring_ended"
+    # The value we overwrote is a clinical record; it is kept, not dropped.
+    assert alert.end_time_superseded is not None
+
+
+def test_a_plausible_closure_is_never_touched(db_session, patient):
+    """Continuous data throughout: nothing here is evidence of a problem."""
+    _samples(db_session, patient.id, [(0, 15, 88, 80), (30, 200, 97, 80)])
+    alert = _alert(db_session, patient.id, end=START + timedelta(minutes=4))
+
+    summary = resweep_implausible_closures(db_session, dry_run=False)
+
+    assert summary["selected"] == 0
+    db_session.refresh(alert)
+    assert alert.end_time == START + timedelta(minutes=4)
+    assert alert.end_source is None
+
+
+def test_a_correction_may_only_ever_shorten(db_session, patient):
+    """The failure being undone always overstates, so a rule that cannot
+    lengthen cannot invent alert time."""
+    _samples(db_session, patient.id, [
+        (0, 1, 89, 92), (2, 12, 90, 90), (6 * 3600, 40, 95, 85),
+    ])
+    alert = _alert(db_session, patient.id, end=START + timedelta(seconds=1))
+
+    resweep_implausible_closures(db_session, dry_run=False)
+
+    db_session.refresh(alert)
+    assert alert.end_time == START + timedelta(seconds=1)
+
+
+def test_a_dry_run_changes_nothing(db_session, patient):
+    alert = _mis_closed(db_session, patient)
+    original = alert.end_time
+
+    summary = resweep_implausible_closures(db_session, dry_run=True)
+
+    assert summary["rewritten"] == 1
+    db_session.refresh(alert)
+    assert alert.end_time == original
+    assert alert.end_source is None
+
+
+def test_correcting_twice_changes_nothing_the_second_time(db_session, patient):
+    _mis_closed(db_session, patient)
+
+    resweep_implausible_closures(db_session, dry_run=False)
+    again = resweep_implausible_closures(db_session, dry_run=False)
+
+    assert again["selected"] == 0
+
+
+def test_a_silence_visible_only_past_the_recorded_end_is_still_found(db_session, patient):
+    """The sample that closes an alert is written just after end_time.
+
+    A window clipped at end_time drops it, so the silence before it vanishes
+    and the row looks continuous. That hid a fifth of the affected rows.
+    """
+    _samples(db_session, patient.id, [(0, 1, 89, 92), (2, 12, 90, 90)])
+    end = START + timedelta(hours=6)
+    # The reading that triggered the close, landing microseconds afterwards.
+    _samples_at = end + timedelta(microseconds=300)
+    from schemas.pulse_ox_data import PulseOxData
+    db_session.add(PulseOxData(
+        patient_id=patient.id, timestamp=_samples_at,
+        spo2=95, bpm=85, pa=2.0, created_at=_samples_at,
+    ))
+    alert = _alert(db_session, patient.id, end=end)
+    db_session.commit()
+
+    summary = resweep_implausible_closures(db_session, dry_run=False)
+
+    assert summary["selected"] == 1, "the post-end sample must be in the window"
+    db_session.refresh(alert)
+    assert (alert.end_time - START).total_seconds() / 60 < 1
+
+
+# --- the maintenance endpoint ----------------------------------------------
+
+def test_alert_closures_needs_a_system_administrator(limited_client):
+    resp = limited_client.post(
+        "/api/system/maintenance/alert-closures", json={"dry_run": True})
+    assert resp.status_code == 403

--- a/docs/alert-subsystem-handoff.md
+++ b/docs/alert-subsystem-handoff.md
@@ -1,0 +1,430 @@
+# Monitoring-alert subsystem: what is known
+
+Written 2026-08-19, after PR #141. Intended as the starting point for someone
+investigating the rest of the alert subsystem, so it separates what has been
+checked against the running system from what has only been read in the source.
+
+Every claim is tagged:
+
+- **[VERIFIED]** — checked against the live dev database or a running container,
+  with the command shown or reproducible from [Queries](#reusable-queries).
+- **[READ]** — read directly in the source at the cited `file:line`, not executed.
+- **[INFERRED]** — a conclusion drawn from the above; the reasoning is given so
+  it can be attacked.
+- **[UNVERIFIED]** — believed, but not established. Treat as a question.
+
+## Contents
+
+1. [What PR #141 changed](#1-what-pr-141-changed)
+2. [Beliefs that turned out to be false](#2-beliefs-that-turned-out-to-be-false)
+3. [Open issues](#3-open-issues)
+4. [The dataset, and what it cannot prove](#4-the-dataset-and-what-it-cannot-prove)
+5. [Reusable queries](#reusable-queries)
+6. [Running things](#running-things)
+
+---
+
+## 1. What PR #141 changed
+
+### The defect it fixed
+
+`modules/state_module.py` closes an alert by watching samples arrive. Its
+recovery countdown compared plain wall-clock between the first normal reading
+and *any* later one, with nothing requiring samples in between. **[READ]**
+
+So when a probe came off mid-recovery and the stream resumed hours later, the
+first sample back satisfied "thirty seconds have passed" and `end_time` was
+stamped at the moment monitoring *resumed*. **[VERIFIED]** on alert 2220 — its
+complete sample set between recorded start and end was:
+
+```
+17:13:40  spo2=89   <- alert opens (min_spo2 = 90)
+17:13:42  spo2=90   <- normal, countdown starts
+17:13:44 .. 17:14:04  all normal   <- 22s, short of the 30s rule
+   *** stream stops for 6h 21m ***
+23:35:20  spo2=95   <- elapsed = 6h21m >= 30  ->  end_time = 23:35:20
+```
+
+Real episode: one sample, ~2 seconds. Recorded: 381.7 minutes.
+
+The rows that were never closed at all are the same mechanism plus a process
+restart before the stream resumed: `current_alert_id` lives only in memory
+(`state_module.py:50`), so after a restart nothing knew the alert existed.
+
+### The rule now in force
+
+Defined once in `crud/alert_closure.py` and imported by both the live engine and
+the offline reconstruction, so the two cannot drift.
+
+> An alert ends at the **earlier** of:
+> - **recovery** — `RECOVERY_SECONDS` (30) of *contiguous* all-normal samples
+> - **monitoring ended** — the last valid sample before the stream goes quiet
+>
+> A sample is `disconnected` if `spo2 <= 0 or bpm <= 0`; else `alarm` if outside
+> the thresholds; else `normal`. A disconnected sample **breaks a recovery run**
+> (it is not evidence the patient stayed well) and **does not count as data**
+> (so time spent in it accrues toward the gap).
+
+Both halves of that last sentence are load-bearing and independent:
+
+- Without "breaks the run": probe off, `-1` every 2s for 10 min, then one normal
+  sample → `elapsed >= 30` closes 10 minutes late.
+- Without "not data": a 9.8-hour `-1` run never registers as silence, so the
+  alert is recorded as lasting the whole probe-off.
+
+`GAP_SECONDS = 120`. **[VERIFIED]** cadence is 2.0s at both p50 and p99, so this
+is 60 consecutive missing samples. 10.4% of observed probe-off runs exceed 60s
+but only 3.6% exceed 120s, so 120 fragments fewer real episodes. The value is
+**not** load-bearing for historical reconstruction: the discontinuities in the
+bad data run to thousands of seconds, so anything in [60s, 3000s] selects an
+identical set.
+
+### The sweep, and why it is not redundant
+
+`modules/alert_sweeper.py`, every 300s. The live engine only executes when a
+sample arrives, so it can never close an alert once samples stop entirely
+(reader unplugged, process restarted). The two cover disjoint failures:
+
+| failure | closed by |
+|---|---|
+| stream resumes with a discontinuity | live gap rule |
+| stream never resumes, or process lost `current_alert_id` | sweep |
+
+**[VERIFIED]** the loop starts cleanly: `[alert_sweeper] Sweep loop started` in
+`docker compose logs backend` after a restart.
+
+### Provenance
+
+Migration `047` adds `end_source` and `end_time_superseded` to
+`monitoring_alerts`. Values: `live_recovery`, `live_gap`, `inferred_recovery`,
+`inferred_monitoring_ended`, `inferred_no_data`, `indeterminate`, or NULL
+meaning "closed before provenance was tracked".
+
+`indeterminate` is written with `end_time` still NULL — it marks "we looked and
+could not tell", which keeps the row visibly open while dropping it out of the
+sweep's candidate set so it is not rescanned forever.
+
+### Effect on the dev database **[VERIFIED]**
+
+36 stranded rows closed, 29 corrected. Longest alert on record went from 789.5
+min to 10.1 min. Zero stranded, zero negative durations. Every replaced value is
+preserved in `end_time_superseded`.
+
+```
+ end_source                | count | min_min | max_min
+ (null - pre-existing)     |  2741 |    0.51 |   10.07
+ inferred_monitoring_ended |    34 |    0.00 |    5.20
+ inferred_recovery         |    31 |    0.57 |    4.70
+```
+
+---
+
+## 2. Beliefs that turned out to be false
+
+Recorded so they are not chased again. Each was believed by someone (including
+a prior memory note and an exploring subagent) before being checked.
+
+**"The reader restarts mid-episode and the closing write never lands."**
+FALSE. **[VERIFIED]** — for every one of the 36 stranded alerts, pulse-ox data
+continues seamlessly, with the next sample ~2s after `start_time` and no gap.
+The data was always there; the state machine lost track of it.
+
+**"`end_time` is written from a naive local clock, which explains the absurd
+durations."** FALSE as an explanation. The naive-clock issue was real
+(`datetime.now()` vs `utc_now()`) and is fixed, but it corrupted nothing:
+**[VERIFIED]** `TZ=UTC` in the container, Postgres session TimeZone UTC,
+`datetime.now() == datetime.utcnow()`, and `SELECT count(*) FROM
+monitoring_alerts WHERE end_time < start_time` returns **0**. A local-time write
+would produce end *before* start — the wrong sign for what was observed.
+
+**"`/api/monitoring/alerts-list` and the dashboard silently use the wrong
+thresholds (95/100/60/100)."** FALSE as stated — see [3.4](#34-a-dead-cluster-in-crudmonitoringpy).
+The uppercase-key bug is real but sits in code no route reaches.
+
+**"Patients 2 and 4 streaming concurrently is evidence the single-scalar
+`current_alert_id` bug fires in practice."** FALSE — see
+[section 4](#4-the-dataset-and-what-it-cannot-prove). It was a bulk copy, not
+concurrent streams.
+
+---
+
+## 3. Open issues
+
+Ranked by what seems most worth resolving first.
+
+### 3.1 Alert state is per-process, not per-patient
+
+`self.current_alert_id`, `self.alert_recovery_start_time` and the new
+`self.alert_last_valid_sample_time` are single scalars on the `StateModule`
+instance (`state_module.py:50-57`). **[READ]**
+
+**[INFERRED]** consequences with two patients streaming through one process:
+
+- While patient A has an open alert, `current_alert_id is not None`, so patient
+  B's out-of-range samples take the ALARM branch and **never open a row**.
+- Patient B's normal samples run the recovery countdown for patient A's alert
+  and can close it.
+- `alert_last_valid_sample_time` is shared, so patient B's samples mask a gap in
+  patient A's stream — the gap rule simply fails to fire.
+
+**Direction of the failure matters:** a masked gap means the live rule does not
+fire, and the sweep (which *is* per-alert and per-patient) picks the row up
+later. So this degrades the fix rather than corrupting data. The missing-row
+case is the more serious half.
+
+**[UNVERIFIED]** — this has never been observed. This install has only ever had
+one real stream (section 4), so there is no evidence either way in the data.
+
+Suggested: rehydrate state from `WHERE end_time IS NULL` on startup and key it by
+`patient_id`. Note that rehydration also fixes the restart case at its source.
+
+### 3.2 Nothing closes an alert on disconnect or shutdown
+
+- Reader WebSocket teardown (`routes/readers.py:723-733`) calls
+  `connection_manager.disconnect` and `_publish_reader_availability(online=False)`
+  and nothing else. It does not notify `StateModule`. **[READ]**
+- `shutdown_event` (`main.py:400-411`) shuts down MQTT and the event bus only.
+  **[READ]**
+- **[VERIFIED]** nothing consumes reader availability for this purpose — the only
+  references are in `mqtt/service.py` and a test.
+
+The sweep now covers the consequences within ~5 minutes. Closing at the source
+would make the recorded end more accurate (it would be the last real sample
+rather than requiring reconstruction), so this is a quality improvement rather
+than a correctness hole.
+
+### 3.3 `start_data_id` / `end_data_id` are NULL on every row ever written
+
+**[VERIFIED]** — `SELECT count(*) FROM monitoring_alerts WHERE start_data_id IS
+NOT NULL` returns 0 across all 2,806 rows.
+
+Cause, **[READ]**: `_save_pulse_ox_data` (`state_module.py:197-214`) discards the
+value returned by `crud/vitals.save_pulse_ox_data`, and `data_point`
+(`state_module.py:174-180`) is built with keys `timestamp/spo2/bpm/perfusion/raw`
+only. So `data_point.get("id")` at the `start_monitoring_alert` call site is
+always `None`. `end_data_id` is never passed by any code path at all.
+
+**[INFERRED]** knock-on: `get_monitoring_alerts(detailed=True)` guards its data
+lookup with `if detailed and row.start_data_id:` (`crud/monitoring.py:81`), which
+is therefore never true — the `data_points` key is never populated. That block
+also contains a genuine expression bug, `(row.end_data_id is None) | (...)`,
+which evaluates the Python `is None` to a bool before the bitwise `|`. It is
+unreachable today, so fixing the id plumbing would expose it.
+
+### 3.4 A dead cluster in `crud/monitoring.py`
+
+**[VERIFIED]** `routes/monitoring.py:38-40` imports exactly seven names from
+`crud.monitoring`. These functions are imported by no route and call only each
+other:
+
+`get_alerts_list`, `get_alert_summary`, `get_active_alerts_count`,
+`get_monitoring_dashboard_data`, `check_system_health`,
+`get_vital_history_for_monitoring`
+
+They matter for two reasons:
+
+1. They read **uppercase** setting keys — `get_setting_value(db, 'MIN_SPO2', 95)`
+   at `crud/monitoring.py:637-640` and `:993-996`. **[VERIFIED]** only lowercase
+   keys exist in `settings`, and `get_setting_value` does an exact match, so
+   these always fall back to 95/100/60/100 rather than the configured
+   90/100/55/155. Harmless while dead; a trap if anything is ever wired to them.
+2. They implement a **second, parallel notion of an alert** — synthesising
+   ephemeral alert dicts by re-scanning `pulse_ox_data` against thresholds,
+   rather than reading `monitoring_alerts`. Two different answers to "what were
+   the alerts?" exist in the codebase.
+
+Suggested: delete, or wire up and fix the keys. Deciding which is the real
+question.
+
+Also dead: `save_pulse_ox_data` in `crud/monitoring.py:573` is a duplicate of the
+live one in `crud/vitals.py:362` and takes no `patient_id`. **[VERIFIED]** no
+callers.
+
+### 3.5 Ventilator and external alarms are never recorded
+
+**[VERIFIED]** `record_ventilator_alarm`, `record_external_pulse_ox_alarm` and
+`clear_external_alarm` (`crud/monitoring.py:146-178`) are placeholders that log
+and return `True`; they have zero callers.
+
+**[INFERRED]** so `ExternalAlarm` and `VentilatorAlert` rows are never created,
+despite `schemas/external_alarm.py` carrying an FK to `monitoring_alerts.id`.
+`external_alarm_triggered` on an alert row is set only by the
+`alert_type="disconnected"` branch of `_start_pulse_ox_alert`, which **[READ]**
+is itself never reached — nothing passes that argument.
+
+### 3.6 A third divergent threshold source
+
+**[VERIFIED]** `routes/core.py:31-34` reads `MIN_SPO2`/`MAX_SPO2`/`MIN_BPM`/
+`MAX_BPM` straight from the environment — not the settings table — and serves
+them from `GET /api/limits` (`routes/core.py:76-81`). Those env vars are **not
+set** in this deployment, so the endpoint returns nulls.
+
+So there are three answers to "what are the alarm thresholds?": the settings
+table (authoritative, used by the engine and by `crud/alert_closure`), the
+uppercase keys in the dead cluster, and this endpoint's env vars.
+
+### 3.7 Sweeper concurrency assumption
+
+**[READ]** `sweep_open_alerts` takes no lock — no `SELECT ... FOR UPDATE SKIP
+LOCKED`. Two instances would both scan. Writes are idempotent so the cost is
+wasted work rather than wrong data, and `serve.py:92` runs the HTTPS listener
+with `lifespan="off"` specifically so `startup_event` fires once. Worth
+revisiting if uvicorn ever runs `--workers > 1`.
+
+---
+
+## 4. The dataset, and what it cannot prove
+
+Understanding this prevents a specific wrong conclusion.
+
+**[VERIFIED]** row counts:
+
+```
+patients:  1 John Carty | 2 Elijah Carty (active) | 4 Elijah Carty (INACTIVE)
+           5 Test Testerson | 9 Jane Doe (no account)
+
+monitoring_alerts:  p2 = 2400 (2026-04-01 .. 2026-08-19)
+                    p4 =  405 (2026-04-01 .. 2026-05-05)
+                    p5 =    1
+
+pulse_ox_data:      p2 = 3,681,172    p4 = 477,396    p9 = 120
+```
+
+Patients 2 and 4 are **the same person**, patient 4 being an inactive duplicate.
+**[VERIFIED]** all 405 of patient 4's alerts share an exact microsecond
+`start_time` with a patient-2 alert, and on a sampled day both carry exactly
+15,163 pulse-ox rows with identical timestamps.
+
+**[INFERRED] it was a bulk copy, not a live dual-write.** Patient 2's alerts
+occupy ids 1–398 and patient 4's occupy 406–810 — contiguous blocks, not
+interleaved. Live concurrent writes would interleave. `created_at` equals
+`start_time` on both copies, consistent with a field-preserving restore
+(`crud/backup.py` re-inserts archived rows verbatim).
+
+There is a second, independent argument for the same conclusion: if the two
+streams *had* been live and concurrent, the single-scalar `current_alert_id`
+(issue 3.1) would have suppressed the second patient's alerts entirely. Both
+sets exist, so they were not written concurrently.
+
+**Consequence for issue 3.1:** this install has never run two concurrent
+patient streams, so **this dataset cannot demonstrate or refute the per-patient
+bug**. Investigating it needs a synthetic two-patient test, not a query.
+
+**Also note:** the PR #141 backfill corrected patient 4's duplicate rows too
+(ids 409, 486–489, 573, 632, 791, 798 appear in the corrected set). That is
+correct — they are copies of the same episodes — but it means the 65 corrected
+rows are not 65 distinct clinical events.
+
+Whether the 810 duplicated rows and the inactive patient 4 should be cleaned up
+is an open question, out of scope for #141.
+
+---
+
+## Reusable queries
+
+Watch out for one trap when writing new ones. **[VERIFIED]**: `end_time` is
+stamped from a timestamp captured *before* the triggering sample row is written,
+so that sample lands a few hundred microseconds **after** `end_time` (alert 2220:
+`23:35:20.701843` vs `23:35:20.701577`). `start_time` has the mirror problem. A
+plain `BETWEEN start_time AND end_time` silently drops both boundary samples —
+this hid 5 of the 29 mis-closed rows on the first pass. Widen both bounds by ~2s.
+
+**Health check — should be all zeros:**
+
+```sql
+SELECT count(*) FILTER (WHERE end_time IS NULL AND end_source IS NULL) AS stranded,
+       count(*) FILTER (WHERE end_time < start_time)                   AS negative,
+       count(*) FILTER (WHERE end_source = 'indeterminate')            AS gave_up,
+       round(max(EXTRACT(EPOCH FROM (end_time-start_time))/60)::numeric,1) AS longest_min
+FROM monitoring_alerts;
+```
+
+**Find an end written across a silence** (the selection predicate the resweep
+uses; both terms are required):
+
+```sql
+WITH windowed AS (
+    SELECT a.id, a.end_time, p.timestamp,
+           LAG(p.timestamp) OVER (PARTITION BY a.id ORDER BY p.timestamp) AS prev_ts
+    FROM monitoring_alerts a
+    JOIN pulse_ox_data p
+      ON p.patient_id = a.patient_id
+     AND p.timestamp >  a.start_time - interval '2 seconds'
+     AND p.timestamp <= a.end_time   + interval '2 seconds'
+     AND p.spo2 > 0 AND p.bpm > 0
+    WHERE a.end_time IS NOT NULL
+)
+SELECT id,
+       MAX(EXTRACT(EPOCH FROM (timestamp - prev_ts)))        AS max_gap,
+       EXTRACT(EPOCH FROM (end_time - MAX(timestamp)))       AS silence_before_close
+FROM windowed GROUP BY id, end_time
+HAVING GREATEST(COALESCE(MAX(EXTRACT(EPOCH FROM (timestamp - prev_ts))), 0),
+                COALESCE(EXTRACT(EPOCH FROM (end_time - MAX(timestamp))), 0)) > 120;
+```
+
+**Probe-off runs** (the `-1` sentinel, which is why silence is measured in valid
+samples):
+
+```sql
+WITH d AS (
+  SELECT timestamp, spo2,
+         row_number() OVER (ORDER BY timestamp)
+       - row_number() OVER (PARTITION BY (spo2 <= 0) ORDER BY timestamp) AS grp
+  FROM pulse_ox_data WHERE patient_id = 2)
+SELECT count(*) AS runs,
+       round(max(EXTRACT(EPOCH FROM (mx-mn)))::numeric,0) AS longest_s
+FROM (SELECT grp, min(timestamp) mn, max(timestamp) mx
+      FROM d WHERE spo2 <= 0 GROUP BY grp) r;
+```
+
+**Sample cadence** (establishes what counts as a gap):
+
+```sql
+WITH d AS (SELECT timestamp, lag(timestamp) OVER (ORDER BY timestamp) AS prev
+           FROM pulse_ox_data WHERE patient_id = 2 AND timestamp > now() - interval '7 days')
+SELECT percentile_disc(0.5)  WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (timestamp-prev))) AS p50,
+       percentile_disc(0.99) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (timestamp-prev))) AS p99
+FROM d WHERE prev IS NOT NULL;
+```
+
+---
+
+## Running things
+
+```bash
+bash scripts/run_tests.sh          # backend gate, ephemeral Timescale. 710 tests.
+npm test && npm run lint           # from frontend/. 1005 tests; lint is --max-warnings 0
+docker compose exec backend alembic upgrade head
+```
+
+Reconstruction is exposed as a superuser endpoint, dry-run by default:
+
+```bash
+POST /api/system/maintenance/alert-closures
+     {"dry_run": true, "include_open": true, "include_closed": true}
+```
+
+It returns per-alert old/new times and the thresholds used. **Run it dry and
+read the output before applying** — applying rewrites clinical records.
+
+Two gotchas when poking at this from a shell:
+
+- A bare `python -c` script that touches the ORM fails with
+  `expression 'VentilatorAlert' failed to locate a name` — the mappers are only
+  fully registered once `main` is imported. Start such scripts with
+  `import main`. Raw-SQL paths are unaffected, which is why
+  `crud/alert_closure.py` uses `text()` throughout.
+- `crud/settings.get_setting` swallows exceptions and returns the default, so a
+  mapper failure shows up as thresholds silently reverting to 90/100/55/155
+  rather than as an error.
+
+The relevant code:
+
+| file | role |
+|---|---|
+| `crud/alert_closure.py` | the rule, the reconstruction, the sweep and resweep passes |
+| `modules/state_module.py` | the live engine; `_check_pulse_ox_thresholds` is the state machine |
+| `modules/alert_sweeper.py` | the 300s background loop |
+| `crud/monitoring.py` | alert CRUD, plus the dead cluster in 3.4 |
+| `routes/reports.py` | overnight (~line 600) and weekly (~line 1290) alert sections |
+| `tests/test_alert_closure.py` | 30 tests, each named for the real row whose shape it reproduces |

--- a/frontend/src/pages/admin-v2/AdminV2ReportsOvernight.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2ReportsOvernight.jsx
@@ -51,6 +51,15 @@ Chart.register(annotationPlugin);
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const EPISODE_PREVIEW = 2;
 
+// Why an episode's end had to be worked out afterwards. "Recovered" and "the
+// sensor stopped reporting" are different statements about the same number, so
+// the marker says which one it is rather than just flagging it as an estimate.
+const END_INFERRED_HINT = {
+  inferred_recovery: 'Ended when the readings had held steady — worked out from the sensor record',
+  inferred_monitoring_ended: 'Ended when the sensor stopped reporting, so the episode may have continued unseen',
+  inferred_no_data: 'No sensor readings for this episode, so no length could be established',
+};
+
 const toDateStr = (d) =>
   `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 
@@ -461,7 +470,13 @@ const AdminV2ReportsOvernight = () => {
                   figures above cover only the rest. Say so rather than let the
                   total read as the whole night. */}
               {data.alerts.unclosed > 0 && (
-                <> · {data.alerts.unclosed} never closed, not counted in the time</>
+                <> · {data.alerts.unclosed} still open, not counted in the time</>
+              )}
+              {/* These do count toward the figures, but their end was worked
+                  out from the sensor record afterwards rather than watched
+                  happening, so the times are close rather than exact. */}
+              {data.alerts.inferred > 0 && (
+                <> · {data.alerts.inferred} ended by inference</>
               )}
             </div>
             <div className="rpt-table-wrap">
@@ -477,7 +492,11 @@ const AdminV2ReportsOvernight = () => {
                         {e.nadir != null ? `${e.nadir}%` : '—'}
                       </td>
                       <td>{e.bpm_min != null ? `${e.bpm_min}–${e.bpm_max}` : '—'}</td>
-                      <td>{formatMinutes(e.duration_minutes)}</td>
+                      {/* An inferred end is an estimate; mark it as one rather
+                          than let it sit next to measured durations unqualified. */}
+                      <td title={e.end_inferred ? END_INFERRED_HINT[e.end_source] : undefined}>
+                        {e.end_inferred ? '≈' : ''}{formatMinutes(e.duration_minutes)}
+                      </td>
                       <td className="rpt-muted">{e.oxygen_used ? `${e.oxygen_highest || ''}L` : '—'}</td>
                     </tr>
                   ))}

--- a/frontend/src/pages/admin-v2/AdminV2ReportsOvernight.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2ReportsOvernight.test.jsx
@@ -243,7 +243,30 @@ describe('AdminV2ReportsOvernight', () => {
     // Both episodes listed, and the total says what it left out rather than
     // quietly reading as the whole night.
     expect(await screen.findByText(/2 episodes/)).toBeInTheDocument();
-    expect(screen.getByText(/1 never closed, not counted in the time/)).toBeInTheDocument();
+    expect(screen.getByText(/1 still open, not counted in the time/)).toBeInTheDocument();
+  });
+
+  it('marks an episode whose end was worked out after the fact', async () => {
+    body = payload({
+      alerts: {
+        total: 2, total_duration_minutes: 4, longest_duration_minutes: 3, inferred: 1,
+        items: [
+          { start_time: '2026-08-18T03:13:00Z', end_time: '2026-08-18T03:16:00Z',
+            duration_minutes: 3, spo2_min: 88, spo2_max: 95, bpm_min: 70, bpm_max: 90,
+            oxygen_used: false, oxygen_highest: null, unclosed: false, end_inferred: false },
+          { start_time: '2026-08-19T03:06:00Z', end_time: '2026-08-19T03:07:00Z',
+            duration_minutes: 1, spo2_min: 81, spo2_max: 95, bpm_min: 70, bpm_max: 90,
+            oxygen_used: false, oxygen_highest: null, unclosed: false,
+            end_inferred: true, end_source: 'inferred_monitoring_ended' },
+        ],
+      },
+    });
+    setup();
+    // It counts toward the total, but the reader is told the number is an
+    // estimate and why.
+    expect(await screen.findByText(/1 ended by inference/)).toBeInTheDocument();
+    const estimated = screen.getByTitle(/the sensor stopped reporting/i);
+    expect(estimated.textContent).toMatch(/^\u2248/);
   });
 
   it('surfaces a failed report', async () => {


### PR DESCRIPTION
Closes the gap that left 36 `monitoring_alerts` rows stranded with `end_time IS NULL`, and fixes the defect that produced them.

## What was wrong

The recovery countdown in `state_module.py` compared wall-clock between the first normal reading and any later one, with **nothing requiring samples in between**. When a probe came off mid-recovery and the stream resumed hours later, the first sample back satisfied "30 seconds have passed" and the alert was stamped closed at the moment monitoring *resumed*.

Proven on alert 2220 — its complete sample set between the recorded start and end:

```
17:13:40  spo2=89   <- alert opens (min_spo2 = 90)
17:13:42  spo2=90   <- normal, countdown starts
17:13:44 .. 17:14:04  all normal   <- 22s, just short of the 30s rule
   *** stream stops for 6h 21m ***
23:35:20  spo2=95   <- elapsed = 6h21m >= 30  ->  end_time = 23:35:20
```

Actual desat: one sample, ~2 seconds. Recorded: **381.7 minutes**.

The 36 orphans are the same mechanism plus a restart before the stream resumed, so `current_alert_id` (in-memory) was lost and no close ever ran.

| | count | detail |
|---|---|---|
| Legitimate | 2,741 | 0.5–10.1 min, continuous streams |
| Closed but absurd | 29 | up to 789.5 min; every one has a stream discontinuity of 3,446–47,242s |
| Never closed | 36 | 2026-04-02 → 2026-08-19 |

## What changed

- **The countdown now requires continuous samples**, and a stream going quiet ends the alert at the last real reading. Silence is measured in *valid* samples, not rows — a probe left off keeps streaming at full cadence carrying `-1`, and those runs reach **9.8 hours** here. Counting them as data claims the patient was in alarm throughout.
- **A sweep every 5 minutes** closes what the live path structurally cannot. These cover disjoint failures and neither is redundant: the live engine only runs when a sample arrives, so it can never close an alert once samples stop entirely.
- **Provenance column** (`end_source`). "We watched them recover" and "the sensor stopped and we stopped knowing" are different clinical statements, so they are different values, and the report says which rather than presenting an estimate as a measurement. `end_time_superseded` keeps any value a correction replaced.
- **Reports** now count inferred ends toward the durations (they have real lengths) and mark them `≈` with a tooltip; "never closed" becomes "still open".

## Results on the dev database

36 stranded rows closed, 29 corrected. Longest alert on record: **789.5 min → 10.1 min**. Zero stranded, zero negative durations, no original value discarded.

Selection for correction is by *evidence of a silence*, never by duration — a long alert is not by itself wrong, but an end written across a stretch with no data is. Corrections may only ever shorten.

## Test plan
- [x] `bash scripts/run_tests.sh` — 710 passed (was 708; 30 new in `test_alert_closure.py`)
- [x] `npm test` — 1005 passed; `npm run lint` clean
- [x] Migration applied; dry-run reviewed before applying
- [x] Overnight report for 2026-08-18 (the two most recent orphans) now shows real durations marked inferred, where it previously showed none

Test cases are named for the real rows they stand for — alert 2220's shape, ids 143/573 (stream ends), id 1308 (13-hour gap), the 9.8h `-1` run, and the sample landing 300µs past `end_time`.

## Not fixed here

The state machine is still a single process-wide scalar rather than per-patient, and reader disconnect / shutdown still don't close alerts — the sweeper covers the consequences, not the cause. Worth a follow-up issue, along with `start_data_id`/`end_data_id` never being populated and the UPPERCASE threshold keys in `crud/monitoring.py:625,981` that have never matched anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B599mEt9oUqjMEzvUSNKDe