### PR TITLE
Rebuild the day timeline, and give each patient a definition of a bad room

### DIFF
--- a/backend/alembic/versions/048_patient_env_ranges.py
+++ b/backend/alembic/versions/048_patient_env_ranges.py
@@ -1,0 +1,60 @@
+"""Per-patient bounds for the room a patient is in
+
+Revision ID: 048_patient_env_ranges
+Revises: 047_monitoring_alert_end_source
+Create Date: 2026-08-19
+
+The environment data has been charted since the env epic, but nothing said
+what a *bad* room looked like for a given patient, so nothing could flag one.
+This table holds that judgement.
+
+Separate from patient_vital_ranges on purpose. That table feeds
+vital_validation, which gates saving a reading; a CO2 bound has no business
+in that path, and sharing the table would put it there.
+
+Two bands per metric — caution and critical — because the timeline needs
+three states for PM2.5 (green / amber / red) and two thresholds are the
+smallest thing that produces three states. The same two bands describe the
+other metrics' high/low flags, so there is one shape rather than one per
+metric.
+
+Every bound is nullable and NULL means "no bound on this side", which is not
+the same as zero: CO2 and PM2.5 have ceilings but no meaningful floor, and a
+0 floor would read as one. A patient with no rows at all falls back to the
+defaults in crud/env_ranges.py rather than to "anything goes".
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '048_patient_env_ranges'
+down_revision = '047_monitoring_alert_end_source'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'patient_env_ranges',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('patient_id', sa.Integer(), nullable=False),
+        sa.Column('metric', sa.String(length=50), nullable=False),
+        sa.Column('caution_min', sa.Float(), nullable=True),
+        sa.Column('caution_max', sa.Float(), nullable=True),
+        sa.Column('critical_min', sa.Float(), nullable=True),
+        sa.Column('critical_max', sa.Float(), nullable=True),
+        sa.Column('note', sa.Text(), nullable=True),
+        sa.Column('set_by', sa.Integer(), nullable=True),
+        sa.Column('set_at', sa.TIMESTAMP(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['patient_id'], ['patients.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['set_by'], ['users.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('patient_id', 'metric', name='uq_patient_env_range'),
+    )
+    op.create_index('ix_patient_env_ranges_patient_id', 'patient_env_ranges',
+                    ['patient_id'])
+
+
+def downgrade():
+    op.drop_index('ix_patient_env_ranges_patient_id', table_name='patient_env_ranges')
+    op.drop_table('patient_env_ranges')

--- a/backend/crud/env_ranges.py
+++ b/backend/crud/env_ranges.py
@@ -1,0 +1,112 @@
+#
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Per-patient environment bounds: resolve (defaults + overrides) and upsert."""
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from models.patient_env_range import PatientEnvRange
+
+# The metrics a room is judged on. Room-scoped only: these describe the air
+# the patient is actually in, which is the thing a bound can be acted on.
+# Outdoor readings are context for correlation, not something a carer can fix,
+# so they are deliberately absent.
+ENV_RANGE_METRICS = ('temperature', 'relative_humidity', 'co2', 'pm25')
+
+# Starting points, not clinical guidance — every one is overridable per
+# patient, and the sources are ordinary public guidance rather than anything
+# specific to a condition:
+#   temperature/humidity  ASHRAE-style indoor comfort bands
+#   co2                   1000 ppm is the usual ventilation complaint level;
+#                         2000 ppm is where drowsiness/headache get reported
+#   pm25                  the US AQI breakpoints (12 = good/moderate,
+#                         35 = moderate/unhealthy-for-sensitive-groups)
+# A patient with lung disease will want tighter numbers; that is the point of
+# the table.
+DEFAULT_ENV_RANGES = {
+    'temperature':       {'caution_min': 18.0, 'caution_max': 24.0,
+                          'critical_min': 15.0, 'critical_max': 28.0},
+    'relative_humidity': {'caution_min': 30.0, 'caution_max': 60.0,
+                          'critical_min': 20.0, 'critical_max': 70.0},
+    'co2':               {'caution_min': None, 'caution_max': 1000.0,
+                          'critical_min': None, 'critical_max': 2000.0},
+    'pm25':              {'caution_min': None, 'caution_max': 12.0,
+                          'critical_min': None, 'critical_max': 35.0},
+}
+
+_BOUNDS = ('caution_min', 'caution_max', 'critical_min', 'critical_max')
+
+
+def resolve_env_ranges(db: Session, patient_id: int) -> list:
+    """Every judged metric for a patient, defaults filled in where unset.
+
+    Always returns one entry per metric in ENV_RANGE_METRICS so the caller
+    never has to distinguish "not configured" from "not a metric we judge".
+    ``source`` says which it is, because a default bound and a bound someone
+    chose for this patient carry different authority and the UI should not
+    present them identically.
+    """
+    stored = {
+        r.metric: r for r in db.query(PatientEnvRange)
+        .filter(PatientEnvRange.patient_id == patient_id).all()
+    }
+    out = []
+    for metric in ENV_RANGE_METRICS:
+        defaults = DEFAULT_ENV_RANGES.get(metric, {})
+        row = stored.get(metric)
+        entry = {'metric': metric, 'source': 'patient' if row else 'default'}
+        for key in _BOUNDS:
+            entry[key] = getattr(row, key) if row else defaults.get(key)
+        entry['note'] = row.note if row else None
+        out.append(entry)
+    return out
+
+
+def upsert_patient_env_ranges(db: Session, patient_id: int, ranges: list,
+                              set_by: Optional[int] = None) -> None:
+    """Apply a set of per-patient overrides.
+
+    A metric whose bounds are all None is deleted rather than stored as a row
+    of nulls — "cleared" has to mean "fall back to the default", or a carer
+    who empties the fields would silently switch the metric off instead.
+    """
+    now = datetime.now(timezone.utc)
+    existing = {
+        r.metric: r for r in db.query(PatientEnvRange)
+        .filter(PatientEnvRange.patient_id == patient_id).all()
+    }
+    for item in ranges:
+        metric = item.get('metric')
+        if metric not in ENV_RANGE_METRICS:
+            continue
+        values = {k: item.get(k) for k in _BOUNDS}
+        row = existing.get(metric)
+        if all(v is None for v in values.values()) and not item.get('note'):
+            if row:
+                db.delete(row)
+            continue
+        if row is None:
+            row = PatientEnvRange(patient_id=patient_id, metric=metric)
+            db.add(row)
+        for key, value in values.items():
+            setattr(row, key, value)
+        row.note = item.get('note')
+        row.set_by = set_by
+        row.set_at = now
+    db.commit()

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -63,6 +63,7 @@ from models.readers import Reader
 from models.ha_identity import HASeenIdentity
 from models.custom_vital_definition import CustomVitalDefinition
 from models.patient_vital_range import PatientVitalRange
+from models.patient_env_range import PatientEnvRange
 from models.user_messages import UserMessage, UserMessageAcknowledgement
 from models.vent_ingested_files import VentIngestedFile
 
@@ -81,7 +82,7 @@ __all__ = [
     'VentImport', 'VentParameterDictionary', 'VentSample', 'VentDeviceInfo',
     'CompleteItemRequest', 'BulkCompleteRequest', 'Organization', 'OrganizationMembership',
     'OrganizationType', 'PatientAccess', 'AccessLevel', 'Reader', 'CustomVitalDefinition',
-    'PatientVitalRange',
+    'PatientVitalRange', 'PatientEnvRange',
     'UserMessage', 'UserMessageAcknowledgement', 'VentIngestedFile',
     'DMEShipment', 'DMEShipmentItem', 'DMEReceiptItem', 'DMEShipmentAlert', 'DMEShipmentDocument',
     'EnvironmentalObservation', 'HASeenIdentity', 'HAEntityMapping'

--- a/backend/models/patient_env_range.py
+++ b/backend/models/patient_env_range.py
@@ -1,0 +1,63 @@
+#
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from sqlalchemy import (
+    Column, Integer, String, Float, Text, ForeignKey, TIMESTAMP,
+    UniqueConstraint,
+)
+
+from db import Base
+
+
+class PatientEnvRange(Base):
+    """What counts as an acceptable room for one patient.
+
+    Deliberately a separate table from patient_vital_ranges rather than more
+    rows in it. That table feeds vital_validation, which drives the capture
+    flow's out-of-range warning and the 422/409 gate on saving a reading —
+    room CO2 is not a vital, and putting it there would make the capture
+    screen start arguing about the air.
+
+    Two bands per metric, the same shape for every one of them:
+      caution_*  — worth noticing
+      critical_* — worth acting on
+    A metric only needs the sides that mean something. CO2 and PM2.5 have no
+    floor, so their *_min columns stay NULL and nothing reads them; room
+    temperature is bounded both ways. PM2.5's two ceilings are what give the
+    timeline its green / amber / red bar without a third concept.
+
+    NULL on a side means "no bound" — never zero. Absent rows mean the patient
+    has not been configured and the caller falls back to DEFAULT_ENV_RANGES.
+    """
+
+    __tablename__ = 'patient_env_ranges'
+    __table_args__ = (
+        UniqueConstraint('patient_id', 'metric', name='uq_patient_env_range'),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    patient_id = Column(Integer, ForeignKey('patients.id', ondelete='CASCADE'),
+                        nullable=False, index=True)
+    # Key from environment.metrics.METRICS, e.g. 'temperature', 'co2'.
+    metric = Column(String(50), nullable=False)
+    caution_min = Column(Float, nullable=True)
+    caution_max = Column(Float, nullable=True)
+    critical_min = Column(Float, nullable=True)
+    critical_max = Column(Float, nullable=True)
+    note = Column(Text, nullable=True)
+    set_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    set_at = Column(TIMESTAMP(timezone=True), nullable=False)

--- a/backend/routes/environment.py
+++ b/backend/routes/environment.py
@@ -26,7 +26,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from db import get_db
-from dependencies import require_full_auth, require_read_access
+from dependencies import (require_full_auth, require_read_access,
+                          require_permission, get_current_user,
+                          get_current_account_id)
 from crud.environment import (
     BUCKET_INTERVALS, DEFAULT_LIMIT, MAX_LIMIT,
     get_locations, get_observations, get_observations_bucketed,
@@ -35,6 +37,7 @@ from environment import metrics as env_metrics
 from environment import service as env_service
 from environment.registry import registry
 from models.environment import BackfillRequest, ConnectorConfigUpdate
+from pydantic import BaseModel
 
 logger = logging.getLogger("app")
 
@@ -195,3 +198,68 @@ async def start_backfill(
 
     asyncio.create_task(run_backfill(slug, body.days))
     return {"status": "started", "days": body.days}
+
+
+# ---------------------------------------------------------------------------
+# Per-patient room bounds (what counts as a bad room for this patient).
+# ---------------------------------------------------------------------------
+
+class EnvRangeUpdate(BaseModel):
+    metric: str
+    caution_min: Optional[float] = None
+    caution_max: Optional[float] = None
+    critical_min: Optional[float] = None
+    critical_max: Optional[float] = None
+    note: Optional[str] = None
+
+
+class EnvRangesUpdate(BaseModel):
+    patient_id: int
+    ranges: list[EnvRangeUpdate]
+
+
+def _scoped_patient(db: Session, patient_id: int, account_id):
+    from schemas.patient import Patient
+    q = db.query(Patient).filter(Patient.id == patient_id)
+    if account_id is not None:
+        q = q.filter((Patient.account_id == account_id) | (Patient.account_id.is_(None)))
+    return q.first()
+
+
+def _ranges_payload(db: Session, patient_id: int):
+    from crud.env_ranges import resolve_env_ranges
+    return {"patient_id": patient_id, "ranges": resolve_env_ranges(db, patient_id)}
+
+
+@router.get("/ranges")
+async def get_env_ranges(
+    patient_id: int = Query(...),
+    db: Session = Depends(get_db),
+    account_id=Depends(get_current_account_id),
+):
+    """Resolved room bounds for a patient — defaults where nothing is set.
+
+    Not gated on require_read_access, matching /api/vitals/ranges: the
+    timeline flags a bad room in monitoring mode too, and a read-restricted
+    session losing the bounds would silently turn the flags off rather than
+    hide them.
+    """
+    if not _scoped_patient(db, patient_id, account_id):
+        raise HTTPException(status_code=404, detail="Patient not found")
+    return _ranges_payload(db, patient_id)
+
+
+@router.put("/ranges", dependencies=[Depends(require_permission("patients.update"))])
+async def put_env_ranges(
+    body: EnvRangesUpdate,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+    account_id=Depends(get_current_account_id),
+):
+    from crud.env_ranges import upsert_patient_env_ranges
+    if not _scoped_patient(db, body.patient_id, account_id):
+        raise HTTPException(status_code=404, detail="Patient not found")
+    upsert_patient_env_ranges(db, body.patient_id,
+                              [r.model_dump() for r in body.ranges],
+                              set_by=getattr(current_user, "id", None))
+    return _ranges_payload(db, body.patient_id)

--- a/backend/routes/monitoring.py
+++ b/backend/routes/monitoring.py
@@ -429,32 +429,32 @@ async def get_timeline_data(
             'notes': v.notes
         } for v in vitals_query]
 
-        # 7. Monitoring alerts for that day
-        all_alerts = get_monitoring_alerts(
-            db, limit=200, include_acknowledged=True, patient_id=patient_id
-        )
-        alerts = []
-        for a in all_alerts:
-            start_time = a.get('start_time')
-            if start_time:
-                if isinstance(start_time, str):
-                    alert_dt = datetime.fromisoformat(start_time)
-                else:
-                    alert_dt = start_time
-                # Check if alert falls within local day boundaries (in UTC)
-                naive_alert = alert_dt.replace(tzinfo=None) if alert_dt.tzinfo else alert_dt
-                if start_dt <= naive_alert <= end_dt:
-                    end_time = a.get('end_time')
-                    alerts.append({
-                        'start': start_time.isoformat() if hasattr(start_time, 'isoformat') else start_time,
-                        'end': end_time.isoformat() if end_time and hasattr(end_time, 'isoformat') else end_time,
-                        'spo2_alarm': a.get('spo2_alarm_triggered', False),
-                        'hr_alarm': a.get('hr_alarm_triggered', False),
-                        'spo2_min': a.get('spo2_min'),
-                        'bpm_min': a.get('bpm_min'),
-                        'oxygen_used': a.get('oxygen_used', False),
-                        'acknowledged': a.get('acknowledged', False)
-                    })
+        # 7. Monitoring alerts for that day.
+        #
+        # Queried against the day bounds like every other stream above. This
+        # used to pull the 200 most recent alerts for the patient and filter
+        # them down afterwards, which quietly returned nothing for any day
+        # sitting further than 200 alerts back — the timeline then showed a
+        # busy day as having none.
+        from schemas.monitoring_alert import MonitoringAlert
+        alert_rows = db.query(MonitoringAlert).filter(
+            MonitoringAlert.patient_id == patient_id,
+            MonitoringAlert.start_time >= start_dt,
+            MonitoringAlert.start_time <= end_dt
+        ).order_by(MonitoringAlert.start_time.asc()).all()
+        alerts = [{
+            'id': a.id,
+            'start': a.start_time.isoformat() if a.start_time else None,
+            # Null end means still open. Never synthesise one — a fabricated
+            # end becomes a fabricated duration downstream.
+            'end': a.end_time.isoformat() if a.end_time else None,
+            'spo2_alarm': bool(a.spo2_alarm_triggered),
+            'hr_alarm': bool(a.hr_alarm_triggered),
+            'spo2_min': a.spo2_min,
+            'bpm_min': a.bpm_min,
+            'oxygen_used': bool(a.oxygen_used),
+            'acknowledged': bool(a.acknowledged),
+        } for a in alert_rows]
 
         return {
             'date': date_str,

--- a/backend/tests/test_env_ranges.py
+++ b/backend/tests/test_env_ranges.py
@@ -1,0 +1,126 @@
+#
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Per-patient room bounds: defaults, overrides, clearing, and scoping."""
+
+BASE = "/api/environment/ranges"
+
+
+def _by_metric(payload):
+    return {r["metric"]: r for r in payload["ranges"]}
+
+
+def test_defaults_when_nothing_is_configured(admin_client, patient):
+    resp = admin_client.get(f"{BASE}?patient_id={patient.id}")
+    assert resp.status_code == 200
+    ranges = _by_metric(resp.json())
+    assert set(ranges) == {"temperature", "relative_humidity", "co2", "pm25"}
+    assert all(r["source"] == "default" for r in ranges.values())
+    # PM2.5 carries the two AQI breakpoints that give the bar three states.
+    assert ranges["pm25"]["caution_max"] == 12.0
+    assert ranges["pm25"]["critical_max"] == 35.0
+
+
+def test_metrics_without_a_floor_report_none_not_zero(admin_client, patient):
+    """A 0 floor would read as a real bound and flag every clean reading low."""
+    ranges = _by_metric(admin_client.get(f"{BASE}?patient_id={patient.id}").json())
+    assert ranges["co2"]["caution_min"] is None
+    assert ranges["co2"]["critical_min"] is None
+    assert ranges["pm25"]["critical_min"] is None
+    # …while a metric that is bounded both ways keeps its floor.
+    assert ranges["temperature"]["critical_min"] == 15.0
+
+
+def test_override_replaces_the_default_and_is_marked_as_chosen(
+        admin_client, patient):
+    resp = admin_client.put(BASE, json={
+        "patient_id": patient.id,
+        "ranges": [{"metric": "co2", "caution_max": 800, "critical_max": 1500,
+                    "note": "chronic lung disease"}],
+    })
+    assert resp.status_code == 200
+    ranges = _by_metric(resp.json())
+    assert ranges["co2"]["caution_max"] == 800
+    assert ranges["co2"]["critical_max"] == 1500
+    assert ranges["co2"]["source"] == "patient"
+    assert ranges["co2"]["note"] == "chronic lung disease"
+    # Untouched metrics stay on their defaults.
+    assert ranges["pm25"]["source"] == "default"
+
+
+def test_clearing_every_bound_falls_back_rather_than_switching_off(
+        admin_client, patient):
+    admin_client.put(BASE, json={
+        "patient_id": patient.id,
+        "ranges": [{"metric": "temperature", "caution_min": 20, "caution_max": 22}],
+    })
+    assert _by_metric(admin_client.get(f"{BASE}?patient_id={patient.id}").json()
+                      )["temperature"]["source"] == "patient"
+
+    resp = admin_client.put(BASE, json={
+        "patient_id": patient.id,
+        "ranges": [{"metric": "temperature"}],
+    })
+    temp = _by_metric(resp.json())["temperature"]
+    assert temp["source"] == "default"
+    assert temp["caution_min"] == 18.0
+
+
+def test_an_unknown_metric_is_ignored(admin_client, patient):
+    resp = admin_client.put(BASE, json={
+        "patient_id": patient.id,
+        "ranges": [{"metric": "unicorns", "caution_max": 1}],
+    })
+    assert resp.status_code == 200
+    assert "unicorns" not in _by_metric(resp.json())
+
+
+def test_updating_twice_does_not_duplicate_the_row(admin_client, db_session, patient):
+    from models.patient_env_range import PatientEnvRange
+    for value in (900, 950):
+        admin_client.put(BASE, json={
+            "patient_id": patient.id,
+            "ranges": [{"metric": "co2", "caution_max": value}],
+        })
+    rows = db_session.query(PatientEnvRange).filter(
+        PatientEnvRange.patient_id == patient.id,
+        PatientEnvRange.metric == "co2").all()
+    assert len(rows) == 1
+    assert rows[0].caution_max == 950
+
+
+def test_unknown_patient_404s(admin_client):
+    assert admin_client.get(f"{BASE}?patient_id=999999").status_code == 404
+
+
+def test_reading_bounds_survives_a_read_restricted_session(limited_client, patient):
+    """Monitoring mode still flags a bad room; losing the bounds there would
+    turn the flags off rather than hide them."""
+    resp = limited_client.get(f"{BASE}?patient_id={patient.id}")
+    assert resp.status_code == 200
+
+
+def test_writing_bounds_needs_the_patient_permission(limited_client, patient):
+    resp = limited_client.put(BASE, json={
+        "patient_id": patient.id,
+        "ranges": [{"metric": "co2", "caution_max": 800}],
+    })
+    assert resp.status_code == 403
+
+
+def test_requires_auth(client, patient):
+    assert client.get(f"{BASE}?patient_id={patient.id}").status_code == 401

--- a/backend/tests/test_monitoring.py
+++ b/backend/tests/test_monitoring.py
@@ -145,3 +145,87 @@ def test_recent_history_patient_scoped(admin_client, db_session, account, pulse_
 
 def test_recent_history_requires_auth(client, patient):
     assert client.get(f"/api/monitoring/history/recent?patient_id={patient.id}").status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Timeline: the day view's alert list.
+# ---------------------------------------------------------------------------
+
+def _alert(db_session, account, patient, start, end=None, **kw):
+    from schemas.monitoring_alert import MonitoringAlert
+    a = MonitoringAlert(
+        account_id=account.id, patient_id=patient.id,
+        start_time=start, end_time=end, created_at=start, **kw,
+    )
+    db_session.add(a)
+    return a
+
+
+def test_timeline_returns_the_days_alerts(admin_client, db_session, account, patient):
+    from datetime import timedelta
+    day = datetime(2026, 3, 4, 12, 0, tzinfo=timezone.utc)
+    _alert(db_session, account, patient, day, day + timedelta(seconds=82),
+           spo2_alarm_triggered=True, spo2_min=88)
+    db_session.commit()
+
+    resp = admin_client.get(
+        f"/api/monitoring/timeline?patient_id={patient.id}&target_date=2026-03-04")
+    assert resp.status_code == 200
+    alerts = resp.json()["alerts"]
+    assert len(alerts) == 1
+    assert alerts[0]["spo2_alarm"] is True
+    assert alerts[0]["spo2_min"] == 88
+    assert alerts[0]["id"] is not None
+
+
+def test_timeline_leaves_an_open_alert_open(admin_client, db_session, account, patient):
+    day = datetime(2026, 3, 5, 9, 30, tzinfo=timezone.utc)
+    _alert(db_session, account, patient, day, None, hr_alarm_triggered=True)
+    db_session.commit()
+
+    resp = admin_client.get(
+        f"/api/monitoring/timeline?patient_id={patient.id}&target_date=2026-03-05")
+    assert resp.status_code == 200
+    alerts = resp.json()["alerts"]
+    assert len(alerts) == 1
+    # No synthesised end: the client needs the null to say "ongoing" rather
+    # than compute a duration that never happened.
+    assert alerts[0]["end"] is None
+
+
+def test_timeline_finds_an_old_day_behind_many_newer_alerts(
+        admin_client, db_session, account, patient):
+    """The day view used to take the 200 most recent alerts and filter to the
+    day afterwards, so a day sitting further back than that returned none."""
+    from datetime import timedelta
+    old_day = datetime(2026, 1, 2, 8, 0, tzinfo=timezone.utc)
+    _alert(db_session, account, patient, old_day, old_day + timedelta(minutes=1),
+           spo2_alarm_triggered=True)
+    # 250 newer alerts, all on other days.
+    newer = datetime(2026, 2, 1, 0, 0, tzinfo=timezone.utc)
+    for i in range(250):
+        _alert(db_session, account, patient, newer + timedelta(hours=i),
+               newer + timedelta(hours=i, minutes=1))
+    db_session.commit()
+
+    resp = admin_client.get(
+        f"/api/monitoring/timeline?patient_id={patient.id}&target_date=2026-01-02")
+    assert resp.status_code == 200
+    assert len(resp.json()["alerts"]) == 1
+
+
+def test_timeline_alerts_are_patient_scoped(admin_client, db_session, account, patient):
+    from crud.patients import create_patient
+    day = datetime(2026, 3, 6, 10, 0, tzinfo=timezone.utc)
+    other = create_patient(db_session, {
+        "first_name": "Other", "last_name": "Patient",
+        "account_id": account.id, "is_active": True,
+    })
+    db_session.commit()
+    _alert(db_session, account, other, day, day, spo2_alarm_triggered=True)
+    db_session.commit()
+
+    resp = admin_client.get(
+        f"/api/monitoring/timeline?patient_id={patient.id}&target_date=2026-03-06")
+    assert resp.status_code == 200
+    assert resp.json()["alerts"] == []

--- a/frontend/src/components/environment/EnvRangesCard.jsx
+++ b/frontend/src/components/environment/EnvRangesCard.jsx
@@ -1,0 +1,195 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// What counts as a bad room for this patient. Sits beside VitalRangesCard on
+// the patient record because it is the same kind of thing — a bound the care
+// team sets — even though it is stored apart from the clinical ranges.
+//
+// Values are entered by the care team, not supplied as clinical guidance; the
+// defaults are ordinary public comfort/air-quality figures and are labelled as
+// defaults until somebody overrides them.
+import { useCallback, useEffect, useState } from 'react';
+import config, { apiFetch } from '../../config';
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Alert } from '@/components/ui/alert';
+
+// hasFloor marks the metrics where a low reading means something. CO2 and
+// PM2.5 only have ceilings — offering a floor for them would invite a 0 that
+// reads as a real bound and flags every clean reading.
+const ENV_METRICS = [
+  { key: 'temperature', label: 'Room temperature', unit: '°C', hasFloor: true },
+  { key: 'relative_humidity', label: 'Room humidity', unit: '%', hasFloor: true },
+  { key: 'co2', label: 'CO2', unit: 'ppm', hasFloor: false },
+  { key: 'pm25', label: 'PM2.5', unit: 'µg/m³', hasFloor: false },
+];
+const META = Object.fromEntries(ENV_METRICS.map((m) => [m.key, m]));
+const FIELDS = ['critical_min', 'caution_min', 'caution_max', 'critical_max'];
+
+export default function EnvRangesCard({ patientId }) {
+  const [rows, setRows] = useState([]);
+  const [edits, setEdits] = useState({});
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState(null);
+
+  const load = useCallback(async () => {
+    try {
+      const resp = await apiFetch(
+        `${config.apiUrl}/api/environment/ranges?patient_id=${patientId}`);
+      if (resp.ok) {
+        setRows((await resp.json()).ranges || []);
+        setEdits({});
+      }
+    } catch {
+      // The patient page owns error reporting; an unreachable card just has
+      // nothing to edit.
+    }
+  }, [patientId]);
+
+  useEffect(() => { if (patientId) load(); }, [patientId, load]);
+
+  const valueOf = (row, field) => {
+    const edited = edits[row.metric]?.[field];
+    if (edited !== undefined) return edited;
+    return row[field] === null || row[field] === undefined ? '' : String(row[field]);
+  };
+
+  const setValue = (metric, field, value) => {
+    setEdits((prev) => ({ ...prev, [metric]: { ...prev[metric], [field]: value } }));
+    setMessage(null);
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setMessage(null);
+    // Send every metric, not just the edited ones: a metric the user emptied
+    // has to reach the server to be cleared back to its default.
+    const payload = rows.map((row) => {
+      const out = { metric: row.metric, note: row.note ?? null };
+      FIELDS.forEach((field) => {
+        const raw = valueOf(row, field);
+        const num = raw === '' ? null : Number(raw);
+        out[field] = num === null || Number.isNaN(num) ? null : num;
+      });
+      return out;
+    });
+    try {
+      const resp = await apiFetch(`${config.apiUrl}/api/environment/ranges`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ patient_id: patientId, ranges: payload }),
+      });
+      if (!resp.ok) throw new Error('Could not save these bounds.');
+      setRows((await resp.json()).ranges || []);
+      setEdits({});
+      setMessage({ tone: 'success', text: 'Saved.' });
+    } catch (err) {
+      setMessage({ tone: 'destructive', text: err.message });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const dirty = Object.keys(edits).length > 0;
+
+  return (
+    <Card className="tw">
+      <CardHeader>
+        <CardTitle>Room conditions</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          When to flag the room on this patient&rsquo;s timeline. Caution is worth
+          noticing; critical is worth acting on. Leave a field blank for no bound.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="py-2 pr-3 font-medium">Metric</th>
+                <th className="py-2 pr-3 font-medium">Critical low</th>
+                <th className="py-2 pr-3 font-medium">Caution low</th>
+                <th className="py-2 pr-3 font-medium">Caution high</th>
+                <th className="py-2 pr-3 font-medium">Critical high</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const meta = META[row.metric] || { label: row.metric, unit: '' };
+                return (
+                  <tr key={row.metric} className="border-t border-border">
+                    <td className="py-2 pr-3 align-middle">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium">{meta.label}</span>
+                        <span className="text-xs text-muted-foreground">{meta.unit}</span>
+                        {row.source === 'default' && (
+                          <Badge variant="outline" className="text-[10px]">Default</Badge>
+                        )}
+                      </div>
+                    </td>
+                    {FIELDS.map((field) => {
+                      const isFloor = field.endsWith('_min');
+                      if (isFloor && !meta.hasFloor) {
+                        return (
+                          <td key={field} className="py-2 pr-3 text-muted-foreground">
+                            <span aria-hidden="true">—</span>
+                            <span className="sr-only">not applicable</span>
+                          </td>
+                        );
+                      }
+                      return (
+                        <td key={field} className="py-2 pr-3">
+                          <Input
+                            type="number"
+                            inputMode="decimal"
+                            className="w-24"
+                            aria-label={`${meta.label} ${field.replace('_', ' ')}`}
+                            value={valueOf(row, field)}
+                            onChange={(e) => setValue(row.metric, field, e.target.value)}
+                          />
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        {message && (
+          <div className="mt-3">
+            <Alert variant={message.tone === 'success' ? 'success' : 'destructive'}>
+              {message.text}
+            </Alert>
+          </div>
+        )}
+      </CardContent>
+      <CardFooter className="flex items-center gap-2">
+        <Button onClick={save} disabled={!dirty || saving}>
+          {saving ? 'Saving…' : 'Save room conditions'}
+        </Button>
+        {dirty && !saving && (
+          <Button variant="ghost" onClick={() => { setEdits({}); setMessage(null); }}>
+            Discard
+          </Button>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
@@ -15,186 +15,292 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect, useRef, useCallback } from 'react';
+// Day timeline — one patient, one local day, bedside-monitor aesthetic.
+//
+// SpO2 and heart rate are separate stacked charts rather than one chart with
+// two y-axes. Two axes forced both series into a shared vertical space where
+// neither could be read at its own scale, and capped the page at two signals.
+// Split, each gets its own scale — and they still read as one instrument
+// because three things are shared: the time window, the scrubbed instant, and
+// the horizontal plot box (see PLOT_GUTTER).
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import Chart from 'chart.js/auto';
 import 'chartjs-adapter-date-fns';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import zoomPlugin from 'chartjs-plugin-zoom';
 import config, { apiFetch } from '../../config';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
+import { alarmsFor } from './reports/dayOverDay';
 import {
+  ENV_LANES, ENV_METRIC_KEYS, buildEnvSpans, worstStatus, describeSpan,
+  severityOf, directionOf,
+} from './timelineEnv';
+import {
+  CalendarIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
-  CalendarIcon,
+  ChevronDownIcon,
+  FilterIcon,
+  AlertIcon,
+  PillIcon,
+  CheckCircleIcon,
+  DropletIcon,
+  ToiletIcon,
+  VitalsIcon,
 } from '../../components/Icons';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Alert } from '@/components/ui/alert';
-import {
-  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
-} from '@/components/ui/select';
-import { useChartColors } from '../../hooks/useChartColors';
+import './monitoring-timeline.css';
 
 Chart.register(annotationPlugin, zoomPlugin);
 
-// Pulse-ox series that can be plotted. The chart has two y-axes, so at most
-// two may be active at once (first active = left axis, second = right).
-const VITAL_SERIES = {
+/* Chart.js is forced to this y-axis width so both charts' plot areas start at
+ * the same x, and the lanes and scrubber are inset by the same amount. Must
+ * match --mtl-gutter / --mtl-rpad in monitoring-timeline.css. */
+const PLOT_GUTTER = 52;
+const PLOT_RPAD = 12;
+
+/* Series colours are the vc-derived ramp the reports already use for these
+ * same two vitals (reports/weekly.js), not the mockup's crimson/indigo: red on
+ * a resting SpO2 trace spends the one colour this palette reserves for
+ * clinical concern, and the alert bands underneath it need that colour to
+ * mean something. */
+const SIGNALS = {
   spo2: {
-    label: 'SpO2', axisLabel: 'SpO2 (%)', color: '#e91e63',
-    fill: 'rgba(233, 30, 99, 0.1)', gridTint: 'rgba(233, 30, 99, 0.08)',
-    defaultMin: 90, defaultMax: 100, minPad: 1, clampMax: 100,
+    label: 'SpO2', axisLabel: 'SPO2 %', color: '#4da7bd',
+    alarmKey: 'spo2', unit: '%', decimals: 1,
+    defaultMin: 86, defaultMax: 100, minPad: 2, clampMax: 100,
   },
   bpm: {
-    label: 'BPM', axisLabel: 'BPM', color: '#3f51b5',
-    fill: 'rgba(63, 81, 181, 0.1)', gridTint: 'rgba(63, 81, 181, 0.08)',
-    defaultMin: 60, defaultMax: 120, minPad: 2, clampMax: null,
-  },
-  perfusion: {
-    label: 'Perfusion', axisLabel: 'Perfusion (PI)', color: '#00bcd4',
-    fill: 'rgba(0, 188, 212, 0.1)', gridTint: 'rgba(0, 188, 212, 0.08)',
-    defaultMin: 0, defaultMax: 5, minPad: 0.2, clampMax: null,
+    label: 'Heart Rate', axisLabel: 'HEART RATE BPM', color: '#3fbf6a',
+    alarmKey: 'heart_rate', unit: 'bpm', decimals: 0,
+    defaultMin: 55, defaultMax: 120, minPad: 4, clampMax: null,
   },
 };
-// Environmental series (home-level, from /api/environment/observations).
-// `dashed: true` marks estimated/derived metrics — rendered with a dashed
-// line to distinguish them from measured readings.
-// `metric`/`scope` select the observation stream; room-scoped series also
-// filter by the picked room (see roomLocation below).
-const ENV_SERIES = {
-  barometric_pressure: {
-    label: 'Pressure', axisLabel: 'Pressure (hPa)', color: '#8d6e63',
-    fill: 'rgba(141, 110, 99, 0.1)', gridTint: 'rgba(141, 110, 99, 0.08)',
-    defaultMin: 990, defaultMax: 1030, minPad: 1, clampMax: null, dashed: false,
-    metric: 'barometric_pressure', scope: 'outdoor',
-  },
-  pressure_delta_6h: {
-    label: 'Pressure Δ6h', axisLabel: 'Pressure change 6h (hPa)', color: '#a1887f',
-    fill: 'rgba(161, 136, 127, 0.1)', gridTint: 'rgba(161, 136, 127, 0.08)',
-    defaultMin: -5, defaultMax: 5, minPad: 0.5, clampMax: null, dashed: true,
-    metric: 'pressure_delta_6h', scope: 'outdoor',
-  },
-  relative_humidity: {
-    label: 'Humidity (out)', axisLabel: 'Outdoor humidity (%)', color: '#26a69a',
-    fill: 'rgba(38, 166, 154, 0.1)', gridTint: 'rgba(38, 166, 154, 0.08)',
-    defaultMin: 20, defaultMax: 80, minPad: 2, clampMax: 100, dashed: false,
-    metric: 'relative_humidity', scope: 'outdoor',
-  },
-  room_temperature: {
-    label: 'Room temp', axisLabel: 'Room temp (°C)', color: '#ef6c00',
-    fill: 'rgba(239, 108, 0, 0.1)', gridTint: 'rgba(239, 108, 0, 0.08)',
-    defaultMin: 15, defaultMax: 30, minPad: 0.5, clampMax: null, dashed: false,
-    metric: 'temperature', scope: 'room',
-  },
-  room_humidity: {
-    label: 'Room humidity', axisLabel: 'Room humidity (%)', color: '#00897b',
-    fill: 'rgba(0, 137, 123, 0.1)', gridTint: 'rgba(0, 137, 123, 0.08)',
-    defaultMin: 20, defaultMax: 80, minPad: 2, clampMax: 100, dashed: false,
-    metric: 'relative_humidity', scope: 'room',
-  },
-  co2: {
-    label: 'CO2', axisLabel: 'CO2 (ppm)', color: '#7e57c2',
-    fill: 'rgba(126, 87, 194, 0.1)', gridTint: 'rgba(126, 87, 194, 0.08)',
-    defaultMin: 400, defaultMax: 1200, minPad: 25, clampMax: null, dashed: false,
-    metric: 'co2', scope: 'room',
-  },
-  pm25: {
-    label: 'PM2.5', axisLabel: 'PM2.5 (µg/m³)', color: '#78909c',
-    fill: 'rgba(120, 144, 156, 0.1)', gridTint: 'rgba(120, 144, 156, 0.08)',
-    defaultMin: 0, defaultMax: 35, minPad: 1, clampMax: null, dashed: false,
-    metric: 'pm25', scope: 'room',
-  },
-};
-const SERIES = { ...VITAL_SERIES, ...ENV_SERIES };
-const MAX_ACTIVE_VITALS = 2;
+const SIGNAL_KEYS = ['spo2', 'bpm'];
 
-const EVENT_TYPES = {
-  medications: { label: 'Medications', color: '#2196F3', borderDash: [] },
-  care_tasks: { label: 'Care Tasks', color: '#4CAF50', borderDash: [] },
-  nutrition_intake: { label: 'Nutrition In', color: '#FF9800', borderDash: [] },
-  nutrition_output: { label: 'Nutrition Out', color: '#9C27B0', borderDash: [] },
-  vitals: { label: 'Vitals', color: '#009688', borderDash: [4, 4] },
-  alerts: { label: 'Alerts', color: '#F44336', borderDash: [] },
+/* Event lanes. Alerts keep the alert red because that is the role; the rest
+ * take the categorical ramp so a lane colour never reads as a state. */
+const LANES = {
+  alerts: { label: 'Alerts', color: '#f0563c', Icon: AlertIcon },
+  medications: { label: 'Meds', color: '#7f9fd4', Icon: PillIcon },
+  care_tasks: { label: 'Care', color: '#4dc3b3', Icon: CheckCircleIcon },
+  nutrition_intake: { label: 'Feeds', color: '#a8c94a', Icon: DropletIcon },
+  nutrition_output: { label: 'Output', color: '#d98cc4', Icon: ToiletIcon },
+  vitals: { label: 'Vitals', color: '#9b8cf0', Icon: VitalsIcon },
 };
+const LANE_KEYS = Object.keys(LANES);
+const COLLAPSED_LANES = 4;
 
-// Zoom presets in minutes
-const ZOOM_PRESETS = [
-  { label: '24h', minutes: 1440 },
-  { label: '6h', minutes: 360 },
-  { label: '1h', minutes: 60 },
-  { label: '30m', minutes: 30 },
-  { label: '15m', minutes: 15 },
+/* 1M is the floor because the timeline endpoint averages pulse-ox into
+ * one-minute buckets, so a narrower window cannot resolve anything further —
+ * it would just magnify the same points. Reading below a minute means going
+ * to /api/monitoring/history/raw, which is a different request. */
+const RANGES = [
+  { label: '24H', minutes: 1440 },
+  { label: '6H', minutes: 360 },
+  { label: '1H', minutes: 60 },
+  { label: '30M', minutes: 30 },
+  { label: '5M', minutes: 5 },
+  { label: '1M', minutes: 1 },
 ];
+const MIN_RANGE_MS = 60_000;
+
+/* Room readings are bucketed server-side; 15m is fine enough to place an
+ * excursion on a day view and coarse enough to stay one request. */
+const ENV_BUCKET = '15m';
+const ENV_BUCKET_MS = 15 * 60_000;
+const ENV_UNITS = {
+  temperature: '°C', relative_humidity: '%', co2: ' ppm', pm25: ' µg/m³',
+};
+
+const CHROME = {
+  grid: 'rgba(255, 255, 255, 0.06)',
+  axis: '#6b7987',
+  text: '#9aa8b8',
+  band: 'rgba(240, 86, 60, 0.14)',
+  bandEdge: 'rgba(240, 86, 60, 0.35)',
+  threshold: 'rgba(154, 168, 184, 0.5)',
+};
+
+/* Local calendar date, not the UTC one. toISOString() rolls over at UTC
+ * midnight, so west of Greenwich an evening visit asked the API for
+ * tomorrow and got an empty day. */
+const toApiDate = (d) => {
+  const p = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+};
+const isSameDay = (a, b) => a.toDateString() === b.toDateString();
+const clockTime = (d) =>
+  d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+
+const formatDuration = (ms) => {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h) return `${h}h ${m}m`;
+  if (m) return `${m}m ${s}s`;
+  return `${s}s`;
+};
+
+const eventLabel = (type, item) => {
+  switch (type) {
+    case 'medications': return `${item.name} ${item.dose}`.trim();
+    case 'care_tasks': return item.name;
+    case 'nutrition_intake':
+      return `${item.item_name}${item.amount ? ` ${item.amount}${item.amount_unit || ''}` : ''}`;
+    case 'nutrition_output': {
+      const parts = [item.output_type];
+      if (item.is_diaper) {
+        if (item.diaper_wetness) parts.push(item.diaper_wetness);
+        if (item.diaper_soiled) parts.push('soiled');
+      }
+      if (item.consistency) parts.push(item.consistency);
+      return parts.filter(Boolean).join(' · ');
+    }
+    case 'vitals': return `${item.vital_type} ${item.value}${item.unit || ''}`;
+    default: return '';
+  }
+};
+
+/* A y range that fits the data and lands on readable numbers. Charting the
+ * raw min/max gave axes labelled 58.08 and 119.2; stepping out to a round
+ * boundary costs a few pixels of headroom and makes the axis legible. */
+const niceScale = (lo, hi, minSpan, clampMax) => {
+  let min = lo;
+  let max = hi;
+  if (max - min < minSpan) {
+    const centre = (min + max) / 2;
+    min = centre - minSpan / 2;
+    max = centre + minSpan / 2;
+  }
+  const raw = (max - min) / 4;
+  const mag = 10 ** Math.floor(Math.log10(raw));
+  const step = [1, 2, 2.5, 5, 10].map((m) => m * mag).find((c) => c >= raw) ?? 10 * mag;
+  min = Math.max(0, Math.floor(min / step) * step);
+  max = Math.ceil(max / step) * step;
+  if (clampMax != null) max = Math.min(clampMax, max);
+  return { min, max, step };
+};
+
+const alertLabel = (a) => {
+  if (a.spo2_alarm && a.hr_alarm) return 'SpO2 + HR alert';
+  if (a.spo2_alarm) return 'Low SpO2 alert';
+  if (a.hr_alarm) return 'Heart rate alert';
+  return 'Monitoring alert';
+};
 
 const AdminV2MonitoringTimeline = () => {
-  const chart = useChartColors();
   const { selectedPatient } = useAdminPatient();
-  const [selectedDate, setSelectedDate] = useState(new Date());
-  const [timelineData, setTimelineData] = useState(null);
+  const [selectedDate, setSelectedDate] = useState(() => new Date());
+  const [data, setData] = useState(null);
+  const [settings, setSettings] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [activePreset, setActivePreset] = useState('24h');
-  // Ordered list of active pulse-ox series (max 2 — one per y-axis).
-  const [activeVitals, setActiveVitals] = useState(['spo2', 'bpm']);
-  const [visibleLayers, setVisibleLayers] = useState({
-    medications: true,
-    care_tasks: true,
-    nutrition_intake: true,
-    nutrition_output: true,
-    vitals: true,
-    alerts: true,
-  });
 
-  const chartRef = useRef(null);
-  const chartInstance = useRef(null);
-  const chartContainerRef = useRef(null);
+  const [activeSignals, setActiveSignals] = useState(SIGNAL_KEYS);
+  const [lanesExpanded, setLanesExpanded] = useState(false);
+  const [rangeLabel, setRangeLabel] = useState('24H');
+  const [view, setView] = useState(null);       // { min, max } epoch ms
+  const [cursor, setCursor] = useState(null);   // scrubbed instant, epoch ms
 
-  const formatDateForApi = (date) => date.toISOString().split('T')[0];
-  const isToday = (date) => date.toDateString() === new Date().toDateString();
+  const stackRef = useRef(null);
+  const pointers = useRef(new Set());
 
-  const goToPreviousDay = () => {
-    const d = new Date(selectedDate);
-    d.setDate(d.getDate() - 1);
-    setSelectedDate(d);
-  };
-  const goToNextDay = () => {
-    const d = new Date(selectedDate);
-    d.setDate(d.getDate() + 1);
-    setSelectedDate(d);
-  };
-  const goToToday = () => setSelectedDate(new Date());
+  /* ---------------- data ---------------- */
 
-  const formatDisplayDate = (date) => {
-    return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
-  };
-
-  // Fetch timeline data
-  const fetchTimeline = useCallback(async () => {
-    if (!selectedPatient) return;
+  useEffect(() => {
+    if (!selectedPatient) return undefined;
+    let cancelled = false;
     setLoading(true);
     setError(null);
-    try {
-      const dateParam = formatDateForApi(selectedDate);
-      const response = await apiFetch(
-        `${config.apiUrl}/api/monitoring/timeline?patient_id=${selectedPatient.id}&target_date=${dateParam}`
-      );
-      if (!response.ok) throw new Error('Failed to fetch timeline data');
-      const data = await response.json();
-      setTimelineData(data);
-    } catch (err) {
-      console.error('Timeline fetch error:', err);
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
+    (async () => {
+      try {
+        const res = await apiFetch(
+          `${config.apiUrl}/api/monitoring/timeline`
+          + `?patient_id=${selectedPatient.id}&target_date=${toApiDate(selectedDate)}`,
+        );
+        if (!res.ok) throw new Error('Could not load the timeline for this day.');
+        const body = await res.json();
+        if (!cancelled) setData(body);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
   }, [selectedPatient, selectedDate]);
 
-  useEffect(() => { fetchTimeline(); }, [fetchTimeline]);
+  // Alarm limits for the threshold lines — the same account settings the live
+  // monitor alarms on. A failure just means no threshold line.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiFetch(`${config.apiUrl}/api/settings`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body = await res.json();
+        if (!cancelled) setSettings(body);
+      } catch {
+        if (!cancelled) setSettings({});
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
-  // Rooms seen in the data (scope=room locations), for the room picker.
-  // "" is a legitimate location (unspecified room) and renders as such.
+  /* ---------------- derived ---------------- */
+
+  // The day's bounds, and the instant the data actually runs out.
+  const bounds = useMemo(() => {
+    const base = data?.date ? new Date(`${data.date}T00:00:00`) : selectedDate;
+    const start = new Date(base);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(23, 59, 59, 999);
+    return { start: start.getTime(), end: end.getTime() };
+  }, [data?.date, selectedDate]);
+
+  const lastSample = useMemo(() => {
+    const rows = data?.pulse_ox;
+    if (!rows?.length) return null;
+    return new Date(rows[rows.length - 1].ts).getTime();
+  }, [data]);
+
+  // Reset the window whenever the day changes.
+  useEffect(() => {
+    setView({ min: bounds.start, max: bounds.end });
+    setRangeLabel('24H');
+    setCursor(null);
+  }, [bounds.start, bounds.end]);
+
+  /* ---------------- room conditions ---------------- */
+
+  const [envRanges, setEnvRanges] = useState(null);
+  const [envSeries, setEnvSeries] = useState({});
   const [roomLocations, setRoomLocations] = useState([]);
   const [roomLocation, setRoomLocation] = useState(null);
+
+  useEffect(() => {
+    if (!selectedPatient) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiFetch(
+          `${config.apiUrl}/api/environment/ranges?patient_id=${selectedPatient.id}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body = await res.json();
+        if (!cancelled) {
+          setEnvRanges(Object.fromEntries((body.ranges || []).map((r) => [r.metric, r])));
+        }
+      } catch {
+        if (!cancelled) setEnvRanges({});
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [selectedPatient]);
+
+  // Rooms that actually have readings. "" is a real location (unspecified
+  // room) and is offered as one.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -206,631 +312,829 @@ const AdminV2MonitoringTimeline = () => {
                                       .map((r) => r.location ?? ''))];
         if (cancelled) return;
         setRoomLocations(rooms);
-        // Default to the patient's configured care area when it has data,
-        // else keep a valid manual choice, else prefer a bedroom-ish name.
+        // Follow the patient's configured care area when it has data, else
+        // keep a still-valid manual pick, else guess at a bedroom.
         const careArea = selectedPatient?.care_area;
         setRoomLocation((prev) => {
           if (careArea && rooms.includes(careArea)) return careArea;
           if (prev !== null && rooms.includes(prev)) return prev;
           return rooms.find((l) => /bed|care/i.test(l)) ?? rooms[0] ?? null;
         });
-      } catch (err) {
-        console.error('Environment locations fetch failed:', err);
+      } catch {
+        if (!cancelled) setRoomLocations([]);
       }
     })();
     return () => { cancelled = true; };
-    // Re-run on patient switch (id, not just care_area — two patients can
-    // share a room name or both have none) so the default follows the
-    // newly selected patient instead of the previous one's manual choice.
   }, [selectedPatient?.id, selectedPatient?.care_area]);
 
-  // Environmental overlay data for the selected day, keyed by series key.
-  // Home-level (not patient-scoped); failure degrades to an empty series and
-  // never blocks the vitals chart.
-  const [envData, setEnvData] = useState({});
-  const activeEnvKeys = activeVitals.filter((k) => ENV_SERIES[k]);
-  const activeEnvKeysStr = activeEnvKeys.join(',');
-  const roomSeriesActive = activeEnvKeys.some((k) => ENV_SERIES[k].scope === 'room');
   useEffect(() => {
+    if (roomLocation === null) { setEnvSeries({}); return undefined; }
     let cancelled = false;
-    const keys = activeEnvKeysStr ? activeEnvKeysStr.split(',') : [];
-    if (keys.length === 0) {
-      setEnvData({});
-      return undefined;
-    }
-    const dateStr = formatDateForApi(selectedDate);
-    const dayStart = new Date(`${dateStr}T00:00:00`);
-    const dayEnd = new Date(`${dateStr}T23:59:59`);
+    const dayStart = new Date(bounds.start).toISOString();
+    const dayEnd = new Date(bounds.end).toISOString();
     (async () => {
       const next = {};
-      await Promise.all(keys.map(async (key) => {
+      await Promise.all(ENV_METRIC_KEYS.map(async (metric) => {
         try {
-          const cfg = ENV_SERIES[key];
           const params = new URLSearchParams({
-            metric: cfg.metric, scope: cfg.scope, bucket: '15m', limit: '500',
-            from: dayStart.toISOString(), to: dayEnd.toISOString(),
+            metric, scope: 'room', location: roomLocation,
+            bucket: ENV_BUCKET, limit: '500', from: dayStart, to: dayEnd,
           });
-          if (cfg.scope === 'room') {
-            if (roomLocation === null) { next[key] = []; return; }
-            params.set('location', roomLocation);
-          }
           const res = await apiFetch(
-            `${config.apiUrl}/api/environment/observations?${params}`
-          );
+            `${config.apiUrl}/api/environment/observations?${params}`);
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           const rows = await res.json();
-          // Newest-first from the API; chart wants ascending
-          next[key] = rows.reverse().map((r) => ({ x: new Date(r.ts), y: r.avg }));
-        } catch (err) {
-          console.error(`Environment fetch failed for ${key}:`, err);
-          next[key] = [];
+          // Newest-first from the API; spans need ascending.
+          next[metric] = rows.slice().reverse()
+            .map((r) => ({ ts: new Date(r.ts).getTime(), value: r.avg }));
+        } catch {
+          next[metric] = [];
         }
       }));
-      if (!cancelled) setEnvData(next);
+      if (!cancelled) setEnvSeries(next);
     })();
     return () => { cancelled = true; };
-  }, [selectedDate, activeEnvKeysStr, roomLocation]);
+  }, [roomLocation, bounds.start, bounds.end]);
 
-  // Build event marker label
-  const getMarkerLabel = (type, item) => {
-    switch (type) {
-      case 'medications': return `${item.name} ${item.dose}`;
-      case 'care_tasks': return item.name;
-      case 'nutrition_intake': return `${item.item_name} (${item.amount}${item.amount_unit})`;
-      case 'nutrition_output': {
-        const parts = [item.output_type];
-        if (item.is_diaper) {
-          if (item.diaper_wetness) parts.push(item.diaper_wetness);
-          if (item.diaper_soiled) parts.push('soiled');
-        }
-        if (item.consistency) parts.push(item.consistency);
-        return parts.join(' / ');
+  const envLanes = useMemo(() => ENV_LANES.map((lane) => {
+    const spans = buildEnvSpans(
+      envSeries[lane.metric] || [], envRanges?.[lane.metric], ENV_BUCKET_MS,
+      { keepOk: lane.banded },
+    );
+    return { ...lane, spans, worst: worstStatus(spans) };
+  }), [envSeries, envRanges]);
+
+  const envFlagged = envLanes.filter((l) => l.worst !== 'ok').length;
+  const hasEnvData = ENV_METRIC_KEYS.some((k) => (envSeries[k] || []).length > 0);
+
+  const series = useMemo(() => {
+    const out = {};
+    SIGNAL_KEYS.forEach((key) => {
+      out[key] = (data?.pulse_ox || [])
+        .filter((p) => p[key] != null && p[key] !== -1)
+        .map((p) => ({ x: new Date(p.ts).getTime(), y: p[key] }));
+    });
+    return out;
+  }, [data]);
+
+  const stats = useMemo(() => {
+    const val = (key) => series[key]?.map((p) => p.y) ?? [];
+    const spo2 = val('spo2');
+    const bpm = val('bpm');
+    const avg = (a) => (a.length ? a.reduce((s, n) => s + n, 0) / a.length : null);
+    const eventTotal = LANE_KEYS
+      .filter((k) => k !== 'alerts')
+      .reduce((n, k) => n + (data?.[k]?.length || 0), 0);
+    return {
+      spo2Avg: avg(spo2), spo2Low: spo2.length ? Math.min(...spo2) : null,
+      bpmAvg: avg(bpm), bpmHigh: bpm.length ? Math.max(...bpm) : null,
+      alerts: data?.alerts?.length || 0,
+      events: eventTotal,
+    };
+  }, [series, data]);
+
+  // Every marker on every lane, normalised to one shape.
+  const laneItems = useMemo(() => {
+    const out = {};
+    LANE_KEYS.forEach((key) => {
+      if (key === 'alerts') {
+        out.alerts = (data?.alerts || [])
+          .filter((a) => a.start)
+          .map((a, i) => {
+            const start = new Date(a.start).getTime();
+            const end = a.end ? new Date(a.end).getTime() : null;
+            return {
+              id: `alerts-${i}`, type: 'alerts', ts: start, end,
+              label: alertLabel(a), alert: a,
+            };
+          });
+      } else {
+        out[key] = (data?.[key] || [])
+          .filter((it) => it.ts)
+          .map((it, i) => ({
+            id: `${key}-${i}`, type: key, ts: new Date(it.ts).getTime(),
+            label: eventLabel(key, it), item: it,
+          }));
       }
-      case 'vitals': return `${item.vital_type}: ${item.value}${item.unit || ''}`;
-      default: return '';
-    }
-  };
+    });
+    return out;
+  }, [data]);
 
-  // Apply a zoom preset centered on current view or current time
-  const applyZoomPreset = useCallback((minutes) => {
-    const chart = chartInstance.current;
-    if (!chart || !timelineData) return;
+  const lanesWithData = LANE_KEYS.filter((k) => (laneItems[k]?.length || 0) > 0);
+  const visibleLanes = lanesExpanded ? LANE_KEYS : LANE_KEYS.slice(0, COLLAPSED_LANES);
+  const hiddenWithData = lanesWithData.filter((k) => !visibleLanes.includes(k)).length;
 
-    const dateStr = timelineData.date;
-    const dayStart = new Date(`${dateStr}T00:00:00`).getTime();
-    const dayEnd = new Date(`${dateStr}T23:59:59`).getTime();
+  // Everything on one ordered list, for the activity panel.
+  const allEvents = useMemo(
+    () => LANE_KEYS.flatMap((k) => laneItems[k] || []).sort((a, b) => b.ts - a.ts),
+    [laneItems],
+  );
 
+  // The alert covering the scrubbed instant, if any.
+  const cursorAlert = useMemo(() => {
+    if (cursor == null) return null;
+    return (laneItems.alerts || []).find((a) => {
+      const end = a.end ?? Date.now();
+      return cursor >= a.ts && cursor <= end;
+    }) || null;
+  }, [cursor, laneItems]);
+
+  // Nearest pulse-ox minute to the cursor, for the readout.
+  const cursorSample = useMemo(() => {
+    if (cursor == null || !data?.pulse_ox?.length) return null;
+    let best = null;
+    let bestGap = Infinity;
+    data.pulse_ox.forEach((p) => {
+      const gap = Math.abs(new Date(p.ts).getTime() - cursor);
+      if (gap < bestGap) { bestGap = gap; best = p; }
+    });
+    // A minute either side; beyond that the readout would be inventing data.
+    return bestGap <= 90_000 ? best : null;
+  }, [cursor, data]);
+
+  const nearbyEvents = useMemo(() => {
+    if (cursor == null) return [];
+    return [...allEvents]
+      .sort((a, b) => Math.abs(a.ts - cursor) - Math.abs(b.ts - cursor))
+      .slice(0, 5)
+      .sort((a, b) => b.ts - a.ts);
+  }, [allEvents, cursor]);
+
+  /* ---------------- interaction ---------------- */
+
+  const applyRange = useCallback((minutes, label) => {
+    setRangeLabel(label);
     if (minutes >= 1440) {
-      // Full day - reset zoom
-      chart.resetZoom();
-      setActivePreset('24h');
+      setView({ min: bounds.start, max: bounds.end });
       return;
     }
+    const span = minutes * 60_000;
+    // Centre on the cursor if one is set, else the newest data, else now.
+    const centre = cursor ?? lastSample ?? Math.min(Date.now(), bounds.end);
+    let min = centre - span / 2;
+    let max = centre + span / 2;
+    if (min < bounds.start) { min = bounds.start; max = min + span; }
+    if (max > bounds.end) { max = bounds.end; min = Math.max(bounds.start, max - span); }
+    setView({ min, max });
+  }, [bounds, cursor, lastSample]);
 
-    const rangeMs = minutes * 60 * 1000;
+  // One finger scrubs; two are left to the zoom plugin's pinch.
+  const tsFromClientX = useCallback((clientX) => {
+    const el = stackRef.current;
+    if (!el || !view) return null;
+    const rect = el.getBoundingClientRect();
+    const width = rect.width - PLOT_GUTTER - PLOT_RPAD;
+    if (width <= 0) return null;
+    const frac = Math.min(1, Math.max(0, (clientX - rect.left - PLOT_GUTTER) / width));
+    return Math.round(view.min + frac * (view.max - view.min));
+  }, [view]);
 
-    // Center on current view center, or current time if today
-    let center;
-    const currentMin = chart.scales.x.min;
-    const currentMax = chart.scales.x.max;
-    if (isToday(selectedDate)) {
-      center = Date.now();
-    } else {
-      center = (currentMin + currentMax) / 2;
-    }
+  const onPointerDown = (e) => {
+    pointers.current.add(e.pointerId);
+    if (pointers.current.size > 1) return;
+    const ts = tsFromClientX(e.clientX);
+    if (ts != null) setCursor(ts);
+  };
+  const onPointerMove = (e) => {
+    if (pointers.current.size !== 1 || !pointers.current.has(e.pointerId)) return;
+    if (e.pointerType === 'mouse' && e.buttons === 0) return;
+    const ts = tsFromClientX(e.clientX);
+    if (ts != null) setCursor(ts);
+  };
+  const endPointer = (e) => { pointers.current.delete(e.pointerId); };
 
-    let newMin = center - rangeMs / 2;
-    let newMax = center + rangeMs / 2;
-
-    // Clamp to day boundaries
-    if (newMin < dayStart) {
-      newMin = dayStart;
-      newMax = dayStart + rangeMs;
-    }
-    if (newMax > dayEnd) {
-      newMax = dayEnd;
-      newMin = Math.max(dayStart, dayEnd - rangeMs);
-    }
-
-    chart.zoomScale('x', { min: newMin, max: newMax }, 'default');
-    chart.update('none');
-
-    // Find matching preset label
-    const preset = ZOOM_PRESETS.find(p => p.minutes === minutes);
-    setActivePreset(preset ? preset.label : null);
-  }, [timelineData, selectedDate]);
-
-  // Toggle a pulse-ox series. Tapping an inactive one when two are already
-  // active replaces the oldest selection, so a tap always takes effect.
-  const toggleVital = (key) => {
-    setActiveVitals(prev => {
-      if (prev.includes(key)) return prev.filter(k => k !== key);
-      if (prev.length < MAX_ACTIVE_VITALS) return [...prev, key];
-      return [...prev.slice(1), key];
+  const toggleSignal = (key) => {
+    setActiveSignals((prev) => {
+      if (!prev.includes(key)) return SIGNAL_KEYS.filter((k) => prev.includes(k) || k === key);
+      // Never leave the card with nothing in it.
+      if (prev.length === 1) return prev;
+      return prev.filter((k) => k !== key);
     });
   };
 
-  const handleResetZoom = useCallback(() => {
-    if (chartInstance.current) {
-      chartInstance.current.resetZoom();
-      setActivePreset('24h');
-    }
-  }, []);
+  const shownSignals = SIGNAL_KEYS.filter((k) => activeSignals.includes(k));
+  const cursorFrac = cursor != null && view && view.max > view.min
+    ? (cursor - view.min) / (view.max - view.min)
+    : null;
+  const cursorVisible = cursorFrac != null && cursorFrac >= 0 && cursorFrac <= 1;
 
-  // Build and render chart
-  useEffect(() => {
-    if (!timelineData || !chartRef.current) return;
-
-    if (chartInstance.current) {
-      chartInstance.current.destroy();
-      chartInstance.current = null;
-    }
-
-    const dateStr = timelineData.date;
-    const dayStart = new Date(`${dateStr}T00:00:00`);
-    const dayEnd = new Date(`${dateStr}T23:59:59`);
-
-    // Active series — pulse-ox metrics come from the timeline payload
-    // (filtering out -1 invalid/disconnected reads), environmental metrics
-    // from the per-day envData fetch. First active series takes the left
-    // y-axis, second the right. Estimated env metrics render dashed.
-    const vitalDatasets = [];
-    const vitalScales = {};
-    activeVitals.forEach((key, i) => {
-      const cfg = SERIES[key];
-      const data = ENV_SERIES[key]
-        ? (envData[key] || [])
-        : timelineData.pulse_ox
-            .filter(p => p[key] != null && p[key] !== -1)
-            .map(p => ({ x: new Date(p.ts), y: p[key] }));
-
-      // Static y-axis range from all data with small padding. Vitals never go
-      // below 0; pressure deltas legitimately do, so only clamp when the
-      // series can't be negative.
-      const min = data.length > 0 ? Math.min(...data.map(p => p.y)) : cfg.defaultMin;
-      const max = data.length > 0 ? Math.max(...data.map(p => p.y)) : cfg.defaultMax;
-      const pad = Math.max((max - min) * 0.05, cfg.minPad);
-      const axisId = `y_${key}`;
-      const allowNegative = key === 'pressure_delta_6h';
-      const roomSuffix = ENV_SERIES[key]?.scope === 'room' && roomLocation
-        ? ` — ${roomLocation}` : '';
-
-      vitalDatasets.push({
-        label: cfg.axisLabel + roomSuffix,
-        data,
-        borderColor: cfg.color,
-        backgroundColor: cfg.fill,
-        borderWidth: 1.5,
-        borderDash: cfg.dashed ? [6, 4] : [],
-        pointRadius: 0,
-        pointHitRadius: 5,
-        fill: false,
-        spanGaps: true,
-        yAxisID: axisId,
-        tension: 0.2,
-      });
-      vitalScales[axisId] = {
-        type: 'linear',
-        position: i === 0 ? 'left' : 'right',
-        min: allowNegative ? min - pad : Math.max(0, min - pad),
-        max: cfg.clampMax != null ? Math.min(cfg.clampMax, max + pad) : max + pad,
-        title: { display: true, text: cfg.axisLabel, color: cfg.color, font: { size: 12 } },
-        ticks: { color: cfg.color },
-        grid: i === 0 ? { color: cfg.gridTint } : { drawOnChartArea: false },
-      };
-    });
-
-    // Build annotation lines for events
-    const annotations = {};
-
-    const addEventAnnotations = (type, items) => {
-      if (!visibleLayers[type]) return;
-      const cfg = EVENT_TYPES[type];
-      items.forEach((item, i) => {
-        const ts = new Date(item.ts);
-        const label = getMarkerLabel(type, item);
-        annotations[`${type}_${i}`] = {
-          type: 'line',
-          xMin: ts,
-          xMax: ts,
-          borderColor: cfg.color,
-          borderWidth: 2,
-          borderDash: cfg.borderDash,
-          label: {
-            display: true,
-            content: label.length > 30 ? label.substring(0, 28) + '...' : label,
-            position: 'start',
-            backgroundColor: cfg.color,
-            color: '#fff',
-            font: { size: 10, weight: 'bold' },
-            padding: { top: 2, bottom: 2, left: 4, right: 4 },
-            borderRadius: 3,
-            rotation: -90,
-            yAdjust: -10,
-          },
-        };
-      });
-    };
-
-    addEventAnnotations('medications', timelineData.medications);
-    addEventAnnotations('care_tasks', timelineData.care_tasks);
-    addEventAnnotations('nutrition_intake', timelineData.nutrition_intake);
-    addEventAnnotations('nutrition_output', timelineData.nutrition_output);
-    addEventAnnotations('vitals', timelineData.vitals);
-
-    // Alert periods as box annotations
-    if (visibleLayers.alerts) {
-      timelineData.alerts.forEach((alert, i) => {
-        if (alert.start) {
-          const start = new Date(alert.start);
-          const end = alert.end ? new Date(alert.end) : new Date(start.getTime() + 60000);
-          annotations[`alert_box_${i}`] = {
-            type: 'box',
-            xMin: start,
-            xMax: end,
-            backgroundColor: 'rgba(244, 67, 54, 0.15)',
-            borderColor: 'rgba(244, 67, 54, 0.4)',
-            borderWidth: 1,
-            label: {
-              display: true,
-              content: `Alert${alert.spo2_alarm ? ' SpO2' : ''}${alert.hr_alarm ? ' HR' : ''}`,
-              position: 'start',
-              backgroundColor: 'rgba(244, 67, 54, 0.8)',
-              color: '#fff',
-              font: { size: 9 },
-              padding: 2,
-            },
-          };
-        }
-      });
-    }
-
-    const ctx = chartRef.current.getContext('2d');
-    chartInstance.current = new Chart(ctx, {
-      type: 'line',
-      data: {
-        datasets: vitalDatasets,
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        interaction: {
-          mode: 'index',
-          intersect: false,
-        },
-        scales: {
-          x: {
-            type: 'time',
-            min: dayStart,
-            max: dayEnd,
-            time: {
-              displayFormats: {
-                minute: 'h:mm a',
-                hour: 'ha',
-              },
-              tooltipFormat: 'h:mm:ss a',
-            },
-            title: { display: true, text: 'Time', font: { size: 12 }, color: chart.axis },
-            grid: { color: chart.grid },
-            ticks: { maxRotation: 0, font: { size: 11 }, color: chart.axis, autoSkip: true, maxTicksLimit: 24 },
-          },
-          ...vitalScales,
-        },
-        plugins: {
-          legend: {
-            position: 'top',
-            labels: { usePointStyle: true, padding: 15, font: { size: 12 }, color: chart.foreground },
-          },
-          tooltip: {
-            callbacks: {
-              title: (items) => {
-                if (items[0]) {
-                  const d = new Date(items[0].parsed.x);
-                  return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', second: '2-digit' });
-                }
-                return '';
-              },
-            },
-          },
-          annotation: { annotations },
-          zoom: {
-            pan: {
-              enabled: true,
-              mode: 'x',
-              modifierKey: null,
-            },
-            zoom: {
-              wheel: { enabled: true, modifierKey: null },
-              pinch: { enabled: true },
-              mode: 'x',
-              onZoom: () => setActivePreset(null),
-            },
-            limits: {
-              x: { min: dayStart.getTime(), max: dayEnd.getTime(), minRange: 5 * 60 * 1000 },
-            },
-          },
-        },
-      },
-    });
-
-    setActivePreset('24h');
-
-    return () => {
-      if (chartInstance.current) {
-        chartInstance.current.destroy();
-        chartInstance.current = null;
-      }
-    };
-  }, [timelineData, envData, visibleLayers, selectedDate, activeVitals, roomLocation, chart.grid, chart.axis, chart.foreground]);
-
-  const toggleLayer = (key) => {
-    setVisibleLayers(prev => ({ ...prev, [key]: !prev[key] }));
-  };
-
-  // Event counts for summary
-  const getEventCount = (type) => {
-    if (!timelineData) return 0;
-    return (timelineData[type] || []).length;
-  };
+  /* ---------------- render ---------------- */
 
   if (!selectedPatient) {
-    return (
-      <div style={{ padding: 40, textAlign: 'center', color: 'var(--muted-foreground)' }}>
-        Select a patient from the sidebar to view the timeline.
-      </div>
-    );
+    return <div className="mtl"><p className="mtl-empty">Select a patient to see their day.</p></div>;
   }
 
+  const today = new Date();
+  const onToday = isSameDay(selectedDate, today);
+  const shiftDay = (days) => {
+    const d = new Date(selectedDate);
+    d.setDate(d.getDate() + days);
+    if (d > today && !isSameDay(d, today)) return;
+    setSelectedDate(d);
+  };
+
   return (
-    <div style={{ padding: '0' }}>
-      {/* Date Navigation - matches /care/schedule */}
-      <div className="admin-v2-schedule-nav tw">
-        <Button variant="secondary" size="icon" onClick={goToPreviousDay} title="Previous Day">
-          <ChevronLeftIcon size={20} />
-        </Button>
-
-        <div className="admin-v2-schedule-date">
-          <CalendarIcon size={18} />
-          <span>{formatDisplayDate(selectedDate)}</span>
-          {isToday(selectedDate) && (
-            <span className="admin-v2-today-badge">Today</span>
-          )}
-        </div>
-
-        <Button variant="secondary" size="icon" onClick={goToNextDay} title="Next Day">
-          <ChevronRightIcon size={20} />
-        </Button>
-
-        {!isToday(selectedDate) && (
-          <Button variant="secondary" size="sm" className="ml-4" onClick={goToToday}>
-            Go to Today
-          </Button>
-        )}
-
-        <Input
-          type="date"
-          value={formatDateForApi(selectedDate)}
-          onChange={(e) => setSelectedDate(new Date(e.target.value + 'T12:00:00'))}
-          className="w-auto"
-        />
-      </div>
-
-      {/* Event Layer Toggles + Zoom Controls */}
-      <div style={{
-        display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: '1rem',
-        padding: '0.75rem 1rem', background: 'var(--card)', borderRadius: 8, border: '1px solid var(--border)',
-        alignItems: 'center', justifyContent: 'space-between',
-      }}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
-          {/* Dataset toggles (max 2 active — one per y-axis). Dashed borders
-              mark estimated/derived environmental metrics. */}
-          {Object.entries(VITAL_SERIES).map(([key, cfg]) => (
-            <SeriesChip key={key} seriesKey={key} cfg={cfg}
-                        active={activeVitals.includes(key)} onToggle={toggleVital} />
-          ))}
-          <span style={{ width: 1, height: 20, background: 'var(--border)', display: 'inline-block' }} />
-          <span style={{ fontSize: 11, color: 'var(--muted-foreground)' }}>Env:</span>
-          {Object.entries(ENV_SERIES).map(([key, cfg]) => (
-            <SeriesChip key={key} seriesKey={key} cfg={cfg}
-                        active={activeVitals.includes(key)} onToggle={toggleVital}
-                        noData={activeVitals.includes(key) && (envData[key] || []).length === 0} />
-          ))}
-          {/* Room picker for room-scoped series; rooms come from observed data */}
-          {roomSeriesActive && roomLocations.length > 0 && (
-            <span className="tw">
-              <Select value={roomLocation === '' ? '__unspecified__' : (roomLocation ?? undefined)}
-                      onValueChange={(v) => setRoomLocation(v === '__unspecified__' ? '' : v)}>
-                <SelectTrigger className="h-7 w-auto min-w-[110px] text-xs">
-                  <SelectValue placeholder="Room…" />
-                </SelectTrigger>
-                <SelectContent>
-                  {roomLocations.map((loc) => (
-                    <SelectItem key={loc || '__unspecified__'} value={loc || '__unspecified__'}>
-                      {loc || '(unspecified)'}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </span>
-          )}
-
-          <span style={{ width: 1, height: 20, background: 'var(--border)', display: 'inline-block' }} />
-
-          {/* Event marker toggles */}
-          {Object.entries(EVENT_TYPES).map(([key, cfg]) => (
-            <button
-              key={key}
-              onClick={() => toggleLayer(key)}
-              style={{
-                display: 'flex', alignItems: 'center', gap: 6,
-                padding: '5px 12px', borderRadius: 16, fontSize: 12, fontWeight: 600,
-                border: `2px solid ${cfg.color}`,
-                background: visibleLayers[key] ? cfg.color : 'transparent',
-                color: visibleLayers[key] ? '#fff' : cfg.color,
-                cursor: 'pointer', transition: 'all 0.15s',
-                opacity: visibleLayers[key] ? 1 : 0.6,
-              }}
-            >
-              <span style={{
-                width: 8, height: 8, borderRadius: '50%',
-                background: visibleLayers[key] ? '#fff' : cfg.color,
-                display: 'inline-block'
-              }} />
-              {cfg.label}
-              {timelineData && <span style={{ opacity: 0.8, marginLeft: 2 }}>({getEventCount(key)})</span>}
-            </button>
-          ))}
-        </div>
-
-        {/* Zoom presets */}
-        <div className="tw" style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
-          <span style={{ fontSize: 11, color: 'var(--muted-foreground)', marginRight: 4 }}>Zoom:</span>
-          {ZOOM_PRESETS.map(p => (
-            <Button
-              key={p.label}
-              size="sm"
-              variant={activePreset === p.label ? 'default' : 'secondary'}
-              onClick={() => applyZoomPreset(p.minutes)}
-            >
-              {p.label}
-            </Button>
-          ))}
-          <Button
-            size="sm"
-            variant="secondary"
-            onClick={handleResetZoom}
-            title="Reset zoom to full day"
-          >
-            Reset
-          </Button>
-        </div>
-      </div>
-
-      {/* Zoom hint */}
-      <div style={{ fontSize: 11, color: 'var(--muted-foreground)', marginBottom: 8, paddingLeft: 4 }}>
-        Scroll to zoom &middot; Click and drag to pan
-      </div>
-
-      {/* Chart */}
-      {loading ? (
-        <div style={{ textAlign: 'center', padding: 60, color: 'var(--muted-foreground)' }}>Loading timeline data...</div>
-      ) : error ? (
-        <div className="tw" style={{ padding: '0 0 1rem' }}><Alert variant="destructive">{error}</Alert></div>
-      ) : !timelineData ? (
-        <div style={{ textAlign: 'center', padding: 60, color: 'var(--muted-foreground)' }}>No data available.</div>
-      ) : (
-        <div
-          ref={chartContainerRef}
-          style={{
-            border: '1px solid var(--border)', borderRadius: 8, background: 'var(--card)',
-            padding: '12px 8px',
-            height: 440,
-            position: 'relative',
-          }}
+    <div className="mtl">
+      <div className="mtl-datenav">
+        <button type="button" className="mtl-navbtn" onClick={() => shiftDay(-1)} aria-label="Previous day">
+          <ChevronLeftIcon size={18} />
+        </button>
+        <button
+          type="button"
+          className={`mtl-navbtn${onToday ? ' on' : ''}`}
+          onClick={() => setSelectedDate(new Date())}
         >
-          <canvas ref={chartRef} />
-        </div>
-      )}
+          Today
+        </button>
+        <button
+          type="button"
+          className="mtl-navbtn"
+          onClick={() => shiftDay(1)}
+          disabled={onToday}
+          aria-label="Next day"
+        >
+          <ChevronRightIcon size={18} />
+        </button>
+        <span className="mtl-datepill">
+          {selectedDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+          <CalendarIcon size={16} />
+          <input
+            type="date"
+            aria-label="Pick a date"
+            max={toApiDate(today)}
+            value={toApiDate(selectedDate)}
+            onChange={(e) => {
+              if (!e.target.value) return;
+              const [y, m, d] = e.target.value.split('-').map(Number);
+              setSelectedDate(new Date(y, m - 1, d));
+            }}
+          />
+        </span>
+      </div>
 
-      {/* Event Details Summary */}
-      {timelineData && !loading && (
-        <div style={{ marginTop: '1rem', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 12 }}>
-          {visibleLayers.medications && timelineData.medications.length > 0 && (
-            <EventSummaryCard title="Medications" color={EVENT_TYPES.medications.color} items={timelineData.medications.map(m => ({
-              time: new Date(m.ts).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
-              text: `${m.name} - ${m.dose}`,
-              subtext: m.status !== 'on-time' ? m.status : null,
-            }))} />
-          )}
-          {visibleLayers.care_tasks && timelineData.care_tasks.length > 0 && (
-            <EventSummaryCard title="Care Tasks" color={EVENT_TYPES.care_tasks.color} items={timelineData.care_tasks.map(t => ({
-              time: new Date(t.ts).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
-              text: t.name,
-              subtext: t.category || null,
-            }))} />
-          )}
-          {visibleLayers.nutrition_intake && timelineData.nutrition_intake.length > 0 && (
-            <EventSummaryCard title="Nutrition In" color={EVENT_TYPES.nutrition_intake.color} items={timelineData.nutrition_intake.map(n => ({
-              time: new Date(n.ts).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
-              text: `${n.item_name} - ${n.amount}${n.amount_unit}`,
-              subtext: n.calories ? `${n.calories} cal` : null,
-            }))} />
-          )}
-          {visibleLayers.nutrition_output && timelineData.nutrition_output.length > 0 && (
-            <EventSummaryCard title="Nutrition Out" color={EVENT_TYPES.nutrition_output.color} items={timelineData.nutrition_output.map(o => ({
-              time: new Date(o.ts).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
-              text: getMarkerLabel('nutrition_output', o),
-              subtext: o.notes || null,
-            }))} />
-          )}
-          {visibleLayers.vitals && timelineData.vitals.length > 0 && (
-            <EventSummaryCard title="Vitals" color={EVENT_TYPES.vitals.color} items={timelineData.vitals.map(v => ({
-              time: new Date(v.ts).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
-              text: `${v.vital_type}${v.vital_group ? ` (${v.vital_group})` : ''}: ${v.value}${v.unit || ''}`,
-              subtext: v.notes || null,
-            }))} />
-          )}
-          {visibleLayers.alerts && timelineData.alerts.length > 0 && (
-            <EventSummaryCard title="Alerts" color={EVENT_TYPES.alerts.color} items={timelineData.alerts.map(a => ({
-              time: new Date(a.start).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
-              text: `${a.spo2_alarm ? 'SpO2 Alarm' : ''}${a.hr_alarm ? 'HR Alarm' : ''}${!a.spo2_alarm && !a.hr_alarm ? 'Alert' : ''}`,
-              subtext: a.acknowledged ? 'Acknowledged' : 'Unacknowledged',
-            }))} />
-          )}
+      <div className="mtl-head">
+        <h2>Day timeline</h2>
+        <p>
+          12:00 AM &mdash; {onToday ? 'now' : '11:59 PM'}
+          {lastSample != null && ` · Live data through ${clockTime(new Date(lastSample))}`}
+          {lastSample == null && !loading && ' · No pulse-ox data this day'}
+        </p>
+      </div>
+
+      <div className="mtl-stats">
+        <div className="mtl-stat">
+          <span className="mtl-stat-head" style={{ color: SIGNALS.spo2.color }}>SpO2</span>
+          <dl className="mtl-stat-rows">
+            <div className="mtl-stat-row">
+              <dt>Avg</dt>
+              <dd>{stats.spo2Avg == null ? <span className="mtl-stat-empty">—</span>
+                : <>{stats.spo2Avg.toFixed(1)}<small>%</small></>}</dd>
+            </div>
+            <div className="mtl-stat-row">
+              <dt>Low</dt>
+              <dd>{stats.spo2Low == null ? <span className="mtl-stat-empty">—</span>
+                : <>{stats.spo2Low}<small>%</small></>}</dd>
+            </div>
+          </dl>
         </div>
+        <div className="mtl-stat">
+          <span className="mtl-stat-head" style={{ color: SIGNALS.bpm.color }}>Heart rate</span>
+          <dl className="mtl-stat-rows">
+            <div className="mtl-stat-row">
+              <dt>Avg</dt>
+              <dd>{stats.bpmAvg == null ? <span className="mtl-stat-empty">—</span>
+                : <>{Math.round(stats.bpmAvg)}<small>bpm</small></>}</dd>
+            </div>
+            <div className="mtl-stat-row">
+              <dt>High</dt>
+              <dd>{stats.bpmHigh == null ? <span className="mtl-stat-empty">—</span>
+                : <>{Math.round(stats.bpmHigh)}</>}</dd>
+            </div>
+          </dl>
+        </div>
+        <div className="mtl-stat">
+          <span className="mtl-stat-head" style={{ color: LANES.alerts.color }}>Alerts</span>
+          <span className="mtl-stat-big" style={{ color: LANES.alerts.color }}>{stats.alerts}</span>
+        </div>
+        <div className="mtl-stat">
+          <span className="mtl-stat-head" style={{ color: 'var(--vc-data-live)' }}>Events</span>
+          <span className="mtl-stat-big" style={{ color: 'var(--vc-data-live)' }}>{stats.events}</span>
+        </div>
+      </div>
+
+      <div className="mtl-controls">
+        <span className="mtl-chip" aria-disabled="true">
+          <FilterIcon size={15} />
+          Signals
+          <span className="mtl-chip-count">{shownSignals.length}</span>
+        </span>
+        {SIGNAL_KEYS.map((key) => (
+          <button
+            key={key}
+            type="button"
+            className="mtl-sig"
+            style={{ '--sig': SIGNALS[key].color }}
+            aria-pressed={activeSignals.includes(key)}
+            onClick={() => toggleSignal(key)}
+          >
+            <span className="mtl-sig-dot" />
+            {SIGNALS[key].label}
+          </button>
+        ))}
+        <span className="mtl-spacer" />
+        <button
+          type="button"
+          className="mtl-chip accent"
+          onClick={() => setLanesExpanded((v) => !v)}
+          aria-expanded={lanesExpanded}
+        >
+          Events
+          <span className="mtl-chip-count">{lanesWithData.length}</span>
+          <ChevronDownIcon size={15} style={{ transform: lanesExpanded ? 'rotate(180deg)' : 'none' }} />
+        </button>
+      </div>
+
+      <div className="mtl-ranges" role="group" aria-label="Time range">
+        {RANGES.map((r) => (
+          <button
+            key={r.label}
+            type="button"
+            className={`mtl-range${rangeLabel === r.label ? ' on' : ''}`}
+            aria-pressed={rangeLabel === r.label}
+            onClick={() => applyRange(r.minutes, r.label)}
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+
+      {error && <p className="mtl-error">{error}</p>}
+
+      {loading && !data && <p className="mtl-empty">Loading the day…</p>}
+
+      {data && (
+        <>
+          <section className="mtl-card">
+            <div className="mtl-card-head"><h3>Signals</h3></div>
+            <div
+              className="mtl-stack"
+              ref={stackRef}
+              onPointerDown={onPointerDown}
+              onPointerMove={onPointerMove}
+              onPointerUp={endPointer}
+              onPointerCancel={endPointer}
+              onPointerLeave={endPointer}
+            >
+              {shownSignals.map((key, i) => (
+                <SignalChart
+                  key={key}
+                  signalKey={key}
+                  points={series[key]}
+                  view={view}
+                  bounds={bounds}
+                  alerts={laneItems.alerts}
+                  alarms={alarmsFor(SIGNALS[key].alarmKey, settings)}
+                  cursor={cursor}
+                  showAxis={i === shownSignals.length - 1}
+                  onViewChange={(next) => { setView(next); setRangeLabel(null); }}
+                />
+              ))}
+
+              <div className="mtl-lanes">
+                <div className="mtl-lanes-title">Event lanes</div>
+                {visibleLanes.map((key) => (
+                  <EventLane
+                    key={key}
+                    laneKey={key}
+                    items={laneItems[key] || []}
+                    view={view}
+                    cursor={cursor}
+                    onPick={setCursor}
+                  />
+                ))}
+                {(hiddenWithData > 0 || lanesExpanded) && (
+                  <button type="button" className="mtl-more" onClick={() => setLanesExpanded((v) => !v)}>
+                    <ChevronDownIcon
+                      size={14}
+                      style={{ transform: lanesExpanded ? 'rotate(180deg)' : 'none' }}
+                    />
+                    {lanesExpanded ? 'Fewer lanes' : `+${LANE_KEYS.length - COLLAPSED_LANES} more`}
+                  </button>
+                )}
+              </div>
+
+              <div className="mtl-lanes mtl-envlanes">
+                <div className="mtl-lanes-title">
+                  <span>Room conditions</span>
+                  {roomLocations.length > 1 && (
+                    <select
+                      className="mtl-roompick"
+                      aria-label="Room"
+                      value={roomLocation ?? ''}
+                      onChange={(e) => setRoomLocation(e.target.value)}
+                    >
+                      {roomLocations.map((loc) => (
+                        <option key={loc || '__none__'} value={loc}>
+                          {loc || 'Unspecified room'}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+                {!hasEnvData ? (
+                  <p className="mtl-lane-note">No room readings for this day.</p>
+                ) : (
+                  <>
+                    {envLanes.map((lane) => (
+                      <EnvLane key={lane.metric} lane={lane} view={view} />
+                    ))}
+                    <p className="mtl-lane-note">
+                      {envFlagged === 0
+                        ? 'In range all day.'
+                        : `${envFlagged} of ${envLanes.length} out of range at some point.`}
+                    </p>
+                  </>
+                )}
+              </div>
+
+
+              {cursorVisible && (
+                <div className="mtl-plotbox">
+                  <div className="mtl-scrub" style={{ left: `${cursorFrac * 100}%` }}>
+                    <span className="mtl-scrub-pill">{clockTime(new Date(cursor))}</span>
+                  </div>
+                </div>
+              )}
+            </div>
+          </section>
+
+          <p className="mtl-hint">Drag to inspect · pinch or scroll to zoom</p>
+
+          <section className="mtl-detail">
+            <div className="mtl-detail-main">
+              <div className="mtl-detail-top">
+                <span className="mtl-detail-time">
+                  {cursor == null ? '—' : clockTime(new Date(cursor))}
+                </span>
+                {cursorAlert && (
+                  <span className={`mtl-badge${cursorAlert.end ? '' : ' ongoing'}`}>
+                    {cursorAlert.end ? alertLabel(cursorAlert.alert) : 'Alert ongoing'}
+                  </span>
+                )}
+              </div>
+
+              {cursor == null ? (
+                <p className="mtl-detail-foot" style={{ border: 'none', margin: 0, paddingTop: 0 }}>
+                  Drag across the charts to read a moment.
+                </p>
+              ) : (
+                <>
+                  <dl className="mtl-readout">
+                    <div>
+                      <dt style={{ color: SIGNALS.spo2.color }}>SpO2</dt>
+                      <dd>{cursorSample?.spo2 != null
+                        ? <>{cursorSample.spo2}<small>%</small></>
+                        : <span className="mtl-stat-empty">—</span>}</dd>
+                    </div>
+                    <div>
+                      <dt style={{ color: SIGNALS.bpm.color }}>Heart rate</dt>
+                      <dd>{cursorSample?.bpm != null
+                        ? <>{Math.round(cursorSample.bpm)}<small>bpm</small></>
+                        : <span className="mtl-stat-empty">—</span>}</dd>
+                    </div>
+                    <div>
+                      <dt style={{ color: 'var(--vc-text-secondary)' }}>Perfusion</dt>
+                      <dd>{cursorSample?.perfusion != null
+                        ? cursorSample.perfusion
+                        : <span className="mtl-stat-empty">—</span>}</dd>
+                    </div>
+                  </dl>
+                  {cursorAlert && (
+                    <p className="mtl-detail-foot">
+                      {cursorAlert.end
+                        ? <>Duration <b>{formatDuration(cursorAlert.end - cursorAlert.ts)}</b></>
+                        : <>Started <b>{clockTime(new Date(cursorAlert.ts))}</b> · still open</>}
+                      {cursorAlert.alert.spo2_min != null && <> · low <b>{cursorAlert.alert.spo2_min}%</b></>}
+                      {cursorAlert.alert.oxygen_used && <> · oxygen used</>}
+                    </p>
+                  )}
+                  {!cursorSample && (
+                    <p className="mtl-detail-foot">No pulse-ox reading within a minute of this time.</p>
+                  )}
+                </>
+              )}
+            </div>
+
+            <div className="mtl-detail-side">
+              <span className="mtl-label">Around this time</span>
+              {cursor == null ? (
+                <p className="mtl-detail-foot" style={{ border: 'none', paddingTop: '0.4rem' }}>
+                  Nothing selected yet.
+                </p>
+              ) : nearbyEvents.length === 0 ? (
+                <p className="mtl-detail-foot" style={{ border: 'none', paddingTop: '0.4rem' }}>
+                  No events logged this day.
+                </p>
+              ) : (
+                <p className="mtl-detail-foot" style={{ border: 'none', paddingTop: '0.4rem' }}>
+                  <b>{nearbyEvents.length}</b> nearest {nearbyEvents.length === 1 ? 'entry' : 'entries'} listed below.
+                </p>
+              )}
+            </div>
+          </section>
+
+          <section className="mtl-activity">
+            <div className="mtl-activity-head">
+              <h3>{cursor == null ? 'Activity' : `Activity around ${clockTime(new Date(cursor))}`}</h3>
+              <span className="mtl-label">{allEvents.length} total</span>
+            </div>
+            {allEvents.length === 0 ? (
+              <p className="mtl-empty">Nothing was logged on this day.</p>
+            ) : (
+              (cursor == null ? allEvents.slice(0, 8) : nearbyEvents).map((ev) => {
+                const lane = LANES[ev.type];
+                const Icon = lane.Icon;
+                const on = cursor != null && Math.abs(ev.ts - cursor) < 60_000;
+                return (
+                  <button
+                    key={ev.id}
+                    type="button"
+                    className={`mtl-row${on ? ' on' : ''}`}
+                    style={{ '--lane': lane.color }}
+                    onClick={() => setCursor(ev.ts)}
+                  >
+                    <span className="mtl-row-icon"><Icon size={16} /></span>
+                    <span className="mtl-row-time">{clockTime(new Date(ev.ts))}</span>
+                    <span className="mtl-row-text">{ev.label}</span>
+                  </button>
+                );
+              })
+            )}
+          </section>
+        </>
       )}
     </div>
   );
 };
 
-// Toggle pill for a plottable series. Dashed border = estimated/derived
-// metric (matches the dashed chart line).
-const SeriesChip = ({ seriesKey, cfg, active, onToggle, noData = false }) => (
-  <button
-    onClick={() => onToggle(seriesKey)}
-    style={{
-      display: 'flex', alignItems: 'center', gap: 6,
-      padding: '5px 12px', borderRadius: 16, fontSize: 12, fontWeight: 600,
-      border: `2px ${cfg.dashed ? 'dashed' : 'solid'} ${cfg.color}`,
-      background: active ? cfg.color : 'transparent',
-      color: active ? '#fff' : cfg.color,
-      cursor: 'pointer', transition: 'all 0.15s',
-      opacity: active ? 1 : 0.6,
-    }}
-  >
-    <span style={{ width: 8, height: 8, borderRadius: '50%', background: active ? '#fff' : cfg.color, display: 'inline-block' }} />
-    {cfg.label}
-    {noData && <span style={{ opacity: 0.8, marginLeft: 2 }}>(no data)</span>}
-  </button>
-);
+/* One signal, one scale. Every chart on the page is this component, so the
+ * two can never drift apart in axis geometry or option shape. */
+const SignalChart = ({
+  signalKey, points, view, bounds, alerts, alarms, cursor, showAxis, onViewChange,
+}) => {
+  const cfg = SIGNALS[signalKey];
+  const canvasRef = useRef(null);
+  const chartRef = useRef(null);
+  const onViewChangeRef = useRef(onViewChange);
+  onViewChangeRef.current = onViewChange;
 
-// Compact card showing event list - dark theme
-const EventSummaryCard = ({ title, color, items }) => (
-  <div style={{
-    border: '1px solid var(--border)', borderRadius: 8, overflow: 'hidden',
-    background: 'var(--card)',
-  }}>
-    <div style={{
-      padding: '8px 12px', background: color, color: '#fff',
-      fontSize: 13, fontWeight: 700,
-    }}>
-      {title} ({items.length})
+  /* Y is fixed for the whole day rather than refitted to each window, so
+   * panning and zooming move across a stable scale instead of rescaling under
+   * the reader. niceScale only rounds the bounds outward, which is what keeps
+   * the ticks reading 85 / 90 / 95 instead of 85.8. */
+  const yRange = useMemo(() => {
+    if (!points.length) {
+      return niceScale(cfg.defaultMin, cfg.defaultMax, cfg.minPad, cfg.clampMax);
+    }
+    const ys = points.map((p) => p.y);
+    return niceScale(Math.min(...ys), Math.max(...ys), cfg.minPad, cfg.clampMax);
+  }, [points, cfg]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+
+    const annotations = {};
+    (alerts || []).forEach((a, i) => {
+      annotations[`band${i}`] = {
+        type: 'box',
+        xMin: a.ts,
+        xMax: a.end ?? bounds.end,
+        backgroundColor: CHROME.band,
+        borderColor: CHROME.bandEdge,
+        borderWidth: 0,
+        drawTime: 'beforeDatasetsDraw',
+      };
+    });
+    const line = (value, text) => ({
+      type: 'line',
+      yMin: value,
+      yMax: value,
+      borderColor: CHROME.threshold,
+      borderWidth: 1,
+      borderDash: [5, 4],
+      label: {
+        display: true,
+        content: text,
+        position: 'start',
+        backgroundColor: 'transparent',
+        color: CHROME.axis,
+        font: { size: 10, family: "'IBM Plex Mono', monospace" },
+        padding: 0,
+        yAdjust: -8,
+      },
+    });
+    if (alarms?.low != null) annotations.low = line(alarms.low, `LOW ${alarms.low}`);
+    if (alarms?.high != null) annotations.high = line(alarms.high, `HIGH ${alarms.high}`);
+
+    const chart = new Chart(canvas.getContext('2d'), {
+      type: 'line',
+      data: {
+        datasets: [{
+          label: cfg.axisLabel,
+          data: points,
+          parsing: false,
+          borderColor: cfg.color,
+          borderWidth: 1.4,
+          pointRadius: 0,
+          pointHitRadius: 0,
+          tension: 0.15,
+          spanGaps: false,
+        }],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: false,
+        events: [],                 // scrubbing is owned by the stack, not the canvas
+        layout: { padding: { right: PLOT_RPAD, top: 14, bottom: 0 } },
+        scales: {
+          x: {
+            type: 'time',
+            min: view?.min ?? bounds.start,
+            max: view?.max ?? bounds.end,
+            // No meridiem on minute ticks: at an hour wide they collided,
+            // and the scrubber pill already carries the full clock time.
+            time: { displayFormats: { minute: 'h:mm', hour: 'ha' } },
+            grid: { color: CHROME.grid, drawTicks: false },
+            border: { display: false },
+            ticks: {
+              display: showAxis,
+              color: CHROME.axis,
+              maxRotation: 0,
+              autoSkip: true,
+              autoSkipPadding: 16,
+              maxTicksLimit: 6,
+              font: { size: 10, family: "'IBM Plex Mono', monospace" },
+            },
+          },
+          y: {
+            min: yRange.min,
+            max: yRange.max,
+            grid: { color: CHROME.grid, drawTicks: false },
+            border: { display: false },
+            ticks: {
+              color: CHROME.axis,
+              stepSize: yRange.step,
+              maxTicksLimit: 6,
+              font: { size: 10, family: "'IBM Plex Mono', monospace" },
+            },
+            // Pin the axis width so this chart's plot area starts at exactly
+            // the same x as its sibling's and the lanes below.
+            afterFit: (scale) => { scale.width = PLOT_GUTTER; },
+          },
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: false },
+          annotation: { annotations },
+          zoom: {
+            pan: { enabled: false },   // one-finger drag scrubs instead
+            zoom: {
+              wheel: { enabled: true },
+              pinch: { enabled: true },
+              mode: 'x',
+              onZoomComplete: ({ chart: c }) => {
+                onViewChangeRef.current({ min: c.scales.x.min, max: c.scales.x.max });
+              },
+            },
+            limits: { x: { min: bounds.start, max: bounds.end, minRange: MIN_RANGE_MS } },
+          },
+        },
+      },
+    });
+    chartRef.current = chart;
+    return () => { chart.destroy(); chartRef.current = null; };
+    // View is applied imperatively below so a pan doesn't rebuild the chart.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [points, alerts, alarms, bounds, showAxis, cfg, yRange]);
+
+  // Both charts follow one window. Guarded so the chart that raised the zoom
+  // doesn't get re-set to the value it just reported.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart || !view) return;
+    if (chart.scales.x.min === view.min && chart.scales.x.max === view.max) return;
+    chart.zoomScale('x', { min: view.min, max: view.max }, 'none');
+  }, [view]);
+
+  // The scrubbed point, drawn as a dot on this series.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+    const anns = chart.options.plugins.annotation.annotations;
+    delete anns.cursor;
+    if (cursor != null && points.length) {
+      let best = null;
+      let gap = Infinity;
+      points.forEach((p) => {
+        const d = Math.abs(p.x - cursor);
+        if (d < gap) { gap = d; best = p; }
+      });
+      if (best && gap <= 90_000) {
+        anns.cursor = {
+          type: 'point',
+          xValue: best.x,
+          yValue: best.y,
+          radius: 4,
+          backgroundColor: cfg.color,
+          borderColor: CHROME.grid,
+          borderWidth: 1,
+        };
+      }
+    }
+    chart.update('none');
+  }, [cursor, points, cfg]);
+
+  return (
+    <div className={`mtl-chart${showAxis ? ' tall' : ''}`}>
+      <span className="mtl-chart-title" style={{ color: cfg.color }}>{cfg.axisLabel}</span>
+      <canvas ref={canvasRef} aria-label={`${cfg.label} over time`} />
     </div>
-    <div style={{ maxHeight: 200, overflowY: 'auto' }}>
-      {items.map((item, i) => (
-        <div key={i} style={{
-          padding: '6px 12px', fontSize: 12, borderBottom: '1px solid var(--secondary)',
-          display: 'flex', gap: 8, alignItems: 'baseline',
-        }}>
-          <span style={{ color: 'var(--muted-foreground)', whiteSpace: 'nowrap', fontWeight: 600, minWidth: 60 }}>{item.time}</span>
-          <span style={{ color: 'var(--foreground)' }}>
-            {item.text}
-            {item.subtext && <span style={{ color: 'var(--muted-foreground)', marginLeft: 4, fontSize: 11 }}>({item.subtext})</span>}
-          </span>
-        </div>
-      ))}
+  );
+};
+
+/* One row of markers, sharing the charts' time window and plot box. */
+const EventLane = ({ laneKey, items, view, cursor, onPick }) => {
+  const lane = LANES[laneKey];
+  const span = view ? view.max - view.min : 0;
+  const inWindow = span > 0
+    ? items.filter((it) => it.ts >= view.min && it.ts <= view.max)
+    : [];
+
+  return (
+    <div className="mtl-lane" style={{ '--lane': lane.color }}>
+      <span className="mtl-lane-name">{lane.label}</span>
+      <div className="mtl-lane-track">
+        {inWindow.length === 0 && <span className="mtl-lane-empty">—</span>}
+        {inWindow.map((it) => (
+          <button
+            key={it.id}
+            type="button"
+            className={`mtl-lane-mark${laneKey === 'alerts' ? ' alert' : ''}`
+              + (cursor != null && Math.abs(it.ts - cursor) < 60_000 ? ' on' : '')}
+            style={{ left: `${((it.ts - view.min) / span) * 100}%` }}
+            title={`${clockTime(new Date(it.ts))} — ${it.label}`}
+            aria-label={`${clockTime(new Date(it.ts))} ${it.label}`}
+            onClick={() => onPick(it.ts)}
+          />
+        ))}
+      </div>
     </div>
-  </div>
-);
+  );
+};
+
+/* One room metric across the window.
+ *
+ * Severity is the colour; direction is the position. A high excursion draws in
+ * the top half of the lane and a low one in the bottom half, so "too hot" and
+ * "too cold" are distinguishable without reading a glyph or relying on the
+ * colour alone. Banded lanes (PM2.5) fill the whole height because every band
+ * including the good one is worth seeing. */
+const EnvLane = ({ lane, view }) => {
+  const span = view ? view.max - view.min : 0;
+  const unit = ENV_UNITS[lane.metric] || '';
+  const visible = span > 0
+    ? lane.spans.filter((s) => s.to > view.min && s.from < view.max)
+    : [];
+
+  return (
+    <div className="mtl-lane">
+      <span className="mtl-lane-name">{lane.label}</span>
+      <div className="mtl-lane-track">
+        {visible.length === 0 && <span className="mtl-lane-empty">—</span>}
+        {visible.map((s) => {
+          const from = Math.max(s.from, view.min);
+          const to = Math.min(s.to, view.max);
+          const dir = directionOf(s.status);
+          const sev = severityOf(s.status);
+          return (
+            <span
+              key={`${s.from}-${s.status}`}
+              className={`mtl-env-span sev-${sev}${lane.banded ? ' banded' : ` dir-${dir}`}`}
+              style={{
+                left: `${((from - view.min) / span) * 100}%`,
+                width: `${Math.max(((to - from) / span) * 100, 0.4)}%`,
+              }}
+              title={`${clockTime(new Date(s.from))} — ${describeSpan(lane.label, s, unit)}`}
+            >
+              <span className="sr-only">{describeSpan(lane.label, s, unit)}</span>
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
 
 export default AdminV2MonitoringTimeline;

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.test.jsx
@@ -15,23 +15,36 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-// AdminV2MonitoringTimeline: pulse-ox series picker — SpO2 / BPM / Perfusion
-// chips, at most two active at once (one per y-axis), tap-to-swap behavior.
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act, fireEvent } from '@testing-library/react';
+// Day timeline. The claims worth pinning: the two charts stay one instrument
+// (same window, same plot geometry), the day summary is computed from the
+// payload rather than trusted, an unclosed alert is never given a duration,
+// and the day requested is the local one.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent, within } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const { chartInstances } = vi.hoisted(() => ({ chartInstances: [] }));
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const { charts } = vi.hoisted(() => ({ charts: [] }));
 
 vi.mock('chart.js/auto', () => {
   class MockChart {
-    constructor(ctx, config) {
-      this.config = config;
-      chartInstances.push(this);
+    constructor(ctx, cfg) {
+      this.config = cfg;
+      this.options = cfg.options;
+      this.data = cfg.data;
+      this.scales = {
+        x: { min: cfg.options.scales.x.min, max: cfg.options.scales.x.max },
+        y: { min: cfg.options.scales.y.min, max: cfg.options.scales.y.max },
+      };
+      this.destroyed = false;
+      charts.push(this);
     }
-    destroy() {}
-    resetZoom() {}
-    zoomScale() {}
+    zoomScale(axis, { min, max }) { this.scales[axis] = { min, max }; }
     update() {}
+    destroy() { this.destroyed = true; }
   }
   MockChart.register = () => {};
   return { default: MockChart };
@@ -44,188 +57,405 @@ vi.mock('../../config', () => ({
   apiFetch: (...args) => fetch(...args),
 }));
 vi.mock('../../contexts/AdminPatientContext', () => {
-  // Stable identity: a fresh object per render would retrigger the fetch
-  // effect (selectedPatient is a useCallback dep) and loop forever.
-  const selectedPatient = { id: 5, first_name: 'Test' };
+  // Stable identity: a fresh object each render would retrigger the fetch
+  // effect and loop.
+  const selectedPatient = { id: 5, first_name: 'Test', last_name: 'Testerson' };
   return { useAdminPatient: () => ({ selectedPatient }) };
 });
-vi.mock('../../hooks/useChartColors', () => ({
-  useChartColors: () => ({ grid: '#333', axis: '#999', foreground: '#fff' }),
-}));
 
 import AdminV2MonitoringTimeline from './AdminV2MonitoringTimeline';
 
-const timelinePayload = {
-  date: '2026-07-14',
+const DAY = '2026-08-19';
+const at = (hhmm, s = 0) => `${DAY}T${hhmm}:${String(s).padStart(2, '0')}`;
+
+const payload = {
+  date: DAY,
   pulse_ox: [
-    { ts: '2026-07-14T10:00:00', spo2: 97.2, bpm: 88, perfusion: 1.4 },
-    { ts: '2026-07-14T10:01:00', spo2: 96.8, bpm: 90, perfusion: 1.1 },
-    { ts: '2026-07-14T10:02:00', spo2: null, bpm: 91, perfusion: null },
+    { ts: at('08:00'), spo2: 98, bpm: 70, perfusion: 5.1 },
+    { ts: at('09:00'), spo2: 96, bpm: 80, perfusion: 4.4 },
+    { ts: at('12:57'), spo2: 89, bpm: 84, perfusion: 7.2 },
+    { ts: at('14:00'), spo2: 94, bpm: 112, perfusion: 3.9 },
   ],
-  medications: [],
-  care_tasks: [],
-  nutrition_intake: [],
-  nutrition_output: [],
-  vitals: [],
-  alerts: [],
+  medications: [{ ts: at('12:43'), name: 'Ondansetron', dose: '4 mg', status: 'on-time', notes: '' }],
+  care_tasks: [{ ts: at('07:30'), name: 'Trach care', category: 'Airway', status: 'completed', notes: '' }],
+  nutrition_intake: [{ ts: at('12:30'), item_name: 'Tube feed', item_type: 'formula', amount: 525, amount_unit: 'mL', calories: 500 }],
+  nutrition_output: [{ ts: at('11:00'), output_type: 'urine', is_diaper: false }],
+  vitals: [{ ts: at('10:00'), vital_type: 'temperature', vital_group: null, value: 37.1, unit: 'C', notes: '' }],
+  alerts: [
+    { start: at('12:57'), end: at('12:58', 22), spo2_alarm: true, hr_alarm: false, spo2_min: 89, bpm_min: 84, oxygen_used: false, acknowledged: true },
+    { start: at('14:00'), end: null, spo2_alarm: false, hr_alarm: true, spo2_min: 94, bpm_min: 112, oxygen_used: true, acknowledged: false },
+  ],
 };
 
-const latestChart = () => chartInstances[chartInstances.length - 1];
-const datasetLabels = () => latestChart().config.data.datasets.map(d => d.label);
-const scaleIds = () => Object.keys(latestChart().config.options.scales).filter(k => k !== 'x');
+const SETTINGS = { min_spo2: 90, max_spo2: 100, min_bpm: 55, max_bpm: 155 };
 
-const renderPage = async () => {
-  await act(async () => {
-    render(<AdminV2MonitoringTimeline />);
-  });
+const ENV_RANGES = {
+  patient_id: 5,
+  ranges: [
+    { metric: 'temperature', source: 'default', caution_min: 18, caution_max: 24, critical_min: 15, critical_max: 28 },
+    { metric: 'relative_humidity', source: 'default', caution_min: 30, caution_max: 60, critical_min: 20, critical_max: 70 },
+    { metric: 'co2', source: 'default', caution_min: null, caution_max: 1000, critical_min: null, critical_max: 2000 },
+    { metric: 'pm25', source: 'default', caution_min: null, caution_max: 12, critical_min: null, critical_max: 35 },
+  ],
 };
-
-// Environmental observations (bucketed, newest-first like the real API)
-const envRows = [
-  { ts: '2026-07-14T10:15:00+00:00', metric: 'pressure_delta_6h', avg: -2.4, min: -2.6, max: -2.1, unit: 'hPa' },
-  { ts: '2026-07-14T10:00:00+00:00', metric: 'pressure_delta_6h', avg: -1.8, min: -2.0, max: -1.6, unit: 'hPa' },
+const LOCATIONS = [
+  { scope: 'room', location: 'Bedroom' },
+  { scope: 'room', location: 'Living room' },
+  { scope: 'outdoor', location: '' },
 ];
-
-const stubFetch = ({ observations = [...envRows], locations = [] } = {}) => {
-  vi.stubGlobal('fetch', vi.fn(async (url) => ({
-    ok: true,
-    status: 200,
-    json: async () => {
-      const u = String(url);
-      if (u.includes('/api/environment/observations')) return observations;
-      if (u.includes('/api/environment/locations')) return locations;
-      return timelinePayload;
-    },
-  })));
+// Newest-first, the way the observations API returns them.
+let envObservations = {
+  co2: [
+    { ts: at('14:00'), avg: 2400 },
+    { ts: at('13:45'), avg: 1400 },
+    { ts: at('13:30'), avg: 600 },
+  ],
+  pm25: [
+    { ts: at('13:45'), avg: 40 },
+    { ts: at('13:30'), avg: 5 },
+  ],
+  temperature: [{ ts: at('13:30'), avg: 21 }],
+  relative_humidity: [{ ts: at('13:30'), avg: 45 }],
 };
+
+let timelineBody;
+const calls = [];
 
 beforeEach(() => {
-  chartInstances.length = 0;
-  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({}));
-  stubFetch();
+  charts.length = 0;
+  calls.length = 0;
+  timelineBody = payload;
+  envObservations = {
+    co2: [
+      { ts: at('14:00'), avg: 2400 },
+      { ts: at('13:45'), avg: 1400 },
+      { ts: at('13:30'), avg: 600 },
+    ],
+    pm25: [
+      { ts: at('13:45'), avg: 40 },
+      { ts: at('13:30'), avg: 5 },
+    ],
+    temperature: [{ ts: at('13:30'), avg: 21 }],
+    relative_humidity: [{ ts: at('13:30'), avg: 45 }],
+  };
+  vi.stubGlobal('fetch', vi.fn(async (url) => {
+    const u = String(url);
+    calls.push(u);
+    if (u.includes('/api/settings')) return { ok: true, json: async () => SETTINGS };
+    if (u.includes('/api/environment/ranges')) return { ok: true, json: async () => ENV_RANGES };
+    if (u.includes('/api/environment/locations')) return { ok: true, json: async () => LOCATIONS };
+    if (u.includes('/api/environment/observations')) {
+      const metric = new URL(u, 'http://x').searchParams.get('metric');
+      return { ok: true, json: async () => envObservations[metric] ?? [] };
+    }
+    return { ok: true, json: async () => timelineBody };
+  }));
+  // Chart.js is mocked, but jsdom still has no 2d context.
+  HTMLCanvasElement.prototype.getContext = () => ({});
+});
+afterEach(() => { vi.unstubAllGlobals(); });
+
+const renderPage = async () => {
+  const utils = render(<AdminV2MonitoringTimeline />);
+  await act(async () => { await Promise.resolve(); });
+  return utils;
+};
+
+// A lane marker and its activity row share an accessible name on purpose —
+// they are the same event. Scope clicks to the list so the query is unique.
+const clickActivity = async (name) => {
+  const list = document.querySelector('.mtl-activity');
+  await act(async () => {
+    fireEvent.click(within(list).getByRole('button', { name }));
+  });
+};
+
+describe('day timeline summary', () => {
+  it('computes the day figures from the readings, not from the payload', async () => {
+    await renderPage();
+    // spo2 avg of 98/96/89/94 = 94.25, low 89; bpm avg 86.5, high 112.
+    expect(screen.getByText('94.3')).toBeInTheDocument();
+    expect(screen.getByText('89')).toBeInTheDocument();
+    expect(screen.getByText('87')).toBeInTheDocument();
+    expect(screen.getByText('112')).toBeInTheDocument();
+  });
+
+  it('counts alerts separately from the other events', async () => {
+    await renderPage();
+    const stats = document.querySelector('.mtl-stats');
+    // 2 alerts; 5 non-alert events (med, care task, intake, output, vital).
+    expect(within(stats).getByText('2')).toBeInTheDocument();
+    expect(within(stats).getByText('5')).toBeInTheDocument();
+  });
+
+  it('renders a day with no readings without inventing numbers', async () => {
+    timelineBody = { ...payload, pulse_ox: [], alerts: [] };
+    await renderPage();
+    expect(screen.getByText(/No pulse-ox data this day/)).toBeInTheDocument();
+    expect(document.querySelectorAll('.mtl-stat-empty').length).toBeGreaterThan(0);
+  });
 });
 
-describe('AdminV2MonitoringTimeline vital series picker', () => {
-  it('shows all three chips and defaults to SpO2 + BPM', async () => {
+describe('the two charts are one instrument', () => {
+  it('renders a chart per active signal', async () => {
     await renderPage();
-    expect(screen.getByRole('button', { name: /SpO2/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /BPM/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Perfusion/ })).toBeInTheDocument();
-
-    expect(datasetLabels()).toEqual(['SpO2 (%)', 'BPM']);
-    expect(scaleIds()).toEqual(['y_spo2', 'y_bpm']);
-    expect(latestChart().config.options.scales.y_spo2.position).toBe('left');
-    expect(latestChart().config.options.scales.y_bpm.position).toBe('right');
+    expect(charts.filter((c) => !c.destroyed)).toHaveLength(2);
   });
 
-  it('tapping a third series replaces the oldest selection (max 2 active)', async () => {
+  it('gives both charts the same time window', async () => {
     await renderPage();
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Perfusion/ }));
-    });
-    // SpO2 was oldest, so BPM + Perfusion remain; BPM takes the left axis
-    expect(datasetLabels()).toEqual(['BPM', 'Perfusion (PI)']);
-    expect(latestChart().config.options.scales.y_bpm.position).toBe('left');
-    expect(latestChart().config.options.scales.y_perfusion.position).toBe('right');
+    const [spo2, bpm] = charts.filter((c) => !c.destroyed);
+    expect(spo2.options.scales.x.min).toBe(bpm.options.scales.x.min);
+    expect(spo2.options.scales.x.max).toBe(bpm.options.scales.x.max);
   });
 
-  it('tapping an active series removes it, leaving a single left axis', async () => {
+  it('pins both y-axes to the same width so the plot boxes line up', async () => {
     await renderPage();
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /BPM/ }));
+    const widths = charts.filter((c) => !c.destroyed).map((c) => {
+      const scale = { width: 0 };
+      c.options.scales.y.afterFit(scale);
+      return scale.width;
     });
-    expect(datasetLabels()).toEqual(['SpO2 (%)']);
-    expect(scaleIds()).toEqual(['y_spo2']);
-    expect(latestChart().config.options.scales.y_spo2.position).toBe('left');
+    expect(widths).toEqual([52, 52]);
+    // …and the stylesheet insets the lanes and scrubber by that same gutter.
+    // jsdom does not apply the imported CSS, so read the contract from source:
+    // if these two ever disagree the markers stop landing on their samples.
+    const css = readFileSync(resolve(__dirname, 'monitoring-timeline.css'), 'utf8');
+    expect(css).toMatch(/--mtl-gutter:\s*52px/);
+    expect(css).toMatch(/--mtl-rpad:\s*12px/);
   });
 
-  it('perfusion dataset uses perfusion values and skips null readings', async () => {
+  it('only the bottom chart draws time labels', async () => {
     await renderPage();
+    const shown = charts.filter((c) => !c.destroyed).map((c) => c.options.scales.x.ticks.display);
+    expect(shown).toEqual([false, true]);
+  });
+
+  it('each chart keeps its own y scale', async () => {
+    await renderPage();
+    const [spo2, bpm] = charts.filter((c) => !c.destroyed);
+    expect(spo2.options.scales.y.max).toBeLessThanOrEqual(100);
+    expect(bpm.options.scales.y.max).toBeGreaterThan(100);
+  });
+
+  it('a zoom on one chart moves the other', async () => {
+    await renderPage();
+    const before = charts.filter((c) => !c.destroyed);
+    const min = new Date(at('12:00')).getTime();
+    const max = new Date(at('13:00')).getTime();
+    before[0].scales.x = { min, max };
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Perfusion/ }));
+      before[0].options.plugins.zoom.zoom.onZoomComplete({ chart: before[0] });
     });
-    const perfusion = latestChart().config.data.datasets.find(d => d.label === 'Perfusion (PI)');
-    expect(perfusion.data.map(p => p.y)).toEqual([1.4, 1.1]);
-    expect(perfusion.yAxisID).toBe('y_perfusion');
+    const after = charts.filter((c) => !c.destroyed);
+    expect(after[1].scales.x).toEqual({ min, max });
   });
 });
 
-describe('AdminV2MonitoringTimeline environmental overlays', () => {
-  it('renders env chips alongside the vitals chips', async () => {
+describe('signal toggles', () => {
+  it('turning a signal off drops its chart', async () => {
     await renderPage();
-    expect(screen.getByRole('button', { name: /Pressure Δ6h/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Humidity \(out\)/ })).toBeInTheDocument();
-    // Room-scoped series chips
-    expect(screen.getByRole('button', { name: /Room temp/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Room humidity/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /CO2/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /PM2\.5/ })).toBeInTheDocument();
-    expect(screen.getByText('Env:')).toBeInTheDocument();
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Heart Rate/ })); });
+    expect(charts.filter((c) => !c.destroyed)).toHaveLength(1);
   });
 
-  it('activating an env metric fetches it and plots a dashed series', async () => {
+  it('refuses to leave the card with no signal in it', async () => {
     await renderPage();
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Pressure Δ6h/ }));
-    });
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Heart Rate/ })); });
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /^SpO2/ })); });
+    expect(charts.filter((c) => !c.destroyed)).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /^SpO2/ })).toHaveAttribute('aria-pressed', 'true');
+  });
+});
 
-    // Swap-oldest still applies: SpO2 (oldest) dropped, BPM + delta active
-    expect(datasetLabels()).toEqual(['BPM', 'Pressure change 6h (hPa)']);
-    const delta = latestChart().config.data.datasets
-      .find(d => d.label === 'Pressure change 6h (hPa)');
-    expect(delta.borderDash).toEqual([6, 4]);
-    // Ascending after the newest-first reverse, values intact
-    expect(delta.data.map(p => p.y)).toEqual([-1.8, -2.4]);
-    // Negative delta axis must not be clamped to zero
-    expect(latestChart().config.options.scales.y_pressure_delta_6h.min).toBeLessThan(0);
-    const envCall = fetch.mock.calls
-      .map(c => String(c[0])).find(u => u.includes('/api/environment/observations'));
-    expect(envCall).toContain('metric=pressure_delta_6h');
-    expect(envCall).toContain('bucket=15m');
+describe('alarm thresholds', () => {
+  it('draws the configured floor, not an invented one', async () => {
+    await renderPage();
+    const [spo2, bpm] = charts.filter((c) => !c.destroyed);
+    expect(spo2.options.plugins.annotation.annotations.low.yMin).toBe(90);
+    expect(spo2.options.plugins.annotation.annotations.high).toBeUndefined();
+    expect(bpm.options.plugins.annotation.annotations.low.yMin).toBe(55);
+    expect(bpm.options.plugins.annotation.annotations.high.yMin).toBe(155);
+  });
+});
+
+describe('alert bands', () => {
+  it('bands every alert on both charts', async () => {
+    await renderPage();
+    charts.filter((c) => !c.destroyed).forEach((c) => {
+      const boxes = Object.entries(c.options.plugins.annotation.annotations)
+        .filter(([k]) => k.startsWith('band'));
+      expect(boxes).toHaveLength(2);
+    });
   });
 
-  it('an empty env day still renders and marks the chip (no data)', async () => {
-    stubFetch({ observations: [] });
+  it('runs an unclosed alert to the end of the day rather than stopping it early', async () => {
     await renderPage();
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Humidity \(out\)/ }));
-    });
-    expect(screen.getByText('(no data)')).toBeInTheDocument();
-    expect(datasetLabels()).toContain('Outdoor humidity (%)');
+    const [spo2] = charts.filter((c) => !c.destroyed);
+    const open = spo2.options.plugins.annotation.annotations.band1;
+    const endOfDay = new Date(`${DAY}T23:59:59.999`).getTime();
+    expect(open.xMax).toBe(endOfDay);
+  });
+});
+
+describe('the scrubbed moment', () => {
+  it('reads the sample at the selected time, perfusion included', async () => {
+    await renderPage();
+    await clickActivity(/12:57 PM Low SpO2 alert/);
+    const detail = document.querySelector('.mtl-detail-main');
+    expect(within(detail).getByText('89')).toBeInTheDocument();
+    expect(within(detail).getByText('84')).toBeInTheDocument();
+    expect(within(detail).getByText('7.2')).toBeInTheDocument();
   });
 
-  it('room series fetch scope=room with the default room and show the picker', async () => {
-    stubFetch({
-      observations: [
-        { ts: '2026-07-14T10:00:00+00:00', metric: 'co2', avg: 640, min: 620, max: 660, unit: 'ppm' },
-      ],
-      locations: [
-        { scope: 'room', location: 'Living Room', last_seen: null, metric_count: 2 },
-        { scope: 'room', location: 'Bedroom', last_seen: null, metric_count: 3 },
-        { scope: 'outdoor', location: '', last_seen: null, metric_count: 9 },
-      ],
-    });
+  it('gives a closed alert its duration', async () => {
     await renderPage();
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /CO2/ }));
-    });
-
-    // Default room prefers the bedroom-ish name; fetch is room-scoped.
-    const envCall = fetch.mock.calls
-      .map(c => String(c[0])).find(u => u.includes('metric=co2'));
-    expect(envCall).toContain('scope=room');
-    expect(envCall).toContain('location=Bedroom');
-    // Series label carries the room; the room picker combobox is rendered.
-    expect(datasetLabels()).toContain('CO2 (ppm) — Bedroom');
-    expect(screen.getByRole('combobox')).toHaveTextContent('Bedroom');
+    await clickActivity(/12:57 PM Low SpO2 alert/);
+    expect(screen.getByText(/1m 22s/)).toBeInTheDocument();
   });
 
-  it('no room picker is shown when no room-scoped data exists', async () => {
+  it('says an unclosed alert is still open instead of timing it', async () => {
     await renderPage();
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Room temp/ }));
+    await clickActivity(/2:00 PM Heart rate alert/);
+    expect(screen.getByText(/still open/)).toBeInTheDocument();
+    expect(screen.getByText('Alert ongoing')).toBeInTheDocument();
+    expect(screen.queryByText(/Duration/)).not.toBeInTheDocument();
+  });
+
+  it('will not read a value for a time with no nearby sample', async () => {
+    await renderPage();
+    await clickActivity(/7:30 AM Trach care/);
+    expect(screen.getByText(/No pulse-ox reading within a minute/)).toBeInTheDocument();
+  });
+});
+
+describe('event lanes', () => {
+  it('shows four lanes until asked for the rest', async () => {
+    await renderPage();
+    // Scoped: the room-condition lanes share the .mtl-lane class.
+    const events = () => document.querySelectorAll('.mtl-lanes:not(.mtl-envlanes) .mtl-lane');
+    expect(events()).toHaveLength(4);
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /more/i })); });
+    expect(events()).toHaveLength(6);
+  });
+
+  it('places a marker by its position in the visible window', async () => {
+    await renderPage();
+    const mark = document.querySelector('.mtl-lanes:not(.mtl-envlanes) .mtl-lane-mark');
+    // 12:57 PM of a full day ≈ 54%.
+    expect(parseFloat(mark.style.left)).toBeCloseTo(53.96, 1);
+  });
+});
+
+describe('the day it asks for', () => {
+  it('uses the local calendar date, not the UTC one', async () => {
+    // 11pm on the 19th in a zone behind UTC is already the 20th in UTC; the
+    // request must still be for the 19th.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 7, 19, 23, 30));
+    try {
+      await renderPage();
+      expect(calls.find((c) => c.includes('/api/monitoring/timeline')))
+        .toContain('target_date=2026-08-19');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('time cuts', () => {
+  it('offers the whole ladder down to a minute', async () => {
+    await renderPage();
+    const group = screen.getByRole('group', { name: 'Time range' });
+    expect(within(group).getAllByRole('button').map((b) => b.textContent))
+      .toEqual(['24H', '6H', '1H', '30M', '5M', '1M']);
+  });
+
+  it('narrows the window to the chosen span', async () => {
+    await renderPage();
+    await clickActivity(/12:57 PM Low SpO2 alert/);
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: '5M' })); });
+    const [spo2, bpm] = charts.filter((c) => !c.destroyed);
+    expect(spo2.scales.x.max - spo2.scales.x.min).toBe(5 * 60_000);
+    // …and the sibling came with it.
+    expect(bpm.scales.x).toEqual(spo2.scales.x);
+  });
+
+  it('keeps a narrow cut inside the day at the edges', async () => {
+    await renderPage();
+    await clickActivity(/7:30 AM Trach care/);
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: '1M' })); });
+    const [spo2] = charts.filter((c) => !c.destroyed);
+    const dayStart = new Date(`${DAY}T00:00:00`).getTime();
+    const dayEnd = new Date(`${DAY}T23:59:59.999`).getTime();
+    expect(spo2.scales.x.min).toBeGreaterThanOrEqual(dayStart);
+    expect(spo2.scales.x.max).toBeLessThanOrEqual(dayEnd);
+    expect(spo2.scales.x.max - spo2.scales.x.min).toBe(60_000);
+  });
+});
+
+describe('room condition lanes', () => {
+  it('draws a lane per judged metric', async () => {
+    await renderPage();
+    const env = document.querySelector('.mtl-envlanes');
+    expect(within(env).getByText('Room °C')).toBeInTheDocument();
+    expect(within(env).getByText('Humidity')).toBeInTheDocument();
+    expect(within(env).getByText('CO2')).toBeInTheDocument();
+    expect(within(env).getByText('PM2.5')).toBeInTheDocument();
+  });
+
+  it('flags only what is out of bounds, at the right severity', async () => {
+    await renderPage();
+    const env = document.querySelector('.mtl-envlanes');
+    // CO2 ran 600 (ok) -> 1400 (caution) -> 2400 (critical).
+    expect(env.querySelectorAll('.mtl-env-span.sev-caution.dir-high')).toHaveLength(1);
+    expect(env.querySelectorAll('.mtl-env-span.sev-critical.dir-high')).toHaveLength(1);
+    // Temperature and humidity sat in range, so they draw nothing.
+    expect(env.querySelectorAll('.mtl-lane-empty').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('bands PM2.5 across its whole day, good stretches included', async () => {
+    await renderPage();
+    const env = document.querySelector('.mtl-envlanes');
+    const banded = env.querySelectorAll('.mtl-env-span.banded');
+    expect(banded).toHaveLength(2);
+    expect(banded[0].className).toContain('sev-ok');
+    expect(banded[1].className).toContain('sev-critical');
+  });
+
+  it('encodes direction as position, not just colour', async () => {
+    envObservations.temperature = [{ ts: at('13:30'), avg: 12 }];
+    await renderPage();
+    const cold = document.querySelector('.mtl-envlanes .mtl-env-span.dir-low');
+    expect(cold).toBeTruthy();
+    expect(cold.className).toContain('sev-critical');
+  });
+
+  it('summarises how much of the room was out of range', async () => {
+    await renderPage();
+    expect(screen.getByText('2 of 4 out of range at some point.')).toBeInTheDocument();
+  });
+
+  it('says so when the room was never measured', async () => {
+    envObservations = {};
+    await renderPage();
+    expect(screen.getByText('No room readings for this day.')).toBeInTheDocument();
+  });
+
+  it('asks for the room the patient is in, at room scope', async () => {
+    await renderPage();
+    const obs = calls.filter((c) => c.includes('/api/environment/observations'));
+    expect(obs).toHaveLength(4);
+    obs.forEach((c) => {
+      expect(c).toContain('scope=room');
+      expect(c).toContain('location=Bedroom');
     });
-    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
-    expect(screen.getByText('(no data)')).toBeInTheDocument();
+  });
+
+  it('offers the rooms that have readings', async () => {
+    await renderPage();
+    const picker = screen.getByRole('combobox', { name: 'Room' });
+    expect([...picker.options].map((o) => o.textContent))
+      .toEqual(['Bedroom', 'Living room']);
   });
 });

--- a/frontend/src/pages/admin-v2/AdminV2PatientDetail.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2PatientDetail.jsx
@@ -21,6 +21,7 @@ import config from '../../config';
 import AdminV2Layout from './AdminV2Layout';
 import PatientFormFields from '../../components/PatientFormFields';
 import VitalRangesCard from '../../components/vitals/VitalRangesCard';
+import EnvRangesCard from '../../components/environment/EnvRangesCard';
 import CustomVitalsCard from '../../components/vitals/CustomVitalsCard';
 import { MQTT_SECTIONS, permOptionsForSection, permSelectClass } from './mqttConstants';
 import { ChevronLeftIcon } from '../../components/Icons';
@@ -388,6 +389,7 @@ export default function AdminV2PatientDetail() {
                             onChanged={() => setVitalConfigVersion((v) => v + 1)} />
           {/* Re-mount on custom-vital changes so the ranges list picks them up. */}
           <VitalRangesCard key={vitalConfigVersion} patientId={patientId} />
+          <EnvRangesCard patientId={patientId} />
         </div>
       </div>
     </AdminV2Layout>

--- a/frontend/src/pages/admin-v2/AdminV2ReportsOvernight.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2ReportsOvernight.test.jsx
@@ -156,7 +156,16 @@ describe('AdminV2ReportsOvernight', () => {
   it('drops the event markers off the chart when they are switched off', async () => {
     setup();
     await screen.findByText('Episodes');
-    const annotations = () => chartInstances[chartInstances.length - 2].config.options.plugins.annotation.annotations;
+    // Identify the chart by what is on it, not by where it landed in the
+    // construction order: indexing from the end raced the second chart's
+    // creation and picked up an undefined under CI load.
+    const annotated = () => chartInstances.filter(
+      (c) => c.config?.options?.plugins?.annotation?.annotations?.alarm);
+    await waitFor(() => expect(annotated().length).toBeGreaterThan(0));
+    const annotations = () => {
+      const charts = annotated();
+      return charts[charts.length - 1].config.options.plugins.annotation.annotations;
+    };
     expect(Object.keys(annotations()).some(k => k.startsWith('band'))).toBe(true);
     expect(annotations().alarm).toMatchObject({ yMin: 90 });
     fireEvent.click(screen.getByLabelText('Event markers'));

--- a/frontend/src/pages/admin-v2/monitoring-timeline.css
+++ b/frontend/src/pages/admin-v2/monitoring-timeline.css
@@ -1,0 +1,688 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Day timeline — vc-native, dark by design in both app themes (same stance as
+ * symptom-log.css and clinical-summary.css). Tokens only, no raw hex.
+ *
+ * Alignment contract: the two signal charts, the event lanes and the scrubber
+ * all share one horizontal plot box. Chart.js is forced to a fixed y-axis
+ * width (--mtl-gutter) via scale.afterFit, and everything else is inset by the
+ * same gutter, so a time maps to the same x in all of them. Change the gutter
+ * here and in PLOT_GUTTER in the page — they must agree. */
+@import '../../styles/vc-tokens.css';
+
+.mtl {
+  --mtl-gutter: 52px;
+  --mtl-rpad: 12px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-variant-numeric: tabular-nums;
+}
+.mtl *,
+.mtl *::before,
+.mtl *::after {
+  /* The page lives outside the .tw preflight scope, where the UA default is
+     content-box — width:100% controls would overflow their cards. */
+  box-sizing: border-box;
+}
+
+.mtl-label {
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* ---------- date nav ---------- */
+.mtl-datenav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.mtl-navbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  height: 36px;
+  min-width: 36px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.mtl-navbtn:hover:not(:disabled) {
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-primary);
+}
+.mtl-navbtn:disabled { opacity: 0.4; cursor: default; }
+.mtl-navbtn.on {
+  border-color: var(--vc-data-live);
+  color: var(--vc-data-live);
+}
+.mtl-datepill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 36px;
+  padding: 0 0.75rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  font-family: var(--vc-font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: var(--vc-text-primary);
+}
+/* The native picker sits invisibly over the pill so the whole pill is the
+   control, including its calendar glyph. */
+.mtl-datepill input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  color-scheme: dark;
+}
+.mtl-datepill svg { color: var(--vc-text-secondary); flex-shrink: 0; }
+
+/* ---------- heading ---------- */
+.mtl-head h2 {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.mtl-head p {
+  margin: 0.15rem 0 0;
+  font-size: 0.82rem;
+  color: var(--vc-text-secondary);
+}
+
+/* ---------- stat strip ---------- */
+.mtl-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+.mtl-stat {
+  padding: 0.7rem 0.9rem;
+  border-right: 1px solid var(--vc-line-hairline);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.mtl-stat:last-child { border-right: none; }
+.mtl-stat-head {
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.mtl-stat-rows { display: flex; flex-direction: column; gap: 0.1rem; }
+.mtl-stat-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-family: var(--vc-font-mono);
+  font-size: 0.82rem;
+}
+.mtl-stat-row dt {
+  color: var(--vc-text-tertiary);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  min-width: 2.6em;
+}
+.mtl-stat-row dd { margin: 0; color: var(--vc-text-primary); font-weight: 600; }
+.mtl-stat-row dd small { font-weight: 400; color: var(--vc-text-secondary); }
+.mtl-stat-big {
+  font-family: var(--vc-font-mono);
+  font-size: 1.6rem;
+  font-weight: 600;
+  line-height: 1.1;
+}
+.mtl-stat-empty { color: var(--vc-text-tertiary); font-weight: 400; }
+
+@media (max-width: 620px) {
+  .mtl-stat { border-right: none; border-bottom: 1px solid var(--vc-line-hairline); }
+  .mtl-stat:last-child { border-bottom: none; }
+}
+
+/* ---------- control row ---------- */
+.mtl-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.mtl-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  height: 38px;
+  padding: 0 0.8rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 9px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.mtl-chip[aria-disabled='true'] { cursor: default; }
+.mtl-chip svg { flex-shrink: 0; }
+.mtl-chip-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  border-radius: 5px;
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-primary);
+  font-size: 0.7rem;
+}
+.mtl-chip.accent .mtl-chip-count {
+  background: color-mix(in srgb, var(--vc-state-alert) 22%, transparent);
+  color: var(--vc-state-alert);
+}
+.mtl-spacer { flex: 1 1 auto; }
+
+/* Signal toggles carry their series colour as an inline --sig custom property
+   so one rule serves every series. */
+.mtl-sig {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 38px;
+  padding: 0 0.9rem;
+  border: 1px solid var(--sig, var(--vc-line-strong));
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--sig, var(--vc-data-live)) 12%, transparent);
+  color: var(--sig, var(--vc-text-primary));
+  font-family: var(--vc-font-sans);
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.mtl-sig[aria-pressed='false'] {
+  border-color: var(--vc-line-hairline);
+  background: transparent;
+  color: var(--vc-text-tertiary);
+}
+.mtl-sig-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+/* ---------- range segmented control ---------- */
+.mtl-ranges {
+  align-self: flex-end;
+  max-width: 100%;
+  display: inline-flex;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 9px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+/* Six cuts have to fit a phone, so they share the row evenly rather than each
+   claiming a comfortable width. */
+.mtl-range {
+  flex: 1 1 0;
+  min-width: 46px;
+  height: 34px;
+  padding: 0 0.4rem;
+  border: none;
+  border-right: 1px solid var(--vc-line-hairline);
+  background: transparent;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+.mtl-range:last-child { border-right: none; }
+.mtl-range:hover { color: var(--vc-text-primary); }
+.mtl-range.on {
+  background: color-mix(in srgb, var(--vc-data-live) 20%, transparent);
+  color: var(--vc-data-live);
+}
+
+/* ---------- signals card ---------- */
+.mtl-card {
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+.mtl-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem;
+}
+.mtl-card-head h3 {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* The stack that the scrubber spans: both charts plus the lanes. */
+.mtl-stack { position: relative; touch-action: pan-y; }
+
+.mtl-chart {
+  position: relative;
+  height: 168px;
+  padding: 0 0 0.2rem;
+}
+.mtl-chart.tall { height: 190px; }
+.mtl-chart-title {
+  position: absolute;
+  top: 2px;
+  left: var(--mtl-gutter);
+  z-index: 1;
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+/* Scrubber: one line across the whole stack, positioned inside the shared
+   plot box so it lands on the same instant in both charts and every lane. */
+.mtl-plotbox {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--mtl-gutter);
+  right: var(--mtl-rpad);
+  pointer-events: none;
+}
+.mtl-scrub {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--vc-data-live);
+  transform: translateX(-0.5px);
+}
+.mtl-scrub-pill {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.15rem 0.45rem;
+  border-radius: 5px;
+  background: var(--vc-data-live);
+  color: var(--vc-bg-base);
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* ---------- event lanes ---------- */
+.mtl-lanes {
+  border-top: 1px solid var(--vc-line-hairline);
+  padding-top: 0.5rem;
+}
+.mtl-lanes-title {
+  padding: 0 0.9rem 0.35rem;
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.mtl-lane {
+  display: flex;
+  align-items: stretch;
+  min-height: 34px;
+  border-top: 1px solid var(--vc-line-hairline);
+}
+.mtl-lane-name {
+  width: var(--mtl-gutter);
+  flex-shrink: 0;
+  padding-right: 0.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-family: var(--vc-font-mono);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-align: right;
+  line-height: 1.1;
+  color: var(--lane, var(--vc-text-secondary));
+}
+.mtl-lane-track {
+  position: relative;
+  flex: 1;
+  margin-right: var(--mtl-rpad);
+  border-left: 1px solid var(--vc-line-hairline);
+}
+.mtl-lane-mark {
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  margin: -6px 0 0 -6px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: var(--lane, var(--vc-data-live));
+  cursor: pointer;
+}
+.mtl-lane-mark:hover,
+.mtl-lane-mark.on {
+  outline: 2px solid var(--vc-text-primary);
+  outline-offset: 1px;
+}
+/* Alerts get a triangle so the lane is still readable without its colour. */
+.mtl-lane-mark.alert {
+  border-radius: 0;
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+}
+.mtl-lane-empty {
+  position: absolute;
+  top: 50%;
+  left: 0.5rem;
+  transform: translateY(-50%);
+  font-size: 0.7rem;
+  color: var(--vc-text-tertiary);
+}
+.mtl-more {
+  width: 100%;
+  padding: 0.45rem 0.9rem;
+  border: none;
+  border-top: 1px solid var(--vc-line-hairline);
+  background: transparent;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.mtl-more:hover { color: var(--vc-text-primary); }
+
+.mtl-hint {
+  font-size: 0.74rem;
+  color: var(--vc-text-tertiary);
+  padding-left: 0.15rem;
+}
+
+/* ---------- detail panel ---------- */
+.mtl-detail {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+@media (max-width: 720px) {
+  .mtl-detail { grid-template-columns: minmax(0, 1fr); }
+}
+.mtl-detail-main { padding: 0.85rem 1rem; }
+.mtl-detail-side {
+  padding: 0.85rem 1rem;
+  border-left: 1px solid var(--vc-line-hairline);
+}
+@media (max-width: 720px) {
+  .mtl-detail-side { border-left: none; border-top: 1px solid var(--vc-line-hairline); }
+}
+.mtl-detail-top {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 0.6rem;
+}
+.mtl-detail-time {
+  font-family: var(--vc-font-mono);
+  font-size: 1.3rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.mtl-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--vc-state-alert);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--vc-state-alert) 14%, transparent);
+  color: var(--vc-state-alert);
+  font-family: var(--vc-font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.mtl-badge.ongoing {
+  border-color: var(--vc-state-due);
+  background: color-mix(in srgb, var(--vc-state-due) 14%, transparent);
+  color: var(--vc-state-due);
+}
+.mtl-readout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 1.6rem;
+  margin: 0;
+}
+.mtl-readout > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.3rem 0;
+}
+.mtl-readout dt {
+  font-family: var(--vc-font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.mtl-readout dd {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+}
+.mtl-readout dd small {
+  font-size: 0.7rem;
+  font-weight: 400;
+  color: var(--vc-text-secondary);
+  margin-left: 0.2rem;
+}
+.mtl-detail-foot {
+  margin: 0.6rem 0 0;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--vc-line-hairline);
+  font-size: 0.82rem;
+  color: var(--vc-text-secondary);
+}
+.mtl-detail-foot b { color: var(--vc-text-primary); font-weight: 600; }
+
+/* ---------- activity list ---------- */
+.mtl-activity { border: 1px solid var(--vc-line-hairline); border-radius: 10px; background: var(--vc-bg-surface); overflow: hidden; }
+.mtl-activity-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.mtl-activity-head h3 {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.mtl-row {
+  display: grid;
+  grid-template-columns: 30px 74px minmax(0, 1fr);
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  padding: 0.5rem 0.9rem;
+  border: none;
+  border-bottom: 1px solid var(--vc-line-hairline);
+  background: transparent;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-size: 0.86rem;
+  text-align: left;
+  cursor: pointer;
+}
+.mtl-row:last-child { border-bottom: none; }
+.mtl-row:hover { background: var(--vc-bg-raised); }
+.mtl-row.on { background: var(--vc-bg-raised); color: var(--vc-data-live); }
+.mtl-row-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--lane, var(--vc-text-secondary));
+}
+.mtl-row-time {
+  font-family: var(--vc-font-mono);
+  font-size: 0.78rem;
+  color: var(--vc-text-secondary);
+  white-space: nowrap;
+}
+.mtl-row.on .mtl-row-time { color: var(--vc-data-live); }
+.mtl-row-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ---------- states ---------- */
+.mtl-empty {
+  padding: 2.5rem 1rem;
+  text-align: center;
+  color: var(--vc-text-secondary);
+  font-size: 0.9rem;
+}
+.mtl-error {
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--vc-state-alert);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
+  color: var(--vc-text-primary);
+  font-size: 0.88rem;
+}
+
+/* ---------- room condition lanes ---------- */
+.mtl-lanes-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+.mtl-roompick {
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 6px;
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: none;
+  padding: 0.15rem 0.3rem;
+}
+.mtl-lane-note {
+  margin: 0;
+  padding: 0.4rem 0.9rem 0.1rem;
+  font-size: 0.74rem;
+  color: var(--vc-text-tertiary);
+}
+
+/* Colour carries severity, vertical position carries direction — so a lane is
+   still readable in greyscale and by someone who cannot separate the hues. */
+.mtl-env-span {
+  position: absolute;
+  border-radius: 2px;
+  min-width: 2px;
+}
+.mtl-env-span.dir-high { top: 4px; height: 9px; }
+.mtl-env-span.dir-low { bottom: 4px; height: 9px; }
+.mtl-env-span.banded { top: 8px; height: 14px; border-radius: 0; }
+.mtl-env-span.sev-ok { background: color-mix(in srgb, var(--vc-state-complete) 55%, transparent); }
+.mtl-env-span.sev-caution { background: var(--vc-state-due); }
+.mtl-env-span.sev-critical { background: var(--vc-state-alert); }
+.mtl-env-span.sev-unknown { background: var(--vc-line-strong); }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/src/pages/admin-v2/timelineEnv.js
+++ b/frontend/src/pages/admin-v2/timelineEnv.js
@@ -1,0 +1,130 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Turning room readings into the timeline's environment lanes.
+//
+// Kept apart from the page because this is the part with rules in it: which
+// band a reading falls in, and where one band stops and the next starts.
+
+/* The lanes, in the order they read. `banded` metrics show their whole day as
+ * a continuous strip because every state is worth seeing (PM2.5 being fine all
+ * afternoon is information); the rest only draw where they are out of bounds,
+ * so an empty lane means an uneventful one. */
+export const ENV_LANES = [
+  { metric: 'temperature', label: 'Room °C', banded: false },
+  { metric: 'relative_humidity', label: 'Humidity', banded: false },
+  { metric: 'co2', label: 'CO2', banded: false },
+  { metric: 'pm25', label: 'PM2.5', banded: true },
+];
+
+export const ENV_METRIC_KEYS = ENV_LANES.map((l) => l.metric);
+
+/* Where one reading sits against a patient's bounds.
+ *
+ * Critical is tested before caution so a reading past both reports the worse
+ * of the two, and each side is only tested when a bound exists — a missing
+ * bound means "no opinion", never zero. */
+export function classifyEnv(value, range) {
+  if (value == null || Number.isNaN(value) || !range) return 'unknown';
+  const { caution_min: cLo, caution_max: cHi,
+    critical_min: xLo, critical_max: xHi } = range;
+  if (xHi != null && value > xHi) return 'critical-high';
+  if (xLo != null && value < xLo) return 'critical-low';
+  if (cHi != null && value > cHi) return 'caution-high';
+  if (cLo != null && value < cLo) return 'caution-low';
+  return 'ok';
+}
+
+export const isOutOfBounds = (status) =>
+  status !== 'ok' && status !== 'unknown';
+
+export const severityOf = (status) => {
+  if (status.startsWith('critical')) return 'critical';
+  if (status.startsWith('caution')) return 'caution';
+  return status === 'ok' ? 'ok' : 'unknown';
+};
+
+export const directionOf = (status) => {
+  if (status.endsWith('-high')) return 'high';
+  if (status.endsWith('-low')) return 'low';
+  return null;
+};
+
+/**
+ * Collapse bucketed readings into contiguous spans of one status.
+ *
+ * Adjacent buckets of the same status merge, so an hour over the CO2 ceiling
+ * is one bar rather than four. A gap longer than one bucket breaks the span
+ * instead of bridging it — the room was not measured then, and drawing
+ * straight through would assert a reading nobody took.
+ *
+ * @param rows      [{ ts: epoch ms, value: number }] ascending
+ * @param range     the patient's bounds for this metric
+ * @param bucketMs  nominal spacing between readings
+ * @param keepOk    include in-bounds spans (banded lanes) or drop them
+ */
+export function buildEnvSpans(rows, range, bucketMs, { keepOk = false } = {}) {
+  const spans = [];
+  let current = null;
+
+  const close = () => {
+    if (!current) return;
+    if (keepOk || isOutOfBounds(current.status)) spans.push(current);
+    current = null;
+  };
+
+  rows.forEach((row) => {
+    const status = classifyEnv(row.value, range);
+    const brokeByGap = current && row.ts - current.to > bucketMs * 1.5;
+    if (current && (current.status !== status || brokeByGap)) close();
+    if (!current) {
+      current = { status, from: row.ts, to: row.ts, peak: row.value, samples: 0 };
+    }
+    current.to = row.ts;
+    current.samples += 1;
+    // Peak is the reading that best justifies the span's colour: the extreme
+    // in whatever direction the span is flagged.
+    if (row.value != null) {
+      const dir = directionOf(status);
+      if (dir === 'low') current.peak = Math.min(current.peak ?? row.value, row.value);
+      else current.peak = Math.max(current.peak ?? row.value, row.value);
+    }
+  });
+  close();
+
+  // A span covers the bucket it ends in, not just the instant it started.
+  return spans.map((s) => ({ ...s, to: s.to + bucketMs }));
+}
+
+/** Worst status seen across a day's spans, for the lane's summary chip. */
+export function worstStatus(spans) {
+  let worst = 'ok';
+  spans.forEach((s) => {
+    const sev = severityOf(s.status);
+    if (sev === 'critical') worst = 'critical';
+    else if (sev === 'caution' && worst !== 'critical') worst = 'caution';
+  });
+  return worst;
+}
+
+export function describeSpan(metricLabel, span, unit) {
+  const dir = directionOf(span.status);
+  const sev = severityOf(span.status);
+  if (!dir) return `${metricLabel} within range`;
+  const peak = span.peak == null ? '' : ` (${Math.round(span.peak * 10) / 10}${unit || ''})`;
+  return `${metricLabel} ${sev === 'critical' ? 'critically ' : ''}${dir}${peak}`;
+}

--- a/frontend/src/pages/admin-v2/timelineEnv.test.js
+++ b/frontend/src/pages/admin-v2/timelineEnv.test.js
@@ -1,0 +1,130 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Room readings -> timeline lanes. The rules worth pinning are the ones about
+// absent bounds and absent data, because both are easy to render as a
+// confident "fine".
+import { describe, it, expect } from 'vitest';
+import {
+  classifyEnv, buildEnvSpans, worstStatus, severityOf, directionOf,
+} from './timelineEnv';
+
+const BOTH = { caution_min: 18, caution_max: 24, critical_min: 15, critical_max: 28 };
+const CEILING = { caution_min: null, caution_max: 1000, critical_min: null, critical_max: 2000 };
+const MIN = 60_000;
+
+describe('classifyEnv', () => {
+  it('reads a value against both bands on both sides', () => {
+    expect(classifyEnv(21, BOTH)).toBe('ok');
+    expect(classifyEnv(25, BOTH)).toBe('caution-high');
+    expect(classifyEnv(29, BOTH)).toBe('critical-high');
+    expect(classifyEnv(17, BOTH)).toBe('caution-low');
+    expect(classifyEnv(14, BOTH)).toBe('critical-low');
+  });
+
+  it('reports the worse band when a value passes both', () => {
+    expect(classifyEnv(3000, CEILING)).toBe('critical-high');
+  });
+
+  it('treats a missing bound as no opinion, not as zero', () => {
+    // A ceiling-only metric must never report "low" — a 0 floor would flag
+    // every clean reading.
+    expect(classifyEnv(0, CEILING)).toBe('ok');
+    expect(classifyEnv(-5, CEILING)).toBe('ok');
+  });
+
+  it('will not judge a reading it does not have', () => {
+    expect(classifyEnv(null, BOTH)).toBe('unknown');
+    expect(classifyEnv(21, null)).toBe('unknown');
+    expect(classifyEnv(undefined, BOTH)).toBe('unknown');
+  });
+
+  it('is inclusive of the bound itself', () => {
+    expect(classifyEnv(24, BOTH)).toBe('ok');
+    expect(classifyEnv(18, BOTH)).toBe('ok');
+  });
+});
+
+describe('buildEnvSpans', () => {
+  const rows = (...vals) => vals.map((v, i) => ({ ts: i * 15 * MIN, value: v }));
+
+  it('merges neighbouring readings of the same status into one span', () => {
+    const spans = buildEnvSpans(rows(30, 30, 30), BOTH, 15 * MIN);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].status).toBe('critical-high');
+    expect(spans[0].samples).toBe(3);
+  });
+
+  it('drops in-range stretches unless the lane is banded', () => {
+    const spans = buildEnvSpans(rows(21, 30, 21), BOTH, 15 * MIN);
+    expect(spans.map((s) => s.status)).toEqual(['critical-high']);
+
+    const banded = buildEnvSpans(rows(21, 30, 21), BOTH, 15 * MIN, { keepOk: true });
+    expect(banded.map((s) => s.status)).toEqual(['ok', 'critical-high', 'ok']);
+  });
+
+  it('extends a span to cover the bucket it ends in', () => {
+    const spans = buildEnvSpans(rows(30), BOTH, 15 * MIN);
+    // One reading is a quarter hour of room, not an instant.
+    expect(spans[0].to - spans[0].from).toBe(15 * MIN);
+  });
+
+  it('breaks a span across a gap instead of bridging it', () => {
+    const spans = buildEnvSpans([
+      { ts: 0, value: 30 },
+      { ts: 15 * MIN, value: 30 },
+      // Four hours with no readings, then the room is hot again.
+      { ts: 4 * 60 * MIN, value: 30 },
+    ], BOTH, 15 * MIN);
+    expect(spans).toHaveLength(2);
+    expect(spans[0].to).toBe(30 * MIN);
+  });
+
+  it('keeps the reading that justifies the span', () => {
+    const hot = buildEnvSpans(rows(29, 33, 30), BOTH, 15 * MIN);
+    expect(hot[0].peak).toBe(33);
+    const cold = buildEnvSpans(rows(14, 11, 13), BOTH, 15 * MIN);
+    expect(cold[0].peak).toBe(11);
+  });
+
+  it('produces nothing from no readings', () => {
+    expect(buildEnvSpans([], BOTH, 15 * MIN)).toEqual([]);
+  });
+
+  it('produces no flags when the patient has no bounds set', () => {
+    expect(buildEnvSpans(rows(30, 40), undefined, 15 * MIN)).toEqual([]);
+  });
+});
+
+describe('lane summary', () => {
+  it('reports the worst band the day reached', () => {
+    expect(worstStatus([])).toBe('ok');
+    expect(worstStatus([{ status: 'caution-high' }])).toBe('caution');
+    expect(worstStatus([{ status: 'caution-high' }, { status: 'critical-low' }]))
+      .toBe('critical');
+  });
+});
+
+describe('severity and direction are separate readings', () => {
+  it('splits the status into the two things the lane encodes', () => {
+    expect(severityOf('critical-low')).toBe('critical');
+    expect(directionOf('critical-low')).toBe('low');
+    expect(severityOf('caution-high')).toBe('caution');
+    expect(directionOf('caution-high')).toBe('high');
+    expect(directionOf('ok')).toBeNull();
+  });
+});


### PR DESCRIPTION
The Monitoring timeline rebuilt to the mockup, plus the storage it needed. Three commits, each standing on its own.

## Two charts, one instrument

SpO2 and heart rate were one chart with two y-axes — both series squeezed into a shared vertical space at neither's natural scale, and a hard cap of two signals. They're separate charts now.

They still read as one instrument because three things are shared: the **time window** (a zoom on either moves both), the **scrubbed instant**, and the **horizontal plot box**. That last one is the part that breaks silently: Chart.js is pinned to a fixed y-axis width via `scale.afterFit`, and the lanes and scrubber are inset by the same `--mtl-gutter`. A test reads that number out of *both* the page and the stylesheet, because when they drift the markers stop pointing at their samples.

Events came off the chart. Six types of rotated annotation lines drawn through the traces made the signals unreadable; they're lanes underneath now — four shown, the rest a click away.

Cuts run 24H / 6H / 1H / 30M / 5M / 1M. **1M is the honest floor** — the endpoint averages pulse-ox into one-minute buckets, so narrower just magnifies the same points. Below that means `/api/monitoring/history/raw`, a different request.

## Room condition lanes

Fed by the new per-patient bounds. **Severity is the colour; direction is the position** — a high excursion draws in the top half of its lane, a low one in the bottom half. That keeps the flag readable in greyscale and for anyone who can't separate amber from red, and it avoids a text glyph. Each span carries a screen-reader description.

PM2.5 bands its whole day green/amber/red, because a clean afternoon is information. The other three draw only where they're out of bounds, so an empty lane means an uneventful one. A gap in the readings **breaks** a span rather than bridging it — nobody measured the room then.

## Per-patient bounds (migration 048)

Its own table, not more rows in `patient_vital_ranges`. That table feeds `vital_validation`, which gates *saving a reading*; a CO2 bound has no business in that path.

Two bands per metric — caution and critical. Three states are needed for PM2.5, and two thresholds are the smallest thing that produces three; the same pair describes the others' high/low flags.

**Null means "no bound", not zero.** CO2 and PM2.5 have ceilings but no meaningful floor, and a 0 floor would flag every clean reading as low — the editor renders those cells unavailable rather than offering an input that invites the 0. Clearing every field falls back to the default instead of switching the metric off.

Defaults (AQI breakpoints for PM2.5, usual ventilation levels for CO2, comfort bands for temp/humidity) are labelled **Default** until overridden, so a number the care team chose never looks like one we guessed.

Editor is **Room conditions** on `/care/configuration/patients/:id`, beside Vital Ranges. Writing needs `patients.update`; reading isn't gated on read access, matching `/api/vitals/ranges` — in monitoring mode, losing the bounds would turn the flags off rather than hide them.

## Alert query fix

The day view took the 200 most recent alerts for the patient and filtered to the date afterwards, so any day further back than that rendered as quiet — empty lane, zero count, no indication data had been dropped. Now day-scoped like every other stream in the endpoint. The regression test buries the day under 250 newer alerts, which is the only arrangement that separates the two implementations.

## Deviations from the mockup — both deliberate, both one-liners to reverse

- **Series colours** are the vc ramp the reports already use for these two vitals, not the mockup's crimson/indigo. Red on a resting SpO2 trace spends the one colour reserved for clinical concern, and the alert bands underneath it need that colour to mean something.
- **Lane colours** are categorical for the same reason — except alerts, where red *is* the role.

Also fixed in passing: the day requested is now the local calendar date. `toISOString()` rolls over at UTC midnight, so an evening visit west of Greenwich asked for tomorrow and got an empty day.

## Dropped from scope

"Recovered to X%" and the "given N minutes before" event correlation, per direction — both need rules that don't exist yet. Duration stayed, and an unclosed alert reports as **ongoing** rather than being given one, with its band running to the end of the day rather than stopping where it didn't stop.

"View alert" is not built: there's no `/care/monitoring/alerts/:id` route to link to. The alert `id` is now in the payload for whenever there is.

## Verification

- 1031 frontend tests / 84 files, 731 backend tests, lint clean at `--max-warnings 0`, production build fine
- Migration applied against the dev stack; `alembic current` reports 048
- New coverage: 14 tests on classification and span-building (null-bound-isn't-zero, gap-breaking, peak selection), 8 on the lanes, 10 on the ranges API, 24 on the timeline itself

Running on device through the session; the screenshots drove the tick-density and axis-rounding fixes.

**Worth a look before merge:** env observations are fetched at 15-minute buckets. Fine for placing an excursion on a day view, but at the 5M and 1M cuts a span will look chunky next to the per-minute pulse-ox trace. Easy drop to `5m` if it reads badly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131eFmnRFvybi3nrNHMWppP