### PR TITLE
Rebuild the ventilator day, led by the parameters each patient cares about

### DIFF
--- a/backend/alembic/versions/049_patient_vent_pins.py
+++ b/backend/alembic/versions/049_patient_vent_pins.py
@@ -1,0 +1,73 @@
+"""Which ventilator parameters lead the page, per patient
+
+Revision ID: 049_patient_vent_pins
+Revises: 048_patient_env_ranges
+Create Date: 2026-08-19
+
+A vent day carries around 44 parameters and the device has no opinion about
+which of them matter. The page had none either, so breath rate and a raw
+vendor counter rendered at identical weight and the important numbers were
+five screens apart. These are the care team's picks.
+
+Keyed by vendor as well as parameter key: the key space belongs to the
+vendor, and VOCSN's 9408 means nothing to another manufacturer.
+
+The second table exists because "no pin rows" is otherwise ambiguous — it
+means both "nobody has chosen yet, show the defaults" and "somebody
+deliberately unpinned everything". Without somewhere to record that a choice
+was made, clearing the last pin silently restores six defaults, which reads
+as the app overruling the person who just cleared them.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '049_patient_vent_pins'
+down_revision = '048_patient_env_ranges'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'patient_vent_pins',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('patient_id', sa.Integer(), nullable=False),
+        sa.Column('vendor', sa.String(length=50), nullable=False),
+        sa.Column('parameter_key', sa.String(length=100), nullable=False),
+        sa.Column('position', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('set_by', sa.Integer(), nullable=True),
+        sa.Column('set_at', sa.TIMESTAMP(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['patient_id'], ['patients.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['set_by'], ['users.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('patient_id', 'vendor', 'parameter_key',
+                            name='uq_patient_vent_pin'),
+    )
+    op.create_index('ix_patient_vent_pins_patient_id', 'patient_vent_pins',
+                    ['patient_id'])
+
+    op.create_table(
+        'patient_vent_pin_state',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('patient_id', sa.Integer(), nullable=False),
+        sa.Column('vendor', sa.String(length=50), nullable=False),
+        sa.Column('configured', sa.Boolean(), nullable=False, server_default='true'),
+        sa.Column('set_by', sa.Integer(), nullable=True),
+        sa.Column('set_at', sa.TIMESTAMP(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['patient_id'], ['patients.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['set_by'], ['users.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('patient_id', 'vendor', name='uq_patient_vent_pin_state'),
+    )
+    op.create_index('ix_patient_vent_pin_state_patient_id', 'patient_vent_pin_state',
+                    ['patient_id'])
+
+
+def downgrade():
+    op.drop_index('ix_patient_vent_pin_state_patient_id',
+                  table_name='patient_vent_pin_state')
+    op.drop_table('patient_vent_pin_state')
+    op.drop_index('ix_patient_vent_pins_patient_id', table_name='patient_vent_pins')
+    op.drop_table('patient_vent_pins')

--- a/backend/crud/vent_pins.py
+++ b/backend/crud/vent_pins.py
@@ -1,0 +1,110 @@
+#
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Per-patient ventilator parameter pins: resolve (defaults or chosen) and save."""
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from models.patient_vent_pin import PatientVentPin, PatientVentPinState
+
+# Where a new patient starts, until somebody says otherwise. These are the
+# respiratory parameters a carer looks at first, and every one of them is
+# present in the shipped VOCSN dictionary with a label, units and a scale
+# factor — an invented key would render as a blank row.
+#
+# Vendor-scoped because the key space is: 9408 is VOCSN's breath rate and
+# means nothing to another manufacturer. A vendor with no entry here simply
+# starts unpinned, which is honest — we have no idea what matters on a device
+# we have never seen.
+DEFAULT_VENT_PINS = {
+    'vocsn': ['9408', '9406', '9407', '9423', '9409', '16003'],
+}
+
+
+def default_pins_for(vendor: str) -> List[str]:
+    return list(DEFAULT_VENT_PINS.get((vendor or '').lower(), []))
+
+
+def resolve_vent_pins(db: Session, patient_id: int, vendor: str) -> dict:
+    """The pinned parameter keys for a patient, in display order.
+
+    ``source`` distinguishes the two states that "no rows" would otherwise
+    collapse: a patient nobody has configured gets the defaults, a patient who
+    deliberately unpinned everything gets an empty list and keeps it.
+    """
+    vendor = (vendor or '').lower()
+    state = db.query(PatientVentPinState).filter(
+        PatientVentPinState.patient_id == patient_id,
+        PatientVentPinState.vendor == vendor,
+    ).first()
+
+    if state is None:
+        return {'vendor': vendor, 'source': 'default',
+                'parameter_keys': default_pins_for(vendor)}
+
+    rows = db.query(PatientVentPin).filter(
+        PatientVentPin.patient_id == patient_id,
+        PatientVentPin.vendor == vendor,
+    ).order_by(PatientVentPin.position.asc(), PatientVentPin.id.asc()).all()
+    return {'vendor': vendor, 'source': 'patient',
+            'parameter_keys': [r.parameter_key for r in rows]}
+
+
+def set_vent_pins(db: Session, patient_id: int, vendor: str,
+                  parameter_keys: List[str], set_by: Optional[int] = None) -> None:
+    """Replace a patient's pins with exactly this list, in this order.
+
+    Writing the state row is what makes an empty list stick. Duplicates are
+    dropped rather than rejected — the same key twice is a client slip, not a
+    reason to fail the save, and the unique constraint would refuse it anyway.
+    """
+    vendor = (vendor or '').lower()
+    now = datetime.now(timezone.utc)
+
+    seen = set()
+    ordered = []
+    for key in parameter_keys:
+        key = str(key)
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(key)
+
+    db.query(PatientVentPin).filter(
+        PatientVentPin.patient_id == patient_id,
+        PatientVentPin.vendor == vendor,
+    ).delete(synchronize_session=False)
+
+    for position, key in enumerate(ordered):
+        db.add(PatientVentPin(patient_id=patient_id, vendor=vendor,
+                              parameter_key=key, position=position,
+                              set_by=set_by, set_at=now))
+
+    state = db.query(PatientVentPinState).filter(
+        PatientVentPinState.patient_id == patient_id,
+        PatientVentPinState.vendor == vendor,
+    ).first()
+    if state is None:
+        state = PatientVentPinState(patient_id=patient_id, vendor=vendor)
+        db.add(state)
+    state.configured = True
+    state.set_by = set_by
+    state.set_at = now
+
+    db.commit()

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -64,6 +64,7 @@ from models.ha_identity import HASeenIdentity
 from models.custom_vital_definition import CustomVitalDefinition
 from models.patient_vital_range import PatientVitalRange
 from models.patient_env_range import PatientEnvRange
+from models.patient_vent_pin import PatientVentPin, PatientVentPinState
 from models.user_messages import UserMessage, UserMessageAcknowledgement
 from models.vent_ingested_files import VentIngestedFile
 
@@ -83,6 +84,7 @@ __all__ = [
     'CompleteItemRequest', 'BulkCompleteRequest', 'Organization', 'OrganizationMembership',
     'OrganizationType', 'PatientAccess', 'AccessLevel', 'Reader', 'CustomVitalDefinition',
     'PatientVitalRange', 'PatientEnvRange',
+    'PatientVentPin', 'PatientVentPinState',
     'UserMessage', 'UserMessageAcknowledgement', 'VentIngestedFile',
     'DMEShipment', 'DMEShipmentItem', 'DMEReceiptItem', 'DMEShipmentAlert', 'DMEShipmentDocument',
     'EnvironmentalObservation', 'HASeenIdentity', 'HAEntityMapping'

--- a/backend/models/patient_vent_pin.py
+++ b/backend/models/patient_vent_pin.py
@@ -1,0 +1,74 @@
+#
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from sqlalchemy import (
+    Column, Integer, String, Boolean, ForeignKey, TIMESTAMP, UniqueConstraint,
+)
+
+from db import Base
+
+
+class PatientVentPin(Base):
+    """Which ventilator parameters lead the page for one patient.
+
+    A vent day carries ~44 parameters and the device offers no opinion about
+    which matter, so this is the care team's. Keyed by vendor as well as
+    parameter because the key space is the vendor's: VOCSN's 9408 is breath
+    rate, another vendor's 9408 is whatever they decided.
+
+    `position` is the display order, not a rank — the page renders pins in it
+    so a reordering does not have to touch every row's meaning.
+    """
+
+    __tablename__ = 'patient_vent_pins'
+    __table_args__ = (
+        UniqueConstraint('patient_id', 'vendor', 'parameter_key',
+                         name='uq_patient_vent_pin'),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    patient_id = Column(Integer, ForeignKey('patients.id', ondelete='CASCADE'),
+                        nullable=False, index=True)
+    vendor = Column(String(50), nullable=False)
+    parameter_key = Column(String(100), nullable=False)
+    position = Column(Integer, nullable=False, default=0, server_default='0')
+    set_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    set_at = Column(TIMESTAMP(timezone=True), nullable=False)
+
+
+class PatientVentPinState(Base):
+    """Whether a patient's pins have been chosen at all.
+
+    Without this, "no rows" is ambiguous: it means both "nobody has been here
+    yet, show the defaults" and "somebody deliberately unpinned everything".
+    Collapsing the two makes clearing the last pin silently restore six
+    defaults, which reads as the app overruling the person who just cleared
+    them. One row per patient/vendor, written the first time pins are saved.
+    """
+
+    __tablename__ = 'patient_vent_pin_state'
+    __table_args__ = (
+        UniqueConstraint('patient_id', 'vendor', name='uq_patient_vent_pin_state'),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    patient_id = Column(Integer, ForeignKey('patients.id', ondelete='CASCADE'),
+                        nullable=False, index=True)
+    vendor = Column(String(50), nullable=False)
+    configured = Column(Boolean, nullable=False, default=True, server_default='true')
+    set_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    set_at = Column(TIMESTAMP(timezone=True), nullable=False)

--- a/backend/routes/integration_imports.py
+++ b/backend/routes/integration_imports.py
@@ -500,6 +500,36 @@ def _infer_grouping(display_label: Optional[str], tag_name: Optional[str]) -> Op
     return None
 
 
+# One parameter key carries samples from several device messages, and they are
+# not the same measurement — VOCSN's column layout differs per message, so all
+# but one message's values land under the wrong keys. Restricting to the
+# message that carries the parameter most often keeps a parameter's day on one
+# coherent source instead of averaging a monitor stream with a settings
+# snapshot and a counter.
+#
+# Most rows wins because the real monitor stream reports on a fixed cadence
+# (288 times a day at five-minute intervals here) while the interlopers are
+# occasional. Ties break on type then id so the choice is stable between the
+# day view and the series behind it — they must agree, or the chart would plot
+# a different source from the number above it.
+_VENT_DOMINANT_MSG_CTE = """
+    WITH dominant_msg AS (
+        SELECT DISTINCT ON (parameter_key)
+               parameter_key, source_message_type, source_message_id
+        FROM (
+            SELECT parameter_key, source_message_type, source_message_id,
+                   COUNT(*) AS n
+            FROM vent_samples
+            WHERE patient_id = :pid
+              AND recorded_at >= :start AND recorded_at < :end
+              AND value_numeric IS NOT NULL
+            GROUP BY parameter_key, source_message_type, source_message_id
+        ) ranked
+        ORDER BY parameter_key, n DESC, source_message_type, source_message_id
+    )
+"""
+
+
 def _vent_day_bounds(db: Session, patient_id: int, date: str):
     """The UTC window covering one local day for this patient.
 
@@ -654,7 +684,7 @@ async def vent_day(
     # ~2000 mL, pressures max ~80 cmH2O) but well below the noise band.
     # If a legitimate counter ever exceeds 5000 we'll revisit; for now this
     # keeps the displayed min/avg/max honest.
-    rows = db.execute(text("""
+    rows = db.execute(text(_VENT_DOMINANT_MSG_CTE + """
         SELECT
             s.parameter_key,
             s.parameter_suffix,
@@ -670,6 +700,10 @@ async def vent_day(
             d.precision,
             d.tag_name
         FROM vent_samples s
+        JOIN dominant_msg m
+          ON m.parameter_key = s.parameter_key
+         AND m.source_message_type = s.source_message_type
+         AND m.source_message_id = s.source_message_id
         LEFT JOIN vent_parameter_dictionary d
           ON d.vendor = 'vocsn' AND d.parameter_key = s.parameter_key
         WHERE s.patient_id = :pid
@@ -744,7 +778,12 @@ async def vent_day(
             {"message_type": r.mt, "message_id": r.mid, "n": int(r.n)})
     for entry in by_key.values():
         entry.setdefault("sources", [])
-        entry["sources"].sort(key=lambda s: -s["n"])
+        entry["sources"].sort(key=lambda s: (-s["n"], s["message_type"], s["message_id"]))
+        # The first is the one the statistics above were computed from; the
+        # rest were dropped. Saying so lets the page report the loss rather
+        # than quietly showing a subset.
+        for i, src in enumerate(entry["sources"]):
+            src["used"] = (i == 0)
 
     # Day-level summary (counts, time range).
     summary_row = db.execute(text("""
@@ -797,20 +836,26 @@ async def vent_day_parameter_series(
         raise HTTPException(status_code=404, detail="No ventilator integration")
     day, start, end = _vent_day_bounds(db, patient_id, date)
 
-    rows = db.execute(text("""
+    # Same dominant-message restriction as the day view. If the two disagreed,
+    # the chart would plot a different source from the number that opened it.
+    rows = db.execute(text(_VENT_DOMINANT_MSG_CTE + """
         SELECT
-            recorded_at,
-            MAX(CASE WHEN parameter_suffix='50' THEN value_numeric END) AS p50,
-            MAX(CASE WHEN parameter_suffix='5'  THEN value_numeric END) AS p5,
-            MAX(CASE WHEN parameter_suffix='95' THEN value_numeric END) AS p95,
-            MAX(CASE WHEN parameter_suffix='N'  THEN value_numeric END) AS n_val
-        FROM vent_samples
-        WHERE patient_id = :pid AND parameter_key = :key
-          AND recorded_at >= :start AND recorded_at < :end
-          AND value_numeric IS NOT NULL
-          AND value_numeric BETWEEN -5000 AND 5000
-        GROUP BY recorded_at
-        ORDER BY recorded_at
+            s.recorded_at,
+            MAX(CASE WHEN s.parameter_suffix='50' THEN s.value_numeric END) AS p50,
+            MAX(CASE WHEN s.parameter_suffix='5'  THEN s.value_numeric END) AS p5,
+            MAX(CASE WHEN s.parameter_suffix='95' THEN s.value_numeric END) AS p95,
+            MAX(CASE WHEN s.parameter_suffix='N'  THEN s.value_numeric END) AS n_val
+        FROM vent_samples s
+        JOIN dominant_msg m
+          ON m.parameter_key = s.parameter_key
+         AND m.source_message_type = s.source_message_type
+         AND m.source_message_id = s.source_message_id
+        WHERE s.patient_id = :pid AND s.parameter_key = :key
+          AND s.recorded_at >= :start AND s.recorded_at < :end
+          AND s.value_numeric IS NOT NULL
+          AND s.value_numeric BETWEEN -5000 AND 5000
+        GROUP BY s.recorded_at
+        ORDER BY s.recorded_at
     """), {"pid": patient_id, "key": key, "start": start, "end": end}).all()
 
     meta = db.execute(text("""

--- a/backend/routes/integration_imports.py
+++ b/backend/routes/integration_imports.py
@@ -51,6 +51,7 @@ from dependencies import get_db, require_permission
 from routes.auth import get_current_account_id, require_full_auth
 from schemas.integration import PatientIntegration
 from schemas.vent_import import VentImport
+from pydantic import BaseModel
 from integrations import get_integration
 
 logger = logging.getLogger("integrations.imports")
@@ -813,3 +814,68 @@ async def calibrate_clock_clear(
     })
     updated = _apply_offset_to_existing_samples(db, integration_id, 0.0)
     return {"status": "cleared", "samples_updated": updated, "settings": pi.settings}
+
+
+# ---------------------------------------------------------------------------
+# Which ventilator parameters lead the page for this patient.
+# ---------------------------------------------------------------------------
+
+class VentPinsUpdate(BaseModel):
+    vendor: str = "vocsn"
+    parameter_keys: list[str] = []
+
+
+def _vent_patient_or_404(db: Session, patient_id: int, account_id):
+    """The vent reads answer for any patient in the account; the pin reads
+    have to as well, or a patient whose integration is briefly disabled loses
+    their pins rather than their data."""
+    from schemas.patient import Patient
+    q = db.query(Patient).filter(Patient.id == patient_id)
+    if account_id is not None:
+        q = q.filter((Patient.account_id == account_id) | (Patient.account_id.is_(None)))
+    patient = q.first()
+    if not patient:
+        raise HTTPException(status_code=404, detail="Patient not found")
+    return patient
+
+
+@router.get(
+    "/patient/{patient_id}/vent/pins",
+    dependencies=[Depends(require_permission("monitoring.read"))],
+)
+async def get_vent_pins(
+    patient_id: int,
+    vendor: str = "vocsn",
+    db: Session = Depends(get_db),
+    current_user=Depends(require_full_auth),
+    account_id: int = Depends(get_current_account_id),
+):
+    """Pinned parameter keys in display order.
+
+    `source` is `default` for a patient nobody has configured and `patient`
+    once somebody has — including when they chose to pin nothing, which is a
+    real choice and not the same as never having looked.
+    """
+    from crud.vent_pins import resolve_vent_pins
+
+    _vent_patient_or_404(db, patient_id, account_id)
+    return {"patient_id": patient_id, **resolve_vent_pins(db, patient_id, vendor)}
+
+
+@router.put(
+    "/patient/{patient_id}/vent/pins",
+    dependencies=[Depends(require_permission("patients.update"))],
+)
+async def put_vent_pins(
+    patient_id: int,
+    body: VentPinsUpdate,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_full_auth),
+    account_id: int = Depends(get_current_account_id),
+):
+    from crud.vent_pins import resolve_vent_pins, set_vent_pins
+
+    _vent_patient_or_404(db, patient_id, account_id)
+    set_vent_pins(db, patient_id, body.vendor, body.parameter_keys,
+                  set_by=getattr(current_user, "id", None))
+    return {"patient_id": patient_id, **resolve_vent_pins(db, patient_id, body.vendor)}

--- a/backend/routes/integration_imports.py
+++ b/backend/routes/integration_imports.py
@@ -29,7 +29,7 @@ import logging
 import os
 import shutil
 import tarfile
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, time as dtime, timedelta, timezone
 from typing import Any, Dict, Optional
 from uuid import uuid4
 
@@ -49,6 +49,7 @@ from sqlalchemy.orm.attributes import flag_modified
 from db import SessionLocal
 from dependencies import get_db, require_permission
 from routes.auth import get_current_account_id, require_full_auth
+from utils.datetime_utils import resolve_tz_for_patient
 from schemas.integration import PatientIntegration
 from schemas.vent_import import VentImport
 from pydantic import BaseModel
@@ -499,6 +500,28 @@ def _infer_grouping(display_label: Optional[str], tag_name: Optional[str]) -> Op
     return None
 
 
+def _vent_day_bounds(db: Session, patient_id: int, date: str):
+    """The UTC window covering one local day for this patient.
+
+    Ventilator days used to be UTC calendar days, which put a patient four
+    hours west of Greenwich into a "day" running 8pm to 8pm — the chart opened
+    at 20:00 and crossed midnight in the middle. Day boundaries come from the
+    account timezone everywhere else in this codebase and now here too.
+
+    The end is the next local midnight rather than start + 24h, so the 23- and
+    25-hour days either side of a DST change cover exactly their own hours,
+    and it is exclusive to match the `recorded_at < :end` the callers use.
+    """
+    try:
+        day = datetime.strptime(date, "%Y-%m-%d").date()
+    except ValueError:
+        raise HTTPException(status_code=400, detail="date must be YYYY-MM-DD")
+    tz = resolve_tz_for_patient(db, patient_id)
+    start = datetime.combine(day, dtime.min, tzinfo=tz).astimezone(timezone.utc)
+    end = datetime.combine(day + timedelta(days=1), dtime.min, tzinfo=tz).astimezone(timezone.utc)
+    return day, start, end
+
+
 def _vent_integration_id(db: Session, patient_id: int, account_id: int) -> Optional[int]:
     """Return the active ventilator PatientIntegration.id for this patient,
     or None if the patient has no vent integration."""
@@ -581,17 +604,20 @@ async def vent_days(
     account_id: int = Depends(get_current_account_id),
 ):
     """List dates that have parsed vent samples (most recent first) so the
-    view can render a day picker. `date` is in UTC."""
+    view can render a day picker. Dates are the patient's local calendar
+    days — bucketing by UTC put a patient west of Greenwich into a day that
+    began at 8pm the evening before."""
     if not _vent_integration_id(db, patient_id, account_id):
         return {"has_integration": False, "days": []}
 
+    tz = str(resolve_tz_for_patient(db, patient_id))
     rows = db.execute(text("""
-        SELECT (recorded_at AT TIME ZONE 'UTC')::date AS day, COUNT(*) AS n
+        SELECT (recorded_at AT TIME ZONE :tz)::date AS day, COUNT(*) AS n
         FROM vent_samples
         WHERE patient_id = :pid
-        GROUP BY (recorded_at AT TIME ZONE 'UTC')::date
+        GROUP BY (recorded_at AT TIME ZONE :tz)::date
         ORDER BY day DESC
-    """), {"pid": patient_id}).all()
+    """), {"pid": patient_id, "tz": tz}).all()
     return {
         "has_integration": True,
         "days": [
@@ -619,12 +645,7 @@ async def vent_day(
     if not _vent_integration_id(db, patient_id, account_id):
         raise HTTPException(status_code=404, detail="No ventilator integration for patient")
 
-    try:
-        day = datetime.strptime(date, "%Y-%m-%d").date()
-    except ValueError:
-        raise HTTPException(status_code=400, detail="date must be YYYY-MM-DD")
-    start = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
-    end = start + timedelta(days=1)
+    day, start, end = _vent_day_bounds(db, patient_id, date)
 
     # Outlier guard: VOCSN encodes "no reading" with uint16-ish sentinels
     # (43577, 21042, 16190, 5326 — likely bit-pattern encodings of NaN/error
@@ -744,12 +765,7 @@ async def vent_day_parameter_series(
     chart can plot median + 5–95% band."""
     if not _vent_integration_id(db, patient_id, account_id):
         raise HTTPException(status_code=404, detail="No ventilator integration")
-    try:
-        day = datetime.strptime(date, "%Y-%m-%d").date()
-    except ValueError:
-        raise HTTPException(status_code=400, detail="date must be YYYY-MM-DD")
-    start = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
-    end = start + timedelta(days=1)
+    day, start, end = _vent_day_bounds(db, patient_id, date)
 
     rows = db.execute(text("""
         SELECT

--- a/backend/routes/integration_imports.py
+++ b/backend/routes/integration_imports.py
@@ -716,6 +716,36 @@ async def vent_day(
     for entry in by_key.values():
         grouped.setdefault(entry["grouping"], []).append(entry)
 
+    # Which device messages each parameter's samples came from.
+    #
+    # A parameter key is not one measurement: VOCSN reports the same key from
+    # several messages, and they are not the same quantity. On a real day, I:E
+    # ratio arrives from message 7201 at 288 rows averaging -2 and from 7204 at
+    # 25 rows averaging 1619 — continuous standby telemetry and active
+    # ventilation, blended into one statistic by the grouping above. Half the
+    # parameters on that day (22 of 44) carry more than one message.
+    #
+    # Reporting the breakdown does not fix the blend, but it stops the page
+    # presenting a mixture as though it were a reading.
+    source_rows = db.execute(text("""
+        SELECT parameter_key, source_message_type AS mt, source_message_id AS mid,
+               COUNT(*) AS n
+        FROM vent_samples
+        WHERE patient_id = :pid
+          AND recorded_at >= :start AND recorded_at < :end
+          AND value_numeric IS NOT NULL
+        GROUP BY parameter_key, source_message_type, source_message_id
+    """), {"pid": patient_id, "start": start, "end": end}).all()
+    for r in source_rows:
+        entry = by_key.get(r.parameter_key)
+        if entry is None:
+            continue
+        entry.setdefault("sources", []).append(
+            {"message_type": r.mt, "message_id": r.mid, "n": int(r.n)})
+    for entry in by_key.values():
+        entry.setdefault("sources", [])
+        entry["sources"].sort(key=lambda s: -s["n"])
+
     # Day-level summary (counts, time range).
     summary_row = db.execute(text("""
         SELECT COUNT(*) AS total,

--- a/backend/tests/test_vent_days.py
+++ b/backend/tests/test_vent_days.py
@@ -60,13 +60,14 @@ def vent_patient(db_session, account, patient):
     return patient
 
 
-def _sample(db_session, patient, when, *, key="9408", suffix="50", value=25.0):
+def _sample(db_session, patient, when, *, key="9408", suffix="50", value=25.0,
+            msg_type="M", msg_id=6007):
     from schemas.vent_sample import VentSample
     db_session.add(VentSample(
         import_id=patient.vent_import_id, patient_id=patient.id,
         recorded_at_raw=when, recorded_at=when,
         parameter_key=key, parameter_suffix=suffix,
-        value_numeric=value, source_message_type="M", source_message_id=6007,
+        value_numeric=value, source_message_type=msg_type, source_message_id=msg_id,
     ))
 
 
@@ -141,3 +142,37 @@ def test_a_bad_date_is_rejected(admin_client, vent_patient):
     resp = admin_client.get(
         f"/api/integrations/patient/{vent_patient.id}/vent/day/19-08-2026")
     assert resp.status_code == 400
+
+
+def test_a_parameter_reports_the_messages_it_came_from(
+        admin_client, db_session, vent_patient):
+    """A parameter key is not one measurement. On real data, I:E ratio arrives
+    from message 7201 (continuous, averaging -2) and 7204 (active ventilation,
+    averaging 1619); the day statistic silently averages the two. The page
+    cannot unpick that, but it can stop presenting a blend as a reading."""
+    for i in range(3):
+        _sample(db_session, vent_patient, EVENING, value=-2.0, msg_id=7201)
+    _sample(db_session, vent_patient, EVENING, value=1619.0, msg_id=7204)
+    db_session.commit()
+
+    resp = admin_client.get(
+        f"/api/integrations/patient/{vent_patient.id}/vent/day/2026-08-19")
+    assert resp.status_code == 200
+    params = [p for g in resp.json()["groups"] for p in g["parameters"]]
+    entry = next(p for p in params if p["parameter_key"] == "9408")
+    # Biggest contributor first, so the dominant message reads as the headline.
+    assert [s["message_id"] for s in entry["sources"]] == [7201, 7204]
+    assert [s["n"] for s in entry["sources"]] == [3, 1]
+
+
+def test_a_single_message_parameter_says_so(admin_client, db_session, vent_patient):
+    _sample(db_session, vent_patient, EVENING, msg_id=7201)
+    _sample(db_session, vent_patient, LATE_EVENING, msg_id=7201)
+    db_session.commit()
+
+    resp = admin_client.get(
+        f"/api/integrations/patient/{vent_patient.id}/vent/day/2026-08-19")
+    params = [p for g in resp.json()["groups"] for p in g["parameters"]]
+    entry = next(p for p in params if p["parameter_key"] == "9408")
+    assert len(entry["sources"]) == 1
+    assert entry["sources"][0]["n"] == 2

--- a/backend/tests/test_vent_days.py
+++ b/backend/tests/test_vent_days.py
@@ -144,25 +144,59 @@ def test_a_bad_date_is_rejected(admin_client, vent_patient):
     assert resp.status_code == 400
 
 
-def test_a_parameter_reports_the_messages_it_came_from(
-        admin_client, db_session, vent_patient):
-    """A parameter key is not one measurement. On real data, I:E ratio arrives
-    from message 7201 (continuous, averaging -2) and 7204 (active ventilation,
-    averaging 1619); the day statistic silently averages the two. The page
-    cannot unpick that, but it can stop presenting a blend as a reading."""
-    for i in range(3):
-        _sample(db_session, vent_patient, EVENING, value=-2.0, msg_id=7201)
+def _day(admin_client, patient_id, date="2026-08-19"):
+    resp = admin_client.get(
+        f"/api/integrations/patient/{patient_id}/vent/day/{date}")
+    assert resp.status_code == 200
+    return {p["parameter_key"]: p
+            for g in resp.json()["groups"] for p in g["parameters"]}
+
+
+def test_only_the_dominant_message_is_counted(admin_client, db_session, vent_patient):
+    """A parameter key is not one measurement. VOCSN's column layout differs
+    per message, so all but one message's values land under the wrong key —
+    on real data that averaged a monitor stream reading 4 cmH2O together with
+    a counter, and printed 164. Only the message carrying the parameter most
+    often is counted."""
+    for _ in range(3):
+        _sample(db_session, vent_patient, EVENING, value=10.0, msg_id=7201)
     _sample(db_session, vent_patient, EVENING, value=1619.0, msg_id=7204)
     db_session.commit()
 
-    resp = admin_client.get(
-        f"/api/integrations/patient/{vent_patient.id}/vent/day/2026-08-19")
-    assert resp.status_code == 200
-    params = [p for g in resp.json()["groups"] for p in g["parameters"]]
-    entry = next(p for p in params if p["parameter_key"] == "9408")
-    # Biggest contributor first, so the dominant message reads as the headline.
+    entry = _day(admin_client, vent_patient.id)["9408"]
+    # 10, not the 412 that averaging in the counter would give.
+    assert entry["stats_by_suffix"]["50"]["mean"] == 10.0
+    assert entry["stats_by_suffix"]["50"]["n"] == 3
+
+
+def test_a_parameter_reports_what_was_used_and_what_was_dropped(
+        admin_client, db_session, vent_patient):
+    for _ in range(3):
+        _sample(db_session, vent_patient, EVENING, value=10.0, msg_id=7201)
+    _sample(db_session, vent_patient, EVENING, value=1619.0, msg_id=7204)
+    db_session.commit()
+
+    entry = _day(admin_client, vent_patient.id)["9408"]
     assert [s["message_id"] for s in entry["sources"]] == [7201, 7204]
+    assert [s["used"] for s in entry["sources"]] == [True, False]
+    # Dropping data silently would let a partial day read as a whole one.
     assert [s["n"] for s in entry["sources"]] == [3, 1]
+
+
+def test_the_series_is_drawn_from_the_same_message_as_the_number(
+        admin_client, db_session, vent_patient):
+    for _ in range(3):
+        _sample(db_session, vent_patient, EVENING, value=10.0, msg_id=7201)
+    _sample(db_session, vent_patient, LATE_EVENING, value=1619.0, msg_id=7204)
+    db_session.commit()
+
+    resp = admin_client.get(
+        f"/api/integrations/patient/{vent_patient.id}"
+        f"/vent/day/2026-08-19/parameter/9408")
+    assert resp.status_code == 200
+    values = [p["p50"] for p in resp.json()["points"]]
+    # The chart must not plot a source the headline excluded.
+    assert 1619.0 not in values
 
 
 def test_a_single_message_parameter_says_so(admin_client, db_session, vent_patient):

--- a/backend/tests/test_vent_days.py
+++ b/backend/tests/test_vent_days.py
@@ -1,0 +1,143 @@
+#
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""A ventilator day is the patient's day.
+
+Bucketing by UTC put an account in America/New_York into a "day" that opened
+at 8pm the previous evening: the day view's chart started at 20:00 and crossed
+midnight in the middle of the plot. The test account is America/New_York, so
+an evening sample lands on the previous UTC date and is the whole test.
+"""
+from datetime import datetime, timezone
+
+import pytest
+
+
+@pytest.fixture
+def vent_patient(db_session, account, patient):
+    """A patient with an enabled ventilator integration and one parsed import
+    for the samples to hang off — vent_samples.import_id is NOT NULL."""
+    from schemas.integration import Integration, PatientIntegration
+    from schemas.vent_import import VentImport
+    integ = db_session.query(Integration).filter(Integration.slug == "ventilator").first()
+    if integ is None:
+        now = datetime.now(timezone.utc)
+        integ = Integration(name="Ventilator", slug="ventilator", auth_type="none",
+                            is_active=True, created_at=now, updated_at=now)
+        db_session.add(integ)
+        db_session.flush()
+    # The ORM sends explicit NULLs for these, so the column defaults never
+    # get a chance; set them here rather than in every test.
+    now = datetime.now(timezone.utc)
+    pi = PatientIntegration(account_id=account.id, patient_id=patient.id,
+                            integration_id=integ.id, is_enabled=True,
+                            created_at=now, updated_at=now)
+    db_session.add(pi)
+    db_session.flush()
+
+    imp = VentImport(
+        id="test-import-0001", patient_id=patient.id, integration_id=pi.id,
+        vendor="vocsn", file_name="export.tar.gz", storage_path="/tmp/export",
+        status="completed", uploaded_at=now, parsed_at=now,
+    )
+    db_session.add(imp)
+    db_session.commit()
+    patient.vent_import_id = imp.id
+    return patient
+
+
+def _sample(db_session, patient, when, *, key="9408", suffix="50", value=25.0):
+    from schemas.vent_sample import VentSample
+    db_session.add(VentSample(
+        import_id=patient.vent_import_id, patient_id=patient.id,
+        recorded_at_raw=when, recorded_at=when,
+        parameter_key=key, parameter_suffix=suffix,
+        value_numeric=value, source_message_type="M", source_message_id=6007,
+    ))
+
+
+# 2026-08-19 23:30 UTC is 19:30 local on the 19th; 2026-08-20 01:30 UTC is
+# 21:30 local, still the 19th. Under UTC bucketing the second lands on the
+# 20th, which is what split the evening off the day it belongs to.
+EVENING = datetime(2026, 8, 19, 23, 30, tzinfo=timezone.utc)
+LATE_EVENING = datetime(2026, 8, 20, 1, 30, tzinfo=timezone.utc)
+NEXT_MORNING = datetime(2026, 8, 20, 14, 0, tzinfo=timezone.utc)
+
+
+def test_days_are_the_patients_local_days(admin_client, db_session, vent_patient):
+    _sample(db_session, vent_patient, EVENING)
+    _sample(db_session, vent_patient, LATE_EVENING)
+    _sample(db_session, vent_patient, NEXT_MORNING)
+    db_session.commit()
+
+    resp = admin_client.get(
+        f"/api/integrations/patient/{vent_patient.id}/vent/days")
+    assert resp.status_code == 200
+    days = {d["date"]: d["sample_count"] for d in resp.json()["days"]}
+    # Both evening samples belong to the 19th locally, even though one of them
+    # carries a UTC date of the 20th.
+    assert days.get("2026-08-19") == 2
+    assert days.get("2026-08-20") == 1
+
+
+def test_a_day_covers_local_midnight_to_local_midnight(
+        admin_client, db_session, vent_patient):
+    _sample(db_session, vent_patient, EVENING)
+    _sample(db_session, vent_patient, LATE_EVENING)
+    _sample(db_session, vent_patient, NEXT_MORNING)
+    db_session.commit()
+
+    resp = admin_client.get(
+        f"/api/integrations/patient/{vent_patient.id}/vent/day/2026-08-19")
+    assert resp.status_code == 200
+    summary = resp.json()["summary"]
+    assert summary["total_samples"] == 2
+    # …and the next morning's sample is not dragged in.
+    assert summary["last_at"].startswith("2026-08-20T01:30")
+
+
+def test_the_series_endpoint_uses_the_same_window(
+        admin_client, db_session, vent_patient):
+    _sample(db_session, vent_patient, LATE_EVENING)
+    _sample(db_session, vent_patient, NEXT_MORNING)
+    db_session.commit()
+
+    resp = admin_client.get(
+        f"/api/integrations/patient/{vent_patient.id}"
+        f"/vent/day/2026-08-19/parameter/9408")
+    assert resp.status_code == 200
+    points = resp.json()["points"]
+    # One point, the 21:30 local one — a day picker and a chart that disagreed
+    # about where the day starts would plot the wrong evening.
+    assert len(points) == 1
+
+
+def test_a_day_with_nothing_in_it_is_empty_not_an_error(
+        admin_client, db_session, vent_patient):
+    _sample(db_session, vent_patient, NEXT_MORNING)
+    db_session.commit()
+    resp = admin_client.get(
+        f"/api/integrations/patient/{vent_patient.id}/vent/day/2026-08-18")
+    assert resp.status_code == 200
+    assert resp.json()["summary"]["total_samples"] == 0
+    assert resp.json()["groups"] == []
+
+
+def test_a_bad_date_is_rejected(admin_client, vent_patient):
+    resp = admin_client.get(
+        f"/api/integrations/patient/{vent_patient.id}/vent/day/19-08-2026")
+    assert resp.status_code == 400

--- a/backend/tests/test_vent_pins.py
+++ b/backend/tests/test_vent_pins.py
@@ -1,0 +1,126 @@
+#
+# Smart Home Health
+# Copyright (C) 2026 John Carty
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Per-patient ventilator pins. The claim worth guarding is that an empty set
+is a choice, not an absence."""
+
+
+def _url(patient_id):
+    return f"/api/integrations/patient/{patient_id}/vent/pins"
+
+
+def test_an_unconfigured_patient_gets_the_defaults(admin_client, patient):
+    resp = admin_client.get(_url(patient.id))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["source"] == "default"
+    # Breath rate leads; it is the one key the reports already hardcode.
+    assert body["parameter_keys"][0] == "9408"
+    assert len(body["parameter_keys"]) == 6
+
+
+def test_pins_come_back_in_the_order_they_were_saved(admin_client, patient):
+    resp = admin_client.put(_url(patient.id), json={
+        "vendor": "vocsn", "parameter_keys": ["9409", "9408", "16003"],
+    })
+    assert resp.status_code == 200
+    assert resp.json()["parameter_keys"] == ["9409", "9408", "16003"]
+    assert resp.json()["source"] == "patient"
+    # …and survive a round trip rather than re-sorting on read.
+    assert admin_client.get(_url(patient.id)).json()["parameter_keys"] == \
+        ["9409", "9408", "16003"]
+
+
+def test_unpinning_everything_stays_unpinned(admin_client, patient):
+    """The whole reason the state table exists: without it, clearing the last
+    pin looks identical to never having configured any, and six defaults come
+    back over the top of a deliberate choice."""
+    admin_client.put(_url(patient.id), json={
+        "vendor": "vocsn", "parameter_keys": ["9408"]})
+    resp = admin_client.put(_url(patient.id), json={
+        "vendor": "vocsn", "parameter_keys": []})
+    assert resp.status_code == 200
+    assert resp.json()["parameter_keys"] == []
+    assert resp.json()["source"] == "patient"
+
+    again = admin_client.get(_url(patient.id))
+    assert again.json()["parameter_keys"] == []
+    assert again.json()["source"] == "patient"
+
+
+def test_saving_twice_replaces_rather_than_accumulates(admin_client, db_session, patient):
+    from models.patient_vent_pin import PatientVentPin
+    admin_client.put(_url(patient.id), json={
+        "vendor": "vocsn", "parameter_keys": ["9408", "9406"]})
+    admin_client.put(_url(patient.id), json={
+        "vendor": "vocsn", "parameter_keys": ["9407"]})
+    rows = db_session.query(PatientVentPin).filter(
+        PatientVentPin.patient_id == patient.id).all()
+    assert [r.parameter_key for r in rows] == ["9407"]
+
+
+def test_a_repeated_key_is_dropped_not_rejected(admin_client, patient):
+    resp = admin_client.put(_url(patient.id), json={
+        "vendor": "vocsn", "parameter_keys": ["9408", "9406", "9408"]})
+    assert resp.status_code == 200
+    assert resp.json()["parameter_keys"] == ["9408", "9406"]
+
+
+def test_pins_are_scoped_per_vendor(admin_client, patient):
+    admin_client.put(_url(patient.id), json={
+        "vendor": "vocsn", "parameter_keys": ["9408"]})
+    # A vendor we have never seen starts unpinned rather than inheriting
+    # another manufacturer's key numbers.
+    other = admin_client.get(f"{_url(patient.id)}?vendor=acme")
+    assert other.json()["parameter_keys"] == []
+    assert other.json()["source"] == "default"
+    assert admin_client.get(_url(patient.id)).json()["parameter_keys"] == ["9408"]
+
+
+def test_pins_are_scoped_per_patient(admin_client, db_session, account, patient):
+    from crud.patients import create_patient
+    other = create_patient(db_session, {
+        "first_name": "Other", "last_name": "Patient",
+        "account_id": account.id, "is_active": True,
+    })
+    db_session.commit()
+    admin_client.put(_url(patient.id), json={
+        "vendor": "vocsn", "parameter_keys": ["9409"]})
+    assert admin_client.get(_url(other.id)).json()["source"] == "default"
+
+
+def test_unknown_patient_404s(admin_client):
+    assert admin_client.get(_url(999999)).status_code == 404
+    assert admin_client.put(_url(999999), json={
+        "vendor": "vocsn", "parameter_keys": []}).status_code == 404
+
+
+def test_reading_pins_needs_the_same_permission_as_the_vent_data(
+        limited_client, patient):
+    """Gated on monitoring.read, matching the sibling vent reads — a user who
+    cannot see the parameters has no use for a list of which ones lead."""
+    assert limited_client.get(_url(patient.id)).status_code == 403
+
+
+def test_changing_pins_needs_the_patient_permission(limited_client, patient):
+    resp = limited_client.put(_url(patient.id), json={
+        "vendor": "vocsn", "parameter_keys": ["9408"]})
+    assert resp.status_code == 403
+
+
+def test_requires_auth(client, patient):
+    assert client.get(_url(patient.id)).status_code == 401

--- a/frontend/src/components/Icons.jsx
+++ b/frontend/src/components/Icons.jsx
@@ -787,6 +787,16 @@ export const BarChartIcon = ({ size = 20 }) => (
   </svg>
 );
 
+// Pinning. Filled when pinned, outline when not — the fill state is the
+// affordance, so callers pass `filled` rather than swapping icons.
+export const StarIcon = ({ size = 20, filled = false }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24"
+       fill={filled ? 'currentColor' : 'none'} stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+  </svg>
+);
+
 export const TargetIcon = ({ size = 20 }) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" 
        strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/frontend/src/components/alerts/AlertsHistory.test.jsx
+++ b/frontend/src/components/alerts/AlertsHistory.test.jsx
@@ -128,9 +128,12 @@ describe('AlertsHistory', () => {
 
   it('does not fetch the raw readings it will not draw', async () => {
     show(true);
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    // Wait for the call being asserted, not for any call: the component fires
+    // several and the first to land is not reliably this one.
+    await waitFor(() => expect(
+      fetchMock.mock.calls.some(c => String(c[0]).includes('/history/analyze/')),
+    ).toBe(true));
     const urls = fetchMock.mock.calls.map(c => String(c[0]));
-    expect(urls.some(u => u.includes('/history/analyze/'))).toBe(true);
     expect(urls.some(u => u.includes('/history/raw/'))).toBe(false);
   });
 

--- a/frontend/src/pages/admin-v2/AdminV2Monitoring.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2Monitoring.jsx
@@ -36,6 +36,17 @@ const AdminV2Monitoring = () => {
   const isInteractionsView = location.pathname.includes('/care/monitoring/interactions');
   const isEnvironmentView = location.pathname.includes('/care/monitoring/environment');
 
+  // The subtitle used to say "Alerts and pulse oximetry history" on every
+  // tab, including the two that show neither.
+  const subtitle = () => {
+    if (isVentilatorView) return 'Ventilator device data';
+    if (isTimelineView) return 'One day of readings and events';
+    if (isEnvironmentView) return 'Environmental readings and correlations';
+    if (isInteractionsView) return 'Interactions between readings and care';
+    if (isHistoryView) return 'Alert history';
+    return 'Alerts and pulse oximetry';
+  };
+
   const renderContent = () => {
     if (!selectedPatient) {
       return (
@@ -80,7 +91,7 @@ const AdminV2Monitoring = () => {
           <h1 className="admin-v2-page-title">Monitoring</h1>
           {selectedPatient && (
             <p className="admin-v2-page-subtitle">
-              Alerts and pulse oximetry history for {selectedPatient.first_name} {selectedPatient.last_name}
+              {subtitle()} for {selectedPatient.first_name} {selectedPatient.last_name}
             </p>
           )}
         </div>

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringVentilator.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringVentilator.jsx
@@ -620,6 +620,7 @@ const PinnedTrend = ({ rows, series }) => {
 /* One parameter's day: the median line inside its 5th–95th percentile band. */
 const ParameterDetail = ({ row, patientId, date, onClose }) => {
   const { param, band, flags } = row;
+  const sources = param.sources || [];
   const [points, setPoints] = useState(null);
   const [loading, setLoading] = useState(true);
   const canvasRef = useRef(null);
@@ -710,7 +711,7 @@ const ParameterDetail = ({ row, patientId, date, onClose }) => {
             Device band, 5th to 95th percentile:{' '}
             <b>{formatValue(band.lo, param.precision)} – {formatValue(band.hi, param.precision)}</b>
             {param.display_units ? ` ${param.display_units}` : ''}
-            {band.inverted && ' — reported inverted by the device and shown low to high'}
+            {band.inverted && ' — averaged inverted over the day and shown low to high'}
           </p>
         )}
         <div style={{ height: 300, position: 'relative' }}>
@@ -726,6 +727,16 @@ const ParameterDetail = ({ row, patientId, date, onClose }) => {
           Line is the device&rsquo;s median for each sampling window; the shaded band is
           its 5th to 95th percentile over the same window.
         </p>
+        {sources.length > 1 && (
+          <p className="vnt-note" style={{ padding: 0 }}>
+            Blended from {sources.length} device messages
+            {' — '}
+            {sources.map((s) => `${s.message_type}/${s.message_id} (${s.n})`).join(', ')}.
+            These are not the same measurement: on this device the continuous
+            message keeps reporting through standby, so a plateau and a floor in
+            the same trace are two states, not a change in the patient.
+          </p>
+        )}
       </div>
     </EntityModal>
   );

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringVentilator.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringVentilator.jsx
@@ -15,100 +15,101 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useEffect, useMemo, useState } from 'react';
+// One ventilator day.
+//
+// A day carries ~44 parameters and the device has no opinion about which
+// matter, so the page is built around two answers to that: the care team's
+// pins lead, and everything else is one line per parameter rather than a
+// card. The previous version gave breath rate and a raw vendor counter the
+// same 250px card, which put the numbers anyone actually reads five screens
+// apart.
+//
+// On trust: see ventParameters.js. We flag where a number came from, never
+// whether it is right — there is no verification step in this pipeline and
+// the UI must not imply one.
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import Chart from 'chart.js/auto';
+import 'chartjs-adapter-date-fns';
+import config, { apiFetch } from '../../config';
+import EntityModal from '../../components/vc/EntityModal';
 import {
-  ResponsiveContainer, ComposedChart, CartesianGrid, XAxis, YAxis,
-  Tooltip, Area, Line,
-} from 'recharts';
-import config from '../../config';
-import { ChevronLeftIcon, ChevronRightIcon } from '../../components/Icons';
-import { useChartColors } from '../../hooks/useChartColors';
-import { Button } from '@/components/ui/button';
-import { Alert } from '@/components/ui/alert';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  CalendarIcon, ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon, StarIcon,
+} from '../../components/Icons';
+import { rowsFrom, matchesQuery, formatValue, bandPosition } from './ventParameters';
+import './monitoring-ventilator.css';
 
-const GROUP_COLORS = {
-  Ventilation: '#3b82f6',
-  Oxygen:      '#3fb950',
-  Cough:       '#f0883e',
-  Suction:     '#bb8009',
-  Nebulizer:   '#a371f7',
-  System:      '#6b7280',
-  Config:      '#6b7280',
-  Other:       '#6b7280',
+/* Group accents from the vc ramp, so a group reads as a category rather than
+ * a state. Unlisted groups fall back to the neutral dot. */
+const GROUP_ACCENT = {
+  Ventilation: '#4da7bd',
+  Oxygen: '#3fbf6a',
+  Cough: '#9b8cf0',
+  Suction: '#4dc3b3',
+  Nebulizer: '#d98cc4',
+  System: '#7f9fd4',
+  Config: '#a8c94a',
+  Other: '#6b7987',
 };
 
-const fmtDateLong = (iso) => {
-  if (!iso) return '';
-  const d = new Date(iso + 'T00:00:00');
-  return d.toLocaleDateString(undefined, {
-    weekday: 'long', month: 'short', day: 'numeric', year: 'numeric',
+/* Series colours for the pinned trend — the vc-derived ramp the reports use. */
+const SERIES_RAMP = ['#4da7bd', '#3fbf6a', '#9b8cf0', '#4dc3b3', '#7f9fd4', '#d98cc4', '#a8c94a'];
+
+const CHROME = {
+  grid: 'rgba(255, 255, 255, 0.06)',
+  axis: '#6b7987',
+  band: 'rgba(77, 167, 189, 0.16)',
+  line: '#4da7bd',
+};
+
+const VENDOR = 'vocsn';
+
+const fmtDay = (iso) => {
+  const [y, m, d] = String(iso).split('-').map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString('en-US', {
+    weekday: 'short', month: 'short', day: 'numeric', year: 'numeric',
   });
 };
-
-const fmtTime = (iso) => {
-  if (!iso) return '—';
-  return new Date(iso).toLocaleTimeString(undefined, {
-    hour: 'numeric', minute: '2-digit', hour12: true,
-  });
-};
-
-const fmtNum = (v, precision) => {
-  if (v == null) return '—';
-  const p = (precision != null && precision >= 0) ? Math.min(precision, 4) : 2;
-  if (Math.abs(v) >= 1000) return v.toFixed(0);
-  return v.toFixed(p);
-};
+const fmtClock = (iso) => (iso
+  ? new Date(iso).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+  : null);
 
 const AdminV2MonitoringVentilator = ({ patientId }) => {
-  const [daysLoading, setDaysLoading] = useState(true);
+  const [days, setDays] = useState([]);
   const [hasIntegration, setHasIntegration] = useState(true);
-  const [days, setDays] = useState([]);  // [{date, sample_count}]
+  const [daysLoading, setDaysLoading] = useState(true);
   const [selectedDate, setSelectedDate] = useState(null);
-  const [dayLoading, setDayLoading] = useState(false);
   const [dayData, setDayData] = useState(null);
+  const [dayLoading, setDayLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  // Drill-down chart modal
-  const [detail, setDetail] = useState(null);   // { parameter, accent } when open
-  const [detailLoading, setDetailLoading] = useState(false);
-  const [detailData, setDetailData] = useState(null);
-  const [detailError, setDetailError] = useState(null);
+  const [pins, setPins] = useState([]);
+  const [pinsSource, setPinsSource] = useState('default');
+  const [pinSeries, setPinSeries] = useState({});
 
-  // Fetch the days list once per patient.
+  const [query, setQuery] = useState('');
+  const [group, setGroup] = useState(null);
+  const [reviewOnly, setReviewOnly] = useState(false);
+  const [openGroups, setOpenGroups] = useState(null);
+  const [detail, setDetail] = useState(null);
+
+  /* ---------------- data ---------------- */
+
   useEffect(() => {
+    if (!patientId) return undefined;
     let cancelled = false;
+    setDaysLoading(true);
     (async () => {
-      setDaysLoading(true);
-      setError(null);
       try {
-        const res = await fetch(
-          `${config.apiUrl}/api/integrations/patient/${patientId}/vent/days`,
-          { credentials: 'include' }
-        );
-        if (!res.ok) throw new Error(`Failed to load days (${res.status})`);
-        const data = await res.json();
+        const res = await apiFetch(
+          `${config.apiUrl}/api/integrations/patient/${patientId}/vent/days`);
+        if (!res.ok) throw new Error('Could not load ventilator days.');
+        const body = await res.json();
         if (cancelled) return;
-        setHasIntegration(!!data.has_integration);
-        setDays(data.days || []);
-        // Default to most recent day with data.
-        if ((data.days || []).length > 0) {
-          setSelectedDate(data.days[0].date);
-        }
-      } catch (e) {
-        if (!cancelled) setError(e.message);
+        setHasIntegration(body.has_integration !== false);
+        setDays(body.days || []);
+        setSelectedDate(body.days?.[0]?.date ?? null);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
       } finally {
         if (!cancelled) setDaysLoading(false);
       }
@@ -116,50 +117,20 @@ const AdminV2MonitoringVentilator = ({ patientId }) => {
     return () => { cancelled = true; };
   }, [patientId]);
 
-  // Fetch the drill-down series when a parameter is picked.
   useEffect(() => {
-    if (!detail || !selectedDate) {
-      setDetailData(null);
-      return;
-    }
+    if (!patientId || !selectedDate) return undefined;
     let cancelled = false;
+    setDayLoading(true);
+    setError(null);
     (async () => {
-      setDetailLoading(true);
-      setDetailError(null);
       try {
-        const res = await fetch(
-          `${config.apiUrl}/api/integrations/patient/${patientId}/vent/day/${selectedDate}/parameter/${detail.parameter.parameter_key}`,
-          { credentials: 'include' }
-        );
-        if (!res.ok) throw new Error(`Failed to load chart (${res.status})`);
-        const data = await res.json();
-        if (!cancelled) setDetailData(data);
-      } catch (e) {
-        if (!cancelled) setDetailError(e.message);
-      } finally {
-        if (!cancelled) setDetailLoading(false);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [detail, selectedDate, patientId]);
-
-  // Fetch the selected day's stats.
-  useEffect(() => {
-    if (!selectedDate) return;
-    let cancelled = false;
-    (async () => {
-      setDayLoading(true);
-      setError(null);
-      try {
-        const res = await fetch(
-          `${config.apiUrl}/api/integrations/patient/${patientId}/vent/day/${selectedDate}`,
-          { credentials: 'include' }
-        );
-        if (!res.ok) throw new Error(`Failed to load day (${res.status})`);
-        const data = await res.json();
-        if (!cancelled) setDayData(data);
-      } catch (e) {
-        if (!cancelled) setError(e.message);
+        const res = await apiFetch(
+          `${config.apiUrl}/api/integrations/patient/${patientId}/vent/day/${selectedDate}`);
+        if (!res.ok) throw new Error('Could not load this day.');
+        const body = await res.json();
+        if (!cancelled) { setDayData(body); setOpenGroups(null); }
+      } catch (err) {
+        if (!cancelled) setError(err.message);
       } finally {
         if (!cancelled) setDayLoading(false);
       }
@@ -167,431 +138,597 @@ const AdminV2MonitoringVentilator = ({ patientId }) => {
     return () => { cancelled = true; };
   }, [patientId, selectedDate]);
 
-  // Day-list-aware prev/next/today helpers (skip empty dates).
-  const dateIndex = useMemo(() => {
-    const idx = days.findIndex(d => d.date === selectedDate);
-    return { idx, total: days.length };
-  }, [days, selectedDate]);
+  useEffect(() => {
+    if (!patientId) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiFetch(
+          `${config.apiUrl}/api/integrations/patient/${patientId}/vent/pins?vendor=${VENDOR}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body = await res.json();
+        if (!cancelled) {
+          setPins(body.parameter_keys || []);
+          setPinsSource(body.source || 'default');
+        }
+      } catch {
+        if (!cancelled) { setPins([]); setPinsSource('default'); }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [patientId]);
 
-  const goPrev = () => {
-    // newer = lower index (days sorted DESC). "Prev" in calendar sense = older = idx+1.
-    if (dateIndex.idx < days.length - 1) setSelectedDate(days[dateIndex.idx + 1].date);
-  };
-  const goNext = () => {
-    if (dateIndex.idx > 0) setSelectedDate(days[dateIndex.idx - 1].date);
-  };
-  const goNewest = () => {
-    if (days.length > 0) setSelectedDate(days[0].date);
+  /* ---------------- derived ---------------- */
+
+  const rows = useMemo(() => rowsFrom(dayData), [dayData]);
+  const byKey = useMemo(
+    () => Object.fromEntries(rows.map((r) => [r.param.parameter_key, r])), [rows]);
+
+  const pinnedRows = useMemo(
+    () => pins.map((key) => byKey[key]).filter(Boolean), [pins, byKey]);
+  // Pins that exist for the patient but produced nothing today: worth showing
+  // as absent rather than dropping, or a silent gap reads as a normal day.
+  const pinsMissingToday = useMemo(
+    () => pins.filter((key) => !byKey[key]), [pins, byKey]);
+
+  const reviewCount = rows.filter((r) => r.review).length;
+
+  const groupCounts = useMemo(() => {
+    const counts = new Map();
+    rows.forEach((r) => counts.set(r.group, (counts.get(r.group) || 0) + 1));
+    return [...counts.entries()].map(([name, count]) => ({ name, count }));
+  }, [rows]);
+
+  const visibleRows = useMemo(() => rows.filter((r) => (
+    (!group || r.group === group)
+    && (!reviewOnly || r.review)
+    && matchesQuery(r, query)
+  )), [rows, group, reviewOnly, query]);
+
+  const visibleGroups = useMemo(() => {
+    const out = [];
+    visibleRows.forEach((r) => {
+      let entry = out.find((g) => g.name === r.group);
+      if (!entry) { entry = { name: r.group, rows: [] }; out.push(entry); }
+      entry.rows.push(r);
+    });
+    return out;
+  }, [visibleRows]);
+
+  // Only the first group starts open; a filtered or searched list opens all,
+  // because a hit hidden inside a collapsed group looks like no hit at all.
+  const filtering = Boolean(query.trim() || group || reviewOnly);
+  const isOpen = useCallback((name, index) => {
+    if (filtering) return true;
+    if (openGroups === null) return index === 0;
+    return openGroups.includes(name);
+  }, [filtering, openGroups]);
+
+  const toggleGroup = (name) => {
+    setOpenGroups((prev) => {
+      const base = prev ?? (visibleGroups[0] ? [visibleGroups[0].name] : []);
+      return base.includes(name) ? base.filter((g) => g !== name) : [...base, name];
+    });
   };
 
-  if (daysLoading) {
-    return <div style={{ padding: 24, color: 'var(--muted-foreground)' }}>Loading ventilator data…</div>;
-  }
+  /* ---------------- pinned series ---------------- */
+
+  const pinKeysStr = pinnedRows.map((r) => r.param.parameter_key).join(',');
+  useEffect(() => {
+    if (!patientId || !selectedDate || !pinKeysStr) { setPinSeries({}); return undefined; }
+    let cancelled = false;
+    const keys = pinKeysStr.split(',');
+    (async () => {
+      const next = {};
+      await Promise.all(keys.map(async (key) => {
+        try {
+          const res = await apiFetch(`${config.apiUrl}/api/integrations/patient/`
+            + `${patientId}/vent/day/${selectedDate}/parameter/${key}`);
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const body = await res.json();
+          next[key] = body.points || [];
+        } catch {
+          next[key] = [];
+        }
+      }));
+      if (!cancelled) setPinSeries(next);
+    })();
+    return () => { cancelled = true; };
+  }, [patientId, selectedDate, pinKeysStr]);
+
+  /* ---------------- pinning ---------------- */
+
+  const savePins = useCallback(async (keys) => {
+    setPins(keys);
+    setPinsSource('patient');
+    try {
+      await apiFetch(`${config.apiUrl}/api/integrations/patient/${patientId}/vent/pins`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vendor: VENDOR, parameter_keys: keys }),
+      });
+    } catch {
+      // The star is optimistic; a failed save leaves the page usable and the
+      // next load re-reads the server's answer.
+    }
+  }, [patientId]);
+
+  const togglePin = (key) => {
+    savePins(pins.includes(key) ? pins.filter((k) => k !== key) : [...pins, key]);
+  };
+
+  /* ---------------- day nav ---------------- */
+
+  const dayIndex = days.findIndex((d) => d.date === selectedDate);
+  const goto = (delta) => {
+    const next = days[dayIndex + delta];
+    if (next) setSelectedDate(next.date);
+  };
+
+  /* ---------------- render ---------------- */
+
+  if (daysLoading) return <div className="vnt"><p className="vnt-empty">Loading ventilator data…</p></div>;
+
   if (!hasIntegration) {
     return (
-      <div style={{
-        padding: 30, color: 'var(--muted-foreground)',
-        background: 'var(--secondary)',
-        border: '1px dashed var(--border)',
-        borderRadius: 8, textAlign: 'center',
-      }}>
-        <p style={{ margin: '0 0 8px 0', color: 'var(--foreground)', fontSize: 16, fontWeight: 600 }}>
-          No ventilator integration
-        </p>
-        <p style={{ margin: 0 }}>
-          Configure a Ventilator integration under <em>Configuration → Integrations</em> and upload a log export.
+      <div className="vnt">
+        <p className="vnt-setup">
+          This patient has no ventilator integration yet. Add one under
+          Configuration &rsaquo; Integrations to start importing device data.
         </p>
       </div>
     );
   }
+
   if (days.length === 0) {
     return (
-      <div style={{
-        padding: 30, color: 'var(--muted-foreground)',
-        background: 'var(--secondary)',
-        border: '1px dashed var(--border)',
-        borderRadius: 8, textAlign: 'center',
-      }}>
-        <p style={{ margin: '0 0 8px 0', color: 'var(--foreground)', fontSize: 16, fontWeight: 600 }}>
-          No vent samples yet
-        </p>
-        <p style={{ margin: 0 }}>
-          Upload a log export via the integration's <em>Logs</em> button to populate this view.
+      <div className="vnt">
+        <p className="vnt-setup">
+          No ventilator samples have been parsed yet. Upload a device export from
+          the integration&rsquo;s Logs panel.
         </p>
       </div>
     );
   }
 
+  const summary = dayData?.summary;
+  const covering = summary && (fmtClock(summary.first_at) && fmtClock(summary.last_at)
+    ? `${fmtClock(summary.first_at)} – ${fmtClock(summary.last_at)}`
+    : null);
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-      {/* Date controls */}
-      <div className="tw" style={{
-        display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap',
-        padding: '12px 14px',
-        background: 'var(--secondary)',
-        border: '1px solid var(--border)',
-        borderRadius: 10,
-      }}>
-        <Button
-          variant="secondary"
-          size="icon"
-          onClick={goPrev}
-          disabled={dateIndex.idx >= days.length - 1}
-          title="Older day with data"
-        ><ChevronLeftIcon size={16} /></Button>
-
-        <Select value={selectedDate || undefined} onValueChange={setSelectedDate}>
-          <SelectTrigger className="w-auto min-w-[260px] font-semibold"><SelectValue /></SelectTrigger>
-          <SelectContent>
-            {days.map(d => (
-              <SelectItem key={d.date} value={d.date}>
-                {fmtDateLong(d.date)} — {d.sample_count.toLocaleString()} samples
-              </SelectItem>
+    <div className="vnt">
+      <div className="vnt-daybar">
+        <button
+          type="button" className="vnt-navbtn" aria-label="Older day"
+          disabled={dayIndex >= days.length - 1} onClick={() => goto(1)}
+        >
+          <ChevronLeftIcon size={18} />
+        </button>
+        <span className="vnt-datepill">
+          {selectedDate ? fmtDay(selectedDate) : '—'}
+          <CalendarIcon size={16} />
+          <select
+            aria-label="Pick a day"
+            value={selectedDate ?? ''}
+            onChange={(e) => setSelectedDate(e.target.value)}
+          >
+            {days.map((d) => (
+              <option key={d.date} value={d.date}>
+                {fmtDay(d.date)} — {d.sample_count.toLocaleString()} samples
+              </option>
             ))}
-          </SelectContent>
-        </Select>
-
-        <Button
-          variant="secondary"
-          size="icon"
-          onClick={goNext}
-          disabled={dateIndex.idx <= 0}
-          title="Newer day with data"
-        ><ChevronRightIcon size={16} /></Button>
-
-        <Button
-          onClick={goNewest}
-          disabled={dateIndex.idx === 0}
-        >Newest</Button>
-
-        <span style={{ marginLeft: 'auto', color: 'var(--muted-foreground)', fontSize: 12 }}>
-          {dateIndex.idx + 1} of {dateIndex.total}
+          </select>
         </span>
+        <button
+          type="button" className="vnt-navbtn" aria-label="Newer day"
+          disabled={dayIndex <= 0} onClick={() => goto(-1)}
+        >
+          <ChevronRightIcon size={18} />
+        </button>
+        <button
+          type="button" className="vnt-navbtn"
+          disabled={dayIndex === 0} onClick={() => setSelectedDate(days[0].date)}
+        >
+          Newest
+        </button>
+        <span className="vnt-count">{dayIndex + 1} of {days.length}</span>
       </div>
 
-      {/* Vendor-encoding caveat — kept small so it doesn't dominate the page. */}
-      <div style={{
-        padding: '8px 12px', borderRadius: 6,
-        background: 'rgba(96,165,250,0.08)',
-        border: '1px solid rgba(96,165,250,0.25)',
-        color: 'var(--muted-foreground)', fontSize: 12, lineHeight: 1.4,
-      }}>
-        <strong style={{ color: 'var(--ring)' }}>Note:</strong> headline values use VOCSN's median (50th percentile) aggregate
-        to match the device's own report. Some parameters (e.g. PEEP, MAP, ambient pressure) may still
-        display in raw vendor units — we apply parameter-specific scaling as it's identified.
-      </div>
+      {error && <p className="vnt-error">{error}</p>}
 
-      {/* Day summary */}
-      {dayData?.summary && (
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
-          gap: 10,
-        }}>
-          <SummaryTile label="Date" value={fmtDateLong(dayData.date)} />
-          <SummaryTile
-            label="Total Samples"
-            value={dayData.summary.total_samples.toLocaleString()}
-          />
-          <SummaryTile
-            label="Parameters Active"
-            value={dayData.summary.parameter_count}
-          />
-          <SummaryTile
-            label="Time Range"
-            value={dayData.summary.first_at
-              ? `${fmtTime(dayData.summary.first_at)} → ${fmtTime(dayData.summary.last_at)}`
-              : '—'}
-          />
+      {summary && (
+        <div className="vnt-stats">
+          <div className="vnt-stat">
+            <span className="vnt-stat-head">Samples</span>
+            <span className="vnt-stat-value">{summary.total_samples.toLocaleString()}</span>
+          </div>
+          <div className="vnt-stat">
+            <span className="vnt-stat-head">Parameters</span>
+            <span className="vnt-stat-value">{summary.parameter_count}</span>
+          </div>
+          <div className="vnt-stat">
+            <span className="vnt-stat-head">Covering</span>
+            <span className="vnt-stat-value" style={{ fontSize: '1rem' }}>{covering || '—'}</span>
+            <span className="vnt-stat-note">first to last sample</span>
+          </div>
+          <button
+            type="button"
+            className={`vnt-stat ${reviewCount ? 'flagged' : 'clean'}`}
+            aria-pressed={reviewOnly}
+            onClick={() => setReviewOnly((v) => !v)}
+          >
+            <span className="vnt-stat-head">Needs review</span>
+            <span className="vnt-stat-value">{reviewCount}</span>
+            <span className="vnt-stat-note">
+              {reviewCount ? (reviewOnly ? 'showing only these' : 'tap to filter') : 'all described'}
+            </span>
+          </button>
         </div>
       )}
 
-      {dayLoading && (
-        <div style={{ padding: 24, color: 'var(--muted-foreground)', textAlign: 'center' }}>
-          Loading day…
-        </div>
+      {pinnedRows.length > 0 && (
+        <section className="vnt-card">
+          <div className="vnt-card-head">
+            <h3>Pinned</h3>
+            <span className="vnt-label">
+              {pinsSource === 'default' ? 'default set' : `${pins.length} chosen`}
+            </span>
+          </div>
+          <div className="vnt-pins">
+            {pinnedRows.map((row) => (
+              <PinnedCell key={row.param.parameter_key} row={row} />
+            ))}
+            {pinsMissingToday.map((key) => (
+              <div className="vnt-pin vnt-pin-missing" key={key}>
+                <span className="vnt-pin-name">#{key}</span>
+                <span className="vnt-pin-value">—</span>
+                <span className="vnt-pin-sub">no samples today</span>
+              </div>
+            ))}
+          </div>
+          <PinnedTrend rows={pinnedRows} series={pinSeries} />
+        </section>
       )}
 
-      {error && (
-        <div className="tw"><Alert variant="destructive">{error}</Alert></div>
-      )}
+      <div className="vnt-controls">
+        <input
+          className="vnt-search"
+          type="search"
+          placeholder="Search parameter or vendor ID"
+          aria-label="Search parameters"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <button
+          type="button" className="vnt-chip"
+          aria-pressed={group === null} onClick={() => setGroup(null)}
+        >
+          All
+          <span className="vnt-chip-count">{rows.length}</span>
+        </button>
+        {groupCounts.map((g) => (
+          <button
+            key={g.name} type="button" className="vnt-chip"
+            aria-pressed={group === g.name}
+            onClick={() => setGroup(group === g.name ? null : g.name)}
+          >
+            <span className="vnt-dot" style={{ '--grp': GROUP_ACCENT[g.name] }} />
+            {g.name}
+            <span className="vnt-chip-count">{g.count}</span>
+          </button>
+        ))}
+      </div>
 
-      {/* Grouped parameter cards */}
-      {!dayLoading && dayData?.groups?.map(group => {
-        const color = GROUP_COLORS[group.name] || GROUP_COLORS.Other;
-        return (
-          <div key={group.name} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <div style={{
-              display: 'flex', alignItems: 'center', gap: 8,
-              paddingBottom: 6,
-              borderBottom: `2px solid ${color}`,
-            }}>
-              <span style={{
-                width: 12, height: 12, borderRadius: '50%', background: color,
-              }} />
-              <h3 style={{ margin: 0, color: 'var(--foreground)', fontSize: 16, fontWeight: 700 }}>
-                {group.name}
-              </h3>
-              <span style={{
-                color: 'var(--muted-foreground)', fontSize: 12, marginLeft: 'auto',
-              }}>{group.parameters.length} parameter{group.parameters.length === 1 ? '' : 's'}</span>
-            </div>
-            <div style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
-              gap: 8,
-            }}>
-              {group.parameters.map(p => (
-                <ParameterCard
-                  key={p.parameter_key}
-                  p={p}
-                  accent={color}
-                  onOpen={() => setDetail({ parameter: p, accent: color })}
+      {dayLoading && !dayData && <p className="vnt-empty">Loading the day…</p>}
+
+      {dayData && (
+        <section className="vnt-card">
+          {visibleGroups.length === 0 ? (
+            <p className="vnt-empty">No parameters match.</p>
+          ) : visibleGroups.map((g, i) => (
+            <div className="vnt-group" key={g.name}>
+              <button
+                type="button" className="vnt-group-head"
+                aria-expanded={isOpen(g.name, i)}
+                onClick={() => toggleGroup(g.name)}
+              >
+                <span className="vnt-dot" style={{ '--grp': GROUP_ACCENT[g.name] }} />
+                {g.name}
+                <span className="vnt-group-meta">
+                  {g.rows.length} {g.rows.length === 1 ? 'parameter' : 'parameters'}
+                </span>
+                <ChevronDownIcon
+                  size={15}
+                  style={{ transform: isOpen(g.name, i) ? 'rotate(180deg)' : 'none' }}
+                />
+              </button>
+              {isOpen(g.name, i) && g.rows.map((row) => (
+                <ParameterRow
+                  key={row.param.parameter_key}
+                  row={row}
+                  pinned={pins.includes(row.param.parameter_key)}
+                  onPin={() => togglePin(row.param.parameter_key)}
+                  onOpen={() => setDetail(row)}
                 />
               ))}
             </div>
-          </div>
-        );
-      })}
+          ))}
+          <p className="vnt-note">
+            Values are the average of the device&rsquo;s per-window medians for the day;
+            the range beside each is the lowest and highest of those medians, not the
+            day&rsquo;s extremes.
+          </p>
+        </section>
+      )}
 
       {detail && (
-        <ParameterDetailModal
-          detail={detail}
+        <ParameterDetail
+          row={detail}
+          patientId={patientId}
           date={selectedDate}
-          loading={detailLoading}
-          data={detailData}
-          error={detailError}
-          onClose={() => { setDetail(null); setDetailData(null); }}
+          onClose={() => setDetail(null)}
         />
       )}
     </div>
   );
 };
 
-// ---- small subcomponents ----
+/* One pinned parameter, big enough to read across a room. */
+const PinnedCell = ({ row }) => {
+  const { param, headline, review } = row;
+  const value = formatValue(headline?.value, param.precision);
+  return (
+    <div className={`vnt-pin${review ? ' review' : ''}`}>
+      <span className="vnt-pin-name" title={param.display_label}>{param.display_label}</span>
+      <span className="vnt-pin-value">
+        {value ?? '—'}
+        {value != null && param.display_units && <small>{param.display_units}</small>}
+      </span>
+      <span className="vnt-pin-sub">
+        {headline ? `${headline.n} samples` : 'no data'}
+        {headline?.basis === 'raw' && ' · raw'}
+      </span>
+    </div>
+  );
+};
 
-const SummaryTile = ({ label, value }) => (
-  <div style={{
-    background: 'var(--card)', borderRadius: 10,
-    border: '1px solid var(--border)',
-    padding: '10px 14px',
-  }}>
-    <div style={{
-      color: 'var(--muted-foreground)', fontSize: 11, fontWeight: 600,
-      textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4,
-    }}>{label}</div>
-    <div style={{ color: 'var(--foreground)', fontSize: 16, fontWeight: 700 }}>{value}</div>
-  </div>
-);
-
-const ParameterCard = ({ p, accent, onOpen }) => {
-  // VOCSN encodes statistical aggregates per sample window:
-  //   _50 = median, _5 = 5th percentile, _95 = 95th percentile,
-  //   _N  = period count / raw single-sample (not a clinical value).
-  // The vendor's own report plots median ± 5/95 band, so we do the same.
-  const median = p.stats_by_suffix['50'];
-  const p5 = p.stats_by_suffix['5'];
-  const p95 = p.stats_by_suffix['95'];
-  const raw = p.stats_by_suffix['N'] || p.stats_by_suffix[''];
-  const hasMedian = !!median;
-
-  // Headline uses median when present, else falls back to the raw _N column.
-  // Min/Max under it are the day's bounds on the median (not on raw samples).
-  const headline = hasMedian ? median : raw;
-  const fallbackLabel = hasMedian ? null : 'raw';
-  const lowBand = p5?.mean ?? p5?.lo;
-  const highBand = p95?.mean ?? p95?.hi;
-  const sampleCount = (median?.n) ?? (raw?.n) ?? p.total_samples;
+/* One parameter, one line. */
+const ParameterRow = ({ row, pinned, onPin, onOpen }) => {
+  const { param, headline, flags, review } = row;
+  const value = formatValue(headline?.value, param.precision);
+  const lo = formatValue(headline?.lo, param.precision);
+  const hi = formatValue(headline?.hi, param.precision);
+  const pos = bandPosition(headline?.value, headline?.lo, headline?.hi);
 
   return (
-    <button
-      type="button"
-      onClick={onOpen}
-      style={{
-        // Reset native <button> styling so the card renders identically.
-        font: 'inherit', color: 'inherit', cursor: 'pointer', textAlign: 'left',
-        appearance: 'none',
-        background: 'var(--card)',
-        border: '1px solid var(--border)',
-        borderLeft: `4px solid ${accent}`,
-        borderRadius: 10, padding: '10px 12px',
-        display: 'flex', flexDirection: 'column', gap: 6,
-        transition: 'border-color 0.15s, transform 0.05s',
-      }}
-      onMouseEnter={(e) => { e.currentTarget.style.borderColor = accent; }}
-      onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'var(--border)'; }}
-      onMouseDown={(e) => { e.currentTarget.style.transform = 'scale(0.99)'; }}
-      onMouseUp={(e) => { e.currentTarget.style.transform = ''; }}
-    >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 8 }}>
-        <span style={{ color: 'var(--foreground)', fontWeight: 600, fontSize: 14, lineHeight: 1.2 }}>
-          {p.display_label}
+    <div className={`vnt-row${review ? ' review' : ''}`}>
+        <button
+          type="button"
+          className="vnt-pinbtn"
+          aria-pressed={pinned}
+          aria-label={`${pinned ? 'Unpin' : 'Pin'} ${param.display_label}`}
+          onClick={onPin}
+        >
+          <StarIcon size={15} filled={pinned} />
+        </button>
+        <button type="button" className="vnt-row-name" onClick={onOpen}>
+          <span className="vnt-row-label">{param.display_label}</span>
+          <span className="vnt-row-key">#{param.parameter_key}</span>
+        </button>
+        <span className="vnt-row-value">
+          {value ?? '—'}
+          {value != null && param.display_units && <small>{param.display_units}</small>}
         </span>
-        <span style={{ color: 'var(--muted-foreground)', fontSize: 11 }}>#{p.parameter_key}</span>
-      </div>
-      {p.display_units && (
-        <span style={{ color: 'var(--muted-foreground)', fontSize: 11 }}>{p.display_units}</span>
-      )}
-
-      {headline && (
-        <div style={{
-          display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 4,
-          marginTop: 2,
-        }}>
-          <MetricChip label="day low" value={fmtNum(headline.lo, p.precision)} />
-          <MetricChip
-            label={hasMedian ? 'median' : (fallbackLabel || 'value')}
-            value={fmtNum(headline.mean, p.precision)}
-            highlight
-          />
-          <MetricChip label="day high" value={fmtNum(headline.hi, p.precision)} />
-        </div>
-      )}
-
-      {hasMedian && (lowBand != null || highBand != null) && (
-        <div style={{
-          color: 'var(--muted-foreground)', fontSize: 11,
-          padding: '4px 6px', borderRadius: 4,
-          background: 'var(--secondary)',
-        }}>
-          5–95% typical:{' '}
-          <strong style={{ color: 'var(--foreground)' }}>
-            {fmtNum(lowBand, p.precision)} – {fmtNum(highBand, p.precision)}
-          </strong>
-        </div>
-      )}
-
-      <div style={{ color: 'var(--muted-foreground)', fontSize: 11, marginTop: 2, display: 'flex', justifyContent: 'space-between' }}>
-        <span>
-          {sampleCount.toLocaleString()} samples
-          {!hasMedian && (
-            <span style={{ marginLeft: 6, color: 'var(--warning)' }}>
-              (no median — showing raw _N)
+        <span className="vnt-row-range">{lo != null && hi != null ? `${lo}–${hi}` : ''}</span>
+        <span className="vnt-row-n">{headline?.n ?? param.total_samples}</span>
+        <span className="vnt-row-chev"><ChevronRightIcon size={14} /></span>
+        {pos != null && (
+          <span className="vnt-pos">
+            <span className="vnt-pos-mark" style={{ left: `${pos * 100}%` }} />
+            <span className="sr-only">
+              sits {Math.round(pos * 100)}% through its range for the day
             </span>
-          )}
-        </span>
-        <span style={{ color: accent, opacity: 0.7 }}>chart →</span>
-      </div>
-    </button>
+          </span>
+        )}
+        {flags.length > 0 && (
+          <span className="vnt-flags">
+            {flags.map((f) => (
+              <span key={f.key} className={`vnt-flag ${f.tone}`} title={f.hint}>{f.label}</span>
+            ))}
+          </span>
+        )}
+    </div>
   );
 };
 
-// Drill-down chart: line+band of one parameter over the selected day.
-const ParameterDetailModal = ({ detail, date, loading, data, error, onClose }) => {
-  const chart = useChartColors();
-  const { parameter, accent } = detail;
-  const chartData = useMemo(() => {
-    if (!data?.points) return [];
-    return data.points
-      .filter(p => p.p50 != null || p.p5 != null || p.p95 != null)
-      .map(p => ({
-        ts: new Date(p.ts).getTime(),
-        // Recharts Area needs separate keys for the band edges.
-        p50: p.p50,
-        p5:  p.p5,
-        p95: p.p95,
-        // For the band: render as [p5, p95] via a single dataKey returning an array.
-        band: (p.p5 != null && p.p95 != null) ? [p.p5, p.p95] : null,
-      }));
-  }, [data]);
+/* The pinned parameters on one time axis. Only pinned series are fetched, so
+ * this is a handful of requests rather than one per parameter on the page. */
+const PinnedTrend = ({ rows, series }) => {
+  const canvasRef = useRef(null);
+  const chartRef = useRef(null);
 
-  const fmtTickTime = (t) => new Date(t).toLocaleTimeString(undefined,
-    { hour: 'numeric', hour12: true });
-  const fmtTooltipTime = (t) => new Date(t).toLocaleString(undefined,
-    { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true });
+  const datasets = useMemo(() => rows.map((row, i) => {
+    const key = row.param.parameter_key;
+    const points = (series[key] || [])
+      .filter((p) => p.p50 != null)
+      .map((p) => ({ x: new Date(p.ts).getTime(), y: p.p50 }));
+    return { key, label: row.param.display_label, points, axis: i === 0 ? 'y' : `y${i}` };
+  }).filter((d) => d.points.length > 0), [rows, series]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || datasets.length === 0) return undefined;
+    // Each parameter keeps its own hidden scale — minute volume in litres and
+    // breath rate per minute on one axis would flatten both to a line.
+    const scales = { x: {
+      type: 'time',
+      time: { displayFormats: { minute: 'h:mm', hour: 'ha' } },
+      grid: { color: CHROME.grid, drawTicks: false },
+      border: { display: false },
+      ticks: { color: CHROME.axis, maxRotation: 0, autoSkip: true, maxTicksLimit: 6,
+        font: { size: 10, family: "'IBM Plex Mono', monospace" } },
+    } };
+    datasets.forEach((d) => {
+      scales[d.axis] = { display: false, grid: { display: false } };
+    });
+
+    const chart = new Chart(canvas.getContext('2d'), {
+      type: 'line',
+      data: {
+        datasets: datasets.map((d, i) => ({
+          label: d.label,
+          data: d.points,
+          parsing: false,
+          yAxisID: d.axis,
+          borderColor: SERIES_RAMP[i % SERIES_RAMP.length],
+          borderWidth: 1.4,
+          pointRadius: 0,
+          tension: 0.15,
+        })),
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: false,
+        interaction: { mode: 'index', intersect: false },
+        layout: { padding: { right: 8, top: 6 } },
+        scales,
+        plugins: {
+          legend: {
+            display: true, position: 'bottom',
+            labels: { usePointStyle: true, boxWidth: 6, color: CHROME.axis,
+              font: { size: 10, family: "'IBM Plex Mono', monospace" } },
+          },
+          tooltip: { enabled: true },
+        },
+      },
+    });
+    chartRef.current = chart;
+    return () => { chart.destroy(); chartRef.current = null; };
+  }, [datasets]);
+
+  if (datasets.length === 0) return null;
+  return (
+    <div className="vnt-plot">
+      <canvas ref={canvasRef} aria-label="Pinned parameters over the day" />
+    </div>
+  );
+};
+
+
+/* One parameter's day: the median line inside its 5th–95th percentile band. */
+const ParameterDetail = ({ row, patientId, date, onClose }) => {
+  const { param, band, flags } = row;
+  const [points, setPoints] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const res = await apiFetch(`${config.apiUrl}/api/integrations/patient/`
+          + `${patientId}/vent/day/${date}/parameter/${param.parameter_key}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body = await res.json();
+        if (!cancelled) setPoints(body.points || []);
+      } catch {
+        if (!cancelled) setPoints([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [patientId, date, param.parameter_key]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !points?.length) return undefined;
+    const at = (k) => points.filter((p) => p[k] != null)
+      .map((p) => ({ x: new Date(p.ts).getTime(), y: p[k] }));
+    const chart = new Chart(canvas.getContext('2d'), {
+      type: 'line',
+      data: {
+        datasets: [
+          // The band is drawn as p5 then p95 filling back to it: Chart.js has
+          // no range series, and two lines with fill:'-1' is the shape that
+          // does not need one.
+          { label: '5th percentile', data: at('p5'), parsing: false,
+            borderColor: 'transparent', pointRadius: 0 },
+          { label: '95th percentile', data: at('p95'), parsing: false,
+            borderColor: 'transparent', pointRadius: 0,
+            backgroundColor: CHROME.band, fill: '-1' },
+          { label: 'Median', data: at('p50'), parsing: false,
+            borderColor: CHROME.line, borderWidth: 1.6, pointRadius: 0, tension: 0.15 },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: false,
+        interaction: { mode: 'index', intersect: false },
+        scales: {
+          x: {
+            type: 'time',
+            time: { displayFormats: { minute: 'h:mm', hour: 'ha' } },
+            grid: { color: CHROME.grid, drawTicks: false },
+            border: { display: false },
+            ticks: { color: CHROME.axis, maxRotation: 0, autoSkip: true, maxTicksLimit: 6,
+              font: { size: 10, family: "'IBM Plex Mono', monospace" } },
+          },
+          y: {
+            grid: { color: CHROME.grid, drawTicks: false },
+            border: { display: false },
+            ticks: { color: CHROME.axis, maxTicksLimit: 6,
+              font: { size: 10, family: "'IBM Plex Mono', monospace" } },
+          },
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: true },
+        },
+      },
+    });
+    return () => chart.destroy();
+  }, [points]);
 
   return (
-    <Dialog open onOpenChange={(o) => { if (!o) onClose(); }}>
-      <DialogContent
-        className="sm:max-w-[820px]"
-        style={{ borderLeft: `5px solid ${accent}` }}
-        aria-describedby={undefined}
-      >
-        <DialogHeader>
-          <DialogTitle>
-            {parameter.display_label}
-            {parameter.display_units && (
-              <span style={{ color: 'var(--muted-foreground)', fontWeight: 500, fontSize: 14, marginLeft: 8 }}>
-                {parameter.display_units}
-              </span>
-            )}
-          </DialogTitle>
-          <div style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>
-            {date} · #{parameter.parameter_key}
-          </div>
-        </DialogHeader>
-
-        {loading && (
-          <div style={{ padding: 30, color: 'var(--muted-foreground)', textAlign: 'center' }}>Loading…</div>
-        )}
-        {error && (
-          <Alert variant="destructive">{error}</Alert>
-        )}
-
-        {!loading && data && chartData.length === 0 && (
-          <div style={{
-            padding: 30, color: 'var(--muted-foreground)', textAlign: 'center',
-            background: 'var(--secondary)',
-            border: '1px dashed var(--border)',
-            borderRadius: 8, margin: '12px 0',
-          }}>No points to plot for this parameter on this day.</div>
-        )}
-
-        {!loading && chartData.length > 0 && (
-          <div style={{ marginTop: 12, padding: '4px 0' }}>
-            <ResponsiveContainer width="100%" height={320}>
-              <ComposedChart data={chartData} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke={chart.grid} />
-                <XAxis
-                  dataKey="ts"
-                  type="number"
-                  domain={['dataMin', 'dataMax']}
-                  tickFormatter={fmtTickTime}
-                  tick={{ fontSize: 10, fill: chart.axis }}
-                  minTickGap={40}
-                />
-                <YAxis tick={{ fontSize: 10, fill: chart.axis }} />
-                <Tooltip
-                  contentStyle={{ backgroundColor: chart.cutout, border: `1px solid ${chart.grid}`, borderRadius: 8, color: chart.foreground }}
-                  labelFormatter={fmtTooltipTime}
-                  formatter={(value, name) => {
-                    if (Array.isArray(value)) return [`${value[0]} – ${value[1]}`, '5–95% band'];
-                    return [value, name === 'p50' ? 'median' : name];
-                  }}
-                />
-                <Area type="monotone" dataKey="band" stroke="none"
-                      fill={accent} fillOpacity={0.18} connectNulls />
-                <Line type="monotone" dataKey="p50" stroke={accent}
-                      strokeWidth={2} dot={false} connectNulls />
-              </ComposedChart>
-            </ResponsiveContainer>
-            <div style={{ color: 'var(--muted-foreground)', fontSize: 11, marginTop: 6 }}>
-              Line = median ({parameter.stats_by_suffix?.['50']?.n || 0} samples).
-              Shaded band = 5th–95th percentile.
-            </div>
+    <EntityModal open onOpenChange={(v) => { if (!v) onClose(); }} wide
+                 title={`${param.display_label} · #${param.parameter_key}`}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+        {flags.length > 0 && (
+          <div className="vnt-flags" style={{ gridColumn: 'auto', margin: 0 }}>
+            {flags.map((f) => (
+              <span key={f.key} className={`vnt-flag ${f.tone}`} title={f.hint}>{f.label}</span>
+            ))}
           </div>
         )}
-      </DialogContent>
-    </Dialog>
+        {band && (
+          <p className="vnt-note" style={{ padding: 0 }}>
+            Device band, 5th to 95th percentile:{' '}
+            <b>{formatValue(band.lo, param.precision)} – {formatValue(band.hi, param.precision)}</b>
+            {param.display_units ? ` ${param.display_units}` : ''}
+            {band.inverted && ' — reported inverted by the device and shown low to high'}
+          </p>
+        )}
+        <div style={{ height: 300, position: 'relative' }}>
+          {loading && <p className="vnt-empty">Loading…</p>}
+          {!loading && !points?.length && (
+            <p className="vnt-empty">No points to plot for this parameter on this day.</p>
+          )}
+          {!loading && points?.length > 0 && (
+            <canvas ref={canvasRef} aria-label={`${param.display_label} over the day`} />
+          )}
+        </div>
+        <p className="vnt-note" style={{ padding: 0 }}>
+          Line is the device&rsquo;s median for each sampling window; the shaded band is
+          its 5th to 95th percentile over the same window.
+        </p>
+      </div>
+    </EntityModal>
   );
 };
-
-const MetricChip = ({ label, value, highlight }) => (
-  <div style={{
-    background: highlight ? 'color-mix(in srgb, var(--success) 10%, transparent)' : 'var(--secondary)',
-    border: `1px solid ${highlight ? 'color-mix(in srgb, var(--success) 30%, transparent)' : 'var(--border)'}`,
-    borderRadius: 6, padding: '4px 6px',
-    textAlign: 'center',
-  }}>
-    <div style={{
-      color: 'var(--muted-foreground)', fontSize: 9, fontWeight: 600,
-      textTransform: 'uppercase', letterSpacing: 0.5,
-    }}>{label}</div>
-    <div style={{
-      color: highlight ? 'var(--success)' : 'var(--foreground)',
-      fontSize: 13, fontWeight: 700,
-    }}>{value}</div>
-  </div>
-);
 
 export default AdminV2MonitoringVentilator;

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringVentilator.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringVentilator.jsx
@@ -621,6 +621,8 @@ const PinnedTrend = ({ rows, series }) => {
 const ParameterDetail = ({ row, patientId, date, onClose }) => {
   const { param, band, flags } = row;
   const sources = param.sources || [];
+  const used = sources.find((s) => s.used) ?? null;
+  const dropped = sources.filter((s) => !s.used);
   const [points, setPoints] = useState(null);
   const [loading, setLoading] = useState(true);
   const canvasRef = useRef(null);
@@ -729,12 +731,11 @@ const ParameterDetail = ({ row, patientId, date, onClose }) => {
         </p>
         {sources.length > 1 && (
           <p className="vnt-note" style={{ padding: 0 }}>
-            Blended from {sources.length} device messages
-            {' — '}
-            {sources.map((s) => `${s.message_type}/${s.message_id} (${s.n})`).join(', ')}.
-            These are not the same measurement: on this device the continuous
-            message keeps reporting through standby, so a plateau and a floor in
-            the same trace are two states, not a change in the patient.
+            Counted from {used ? `${used.message_type}/${used.message_id}` : 'the main message'}
+            {used ? ` (${used.n} samples)` : ''}. Also present but not counted:{' '}
+            {dropped.map((s) => `${s.message_type}/${s.message_id} (${s.n})`).join(', ')}.
+            The same key means different things on different messages, so mixing
+            them produced a plateau and a floor in one trace.
           </p>
         )}
       </div>

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringVentilator.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringVentilator.test.jsx
@@ -1,0 +1,341 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The ventilator day. What matters here: the pinned parameters lead, the rest
+// are one row each, provenance is flagged without claiming correctness, and
+// unpinning everything is respected rather than overwritten by the defaults.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent, within } from '@testing-library/react';
+
+const { charts } = vi.hoisted(() => ({ charts: [] }));
+
+vi.mock('chart.js/auto', () => {
+  class MockChart {
+    constructor(ctx, cfg) {
+      this.config = cfg;
+      this.options = cfg.options;
+      this.data = cfg.data;
+      this.destroyed = false;
+      charts.push(this);
+    }
+    update() {}
+    destroy() { this.destroyed = true; }
+  }
+  MockChart.register = () => {};
+  return { default: MockChart };
+});
+vi.mock('chartjs-adapter-date-fns', () => ({}));
+vi.mock('../../config', () => ({
+  default: { apiUrl: '' },
+  apiFetch: (...args) => fetch(...args),
+}));
+
+import AdminV2MonitoringVentilator from './AdminV2MonitoringVentilator';
+
+const DAY = '2026-05-31';
+
+const p = (key, label, over = {}) => ({
+  parameter_key: key,
+  display_label: label,
+  display_units: 'BPM',
+  display_type: 'NumericMonitor',
+  grouping: 'Ventilation',
+  scale_factor: 1.0,
+  precision: 1,
+  total_samples: 30,
+  stats_by_suffix: {
+    5: { n: 10, lo: 0, hi: 20, mean: 12 },
+    50: { n: 10, lo: 0, hi: 31, mean: 25 },
+    95: { n: 10, lo: 20, hi: 45, mean: 41 },
+  },
+  ...over,
+});
+
+const dayPayload = {
+  date: DAY,
+  summary: {
+    total_samples: 55834, parameter_count: 5,
+    first_at: `${DAY}T20:00:00Z`, last_at: `${DAY}T20:44:00Z`,
+  },
+  groups: [
+    {
+      name: 'Ventilation',
+      parameters: [
+        p('9408', 'BREATH RATE'),
+        p('9406', 'VTE', { display_units: 'mL' }),
+        // No median series — the device sent a single value.
+        p('9404', 'PEEP', {
+          display_units: 'cmH2O',
+          stats_by_suffix: { N: { n: 26, lo: 0, hi: 3029, mean: 370 } },
+        }),
+        // Not in the vendor dictionary: the API echoes the key as the label.
+        p('16011', '16011', {
+          display_type: null, display_units: null, scale_factor: null,
+          stats_by_suffix: { N: { n: 4, lo: 1, hi: 9, mean: 5 } },
+        }),
+      ],
+    },
+    {
+      name: 'Oxygen',
+      parameters: [p('16003', 'OA2 O2 Delivered', { display_units: '%', precision: 1 })],
+    },
+  ],
+};
+
+const daysPayload = {
+  has_integration: true,
+  days: [
+    { date: DAY, sample_count: 55834 },
+    { date: '2026-05-30', sample_count: 55741 },
+  ],
+};
+
+const seriesPayload = {
+  points: [
+    { ts: `${DAY}T20:00:00Z`, p50: 25, p5: 12, p95: 41, n: 3 },
+    { ts: `${DAY}T20:15:00Z`, p50: 26, p5: 13, p95: 42, n: 3 },
+  ],
+};
+
+let pinsPayload;
+let daysBody;
+let dayBody;
+const calls = [];
+let putBodies = [];
+
+beforeEach(() => {
+  charts.length = 0;
+  calls.length = 0;
+  putBodies = [];
+  daysBody = daysPayload;
+  dayBody = dayPayload;
+  pinsPayload = { patient_id: 5, vendor: 'vocsn', source: 'default',
+    parameter_keys: ['9408', '9406'] };
+
+  vi.stubGlobal('fetch', vi.fn(async (url, opts) => {
+    const u = String(url);
+    calls.push(u);
+    if (u.includes('/vent/pins')) {
+      if (opts?.method === 'PUT') {
+        const body = JSON.parse(opts.body);
+        putBodies.push(body);
+        pinsPayload = { ...pinsPayload, source: 'patient',
+          parameter_keys: body.parameter_keys };
+        return { ok: true, json: async () => pinsPayload };
+      }
+      return { ok: true, json: async () => pinsPayload };
+    }
+    if (u.includes('/vent/days')) return { ok: true, json: async () => daysBody };
+    if (u.includes('/parameter/')) return { ok: true, json: async () => seriesPayload };
+    if (u.includes('/vent/day/')) return { ok: true, json: async () => dayBody };
+    return { ok: true, json: async () => ({}) };
+  }));
+  HTMLCanvasElement.prototype.getContext = () => ({});
+});
+afterEach(() => { vi.unstubAllGlobals(); });
+
+const renderPage = async () => {
+  const utils = render(<AdminV2MonitoringVentilator patientId={5} />);
+  await act(async () => { await Promise.resolve(); });
+  await act(async () => { await Promise.resolve(); });
+  return utils;
+};
+
+const listRows = () => document.querySelectorAll('.vnt-row');
+// "Oxygen" names both a filter chip and a group header; scope by which.
+const groupHeader = (name) => [...document.querySelectorAll('.vnt-group-head')]
+  .find((b) => b.textContent.trim().startsWith(name));
+const groupChip = (name) => within(document.querySelector('.vnt-controls'))
+  .getByRole('button', { name: new RegExp(`^${name}\\b`) });
+
+describe('the day at a glance', () => {
+  it('summarises the day from the payload', async () => {
+    await renderPage();
+    const stats = document.querySelector('.vnt-stats');
+    expect(within(stats).getByText('55,834')).toBeInTheDocument();
+    expect(within(stats).getByText('5')).toBeInTheDocument();
+  });
+
+  it('counts the parameters wanting a look', async () => {
+    await renderPage();
+    // PEEP (raw only) and 16011 (unknown) — not VTE or breath rate.
+    const review = document.querySelectorAll('.vnt-stat')[3];
+    expect(within(review).getByText('2')).toBeInTheDocument();
+  });
+
+  it('offers the day pager over the days that have samples', async () => {
+    await renderPage();
+    expect(screen.getByText('1 of 2')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Newer day' })).toBeDisabled();
+  });
+});
+
+describe('one row per parameter', () => {
+  it('renders every parameter as a row, not a card', async () => {
+    await renderPage();
+    // Groups collapse past the first, so open Oxygen too.
+    expect(listRows().length).toBe(4);
+    await act(async () => { fireEvent.click(groupHeader('Oxygen')); });
+    expect(listRows().length).toBe(5);
+  });
+
+  it('leads each row with the median value and its own range', async () => {
+    await renderPage();
+    const row = listRows()[0];
+    expect(within(row).getByText('25.0')).toBeInTheDocument();
+    expect(within(row).getByText('0.0–31.0')).toBeInTheDocument();
+  });
+
+  it('says where a value came from without saying it is right', async () => {
+    await renderPage();
+    const rows = [...listRows()];
+    const peep = rows.find((r) => r.textContent.includes('PEEP'));
+    expect(within(peep).getByText('Raw only')).toBeInTheDocument();
+    // Nothing anywhere claims a parameter has been verified.
+    expect(screen.queryByText(/verified/i)).not.toBeInTheDocument();
+  });
+
+  it('flags an unknown parameter once rather than three times', async () => {
+    await renderPage();
+    const rows = [...listRows()];
+    const unknown = rows.find((r) => r.textContent.includes('16011'));
+    expect(within(unknown).getByText('Unknown parameter')).toBeInTheDocument();
+    expect(within(unknown).queryByText('No units')).not.toBeInTheDocument();
+    expect(within(unknown).queryByText('No scale')).not.toBeInTheDocument();
+  });
+
+  it('says the numbers are medians rather than the day’s extremes', async () => {
+    await renderPage();
+    expect(screen.getByText(/average of the device.s per-window medians/i))
+      .toBeInTheDocument();
+  });
+});
+
+describe('finding a parameter', () => {
+  it('searches label and vendor key', async () => {
+    await renderPage();
+    const search = screen.getByRole('searchbox', { name: 'Search parameters' });
+    await act(async () => { fireEvent.change(search, { target: { value: 'vte' } }); });
+    expect(listRows().length).toBe(1);
+    await act(async () => { fireEvent.change(search, { target: { value: '16003' } }); });
+    expect(listRows().length).toBe(1);
+  });
+
+  it('opens collapsed groups while filtering, so a hit is never hidden', async () => {
+    await renderPage();
+    const search = screen.getByRole('searchbox', { name: 'Search parameters' });
+    // 16003 lives in Oxygen, which is collapsed on load.
+    await act(async () => { fireEvent.change(search, { target: { value: 'O2' } }); });
+    expect(document.querySelector('.vnt-row').textContent).toContain('OA2 O2 Delivered');
+  });
+
+  it('filters to the parameters needing review', async () => {
+    await renderPage();
+    const reviewStat = document.querySelectorAll('.vnt-stat')[3];
+    await act(async () => { fireEvent.click(reviewStat); });
+    const text = [...listRows()].map((r) => r.textContent).join(' ');
+    expect(text).toContain('PEEP');
+    expect(text).toContain('16011');
+    expect(text).not.toContain('BREATH RATE');
+  });
+
+  it('filters by group', async () => {
+    await renderPage();
+    await act(async () => { fireEvent.click(groupChip('Oxygen')); });
+    expect(listRows().length).toBe(1);
+  });
+});
+
+describe('pinning', () => {
+  it('leads with the pinned parameters', async () => {
+    await renderPage();
+    const pinned = document.querySelector('.vnt-pins');
+    expect(within(pinned).getByText('BREATH RATE')).toBeInTheDocument();
+    expect(within(pinned).getByText('VTE')).toBeInTheDocument();
+    expect(within(pinned).queryByText('PEEP')).not.toBeInTheDocument();
+  });
+
+  it('charts only the pinned series, not every parameter', async () => {
+    await renderPage();
+    const series = calls.filter((c) => c.includes('/parameter/'));
+    expect(series).toHaveLength(2);
+    expect(series.every((c) => /\/parameter\/(9408|9406)$/.test(c))).toBe(true);
+  });
+
+  it('pinning a row sends the new set', async () => {
+    await renderPage();
+    const rows = [...listRows()];
+    const peep = rows.find((r) => r.textContent.includes('PEEP'));
+    await act(async () => {
+      fireEvent.click(within(peep).getByRole('button', { name: /^Pin PEEP/ }));
+    });
+    expect(putBodies.at(-1).parameter_keys).toEqual(['9408', '9406', '9404']);
+  });
+
+  it('unpinning the last one sends an empty set rather than nothing', async () => {
+    // The server treats an empty list as a choice; sending no request would
+    // leave the defaults in place and the star would spring back.
+    await renderPage();
+    for (const key of ['BREATH RATE', 'VTE']) {
+      const row = [...listRows()].find((r) => r.textContent.includes(key));
+      await act(async () => {
+        fireEvent.click(within(row).getByRole('button', { name: new RegExp(`^Unpin ${key}`) }));
+      });
+    }
+    expect(putBodies.at(-1).parameter_keys).toEqual([]);
+    expect(document.querySelector('.vnt-pins')).toBeNull();
+  });
+
+  it('shows a pin that produced nothing today as absent, not missing', async () => {
+    pinsPayload = { ...pinsPayload, source: 'patient', parameter_keys: ['9408', '99999'] };
+    await renderPage();
+    const pinned = document.querySelector('.vnt-pins');
+    expect(within(pinned).getByText('#99999')).toBeInTheDocument();
+    expect(within(pinned).getByText('no samples today')).toBeInTheDocument();
+  });
+});
+
+describe('the drill-down', () => {
+  it('charts the median inside its percentile band', async () => {
+    await renderPage();
+    const before = charts.length;
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /BREATH RATE #9408/ }));
+    });
+    await act(async () => { await Promise.resolve(); });
+    const chart = charts[charts.length - 1];
+    expect(charts.length).toBeGreaterThan(before);
+    const labels = chart.data.datasets.map((d) => d.label);
+    expect(labels).toEqual(['5th percentile', '95th percentile', 'Median']);
+    // The band is two lines filling to each other — Chart.js has no range type.
+    expect(chart.data.datasets[1].fill).toBe('-1');
+  });
+});
+
+describe('empty states', () => {
+  it('points at Integrations when the patient has no ventilator', async () => {
+    daysBody = { has_integration: false, days: [] };
+    await renderPage();
+    expect(screen.getByText(/no ventilator integration yet/i)).toBeInTheDocument();
+  });
+
+  it('points at the Logs panel when nothing has been parsed', async () => {
+    daysBody = { has_integration: true, days: [] };
+    await renderPage();
+    expect(screen.getByText(/No ventilator samples have been parsed/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/admin-v2/components/HAIdentitiesCard.test.jsx
+++ b/frontend/src/pages/admin-v2/components/HAIdentitiesCard.test.jsx
@@ -19,7 +19,7 @@
 // vs seen-only fallback; import dialog wiring. Services and config mocked;
 // Radix dialogs rendered inline (portal/focus-trap noise).
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
 // Radix (via ToggleList's Checkbox) probes element size; jsdom has no ResizeObserver.
 vi.stubGlobal('ResizeObserver', class { observe() {} unobserve() {} disconnect() {} });
@@ -95,6 +95,11 @@ const renderCard = async (props = {}) => {
     />
   );
   await waitFor(() => expect(getHaDirectory).toHaveBeenCalled());
+  // Waiting for the call is not waiting for the rows: the card renders from
+  // the resolved directory, so flush that resolution and the effects it runs
+  // before a test reaches for a button. Three tests below query synchronously
+  // straight after this, and under CI load one of them lost the race.
+  await act(async () => {});
 };
 
 describe('HAIdentitiesCard directory mode', () => {

--- a/frontend/src/pages/admin-v2/monitoring-ventilator.css
+++ b/frontend/src/pages/admin-v2/monitoring-ventilator.css
@@ -1,0 +1,524 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Ventilator day — vc-native, dark by design in both app themes (the stance
+ * monitoring-timeline.css and symptom-log.css take). Tokens only, no raw hex.
+ *
+ * The page exists to make ~44 parameters readable, so the list row is the
+ * unit of design: one line each, aligned columns, and the group's colour in a
+ * dot rather than a left rail. */
+@import '../../styles/vc-tokens.css';
+
+.vnt {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-variant-numeric: tabular-nums;
+}
+.vnt *,
+.vnt *::before,
+.vnt *::after {
+  /* Outside the .tw preflight scope the UA default is content-box, and
+     width:100% controls would overflow their cards. */
+  box-sizing: border-box;
+}
+
+.vnt-label {
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* ---------- day bar ---------- */
+.vnt-daybar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.vnt-navbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  height: 36px;
+  min-width: 36px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.vnt-navbtn:hover:not(:disabled) {
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-primary);
+}
+.vnt-navbtn:disabled { opacity: 0.4; cursor: default; }
+.vnt-datepill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 36px;
+  padding: 0 0.75rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  font-family: var(--vc-font-mono);
+  font-size: 0.78rem;
+  color: var(--vc-text-primary);
+}
+/* The native picker covers the pill so the whole pill is the control. Only
+   days with samples exist, so it is a jump-to rather than a free calendar. */
+.vnt-datepill select {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  color-scheme: dark;
+}
+.vnt-datepill svg { color: var(--vc-text-secondary); flex-shrink: 0; }
+.vnt-count {
+  margin-left: auto;
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: var(--vc-text-tertiary);
+  white-space: nowrap;
+}
+
+/* ---------- day strip ---------- */
+.vnt-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+.vnt-stat {
+  padding: 0.7rem 0.9rem;
+  border-right: 1px solid var(--vc-line-hairline);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  text-align: left;
+}
+.vnt-stat:last-child { border-right: none; }
+.vnt-stat-head {
+  font-family: var(--vc-font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.vnt-stat-value {
+  font-family: var(--vc-font-mono);
+  font-size: 1.35rem;
+  font-weight: 600;
+  line-height: 1.1;
+}
+.vnt-stat-note { font-size: 0.72rem; color: var(--vc-text-tertiary); }
+button.vnt-stat {
+  border-top: none;
+  border-bottom: none;
+  border-left: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+button.vnt-stat:hover { background: var(--vc-bg-raised); }
+.vnt-stat.flagged .vnt-stat-value { color: var(--vc-state-due); }
+.vnt-stat.clean .vnt-stat-value { color: var(--vc-state-complete); }
+
+@media (max-width: 620px) {
+  .vnt-stat { border-right: none; border-bottom: 1px solid var(--vc-line-hairline); }
+  .vnt-stat:last-child { border-bottom: none; }
+}
+
+/* ---------- cards ---------- */
+.vnt-card {
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+.vnt-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.vnt-card-head h3 {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* ---------- pinned ---------- */
+.vnt-pins {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+.vnt-pin {
+  padding: 0.7rem 0.9rem;
+  border-right: 1px solid var(--vc-line-hairline);
+  border-bottom: 1px solid var(--vc-line-hairline);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+.vnt-pin-name {
+  font-family: var(--vc-font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.vnt-pin-value {
+  font-family: var(--vc-font-mono);
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.1;
+  color: var(--vc-data-live);
+}
+.vnt-pin-value small {
+  font-size: 0.62rem;
+  font-weight: 400;
+  color: var(--vc-text-secondary);
+  margin-left: 0.25rem;
+}
+.vnt-pin-sub {
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  color: var(--vc-text-tertiary);
+}
+.vnt-pin.review .vnt-pin-value { color: var(--vc-state-due); }
+.vnt-pin-missing .vnt-pin-value { color: var(--vc-text-tertiary); }
+
+.vnt-plot { padding: 0.6rem 0.5rem 0.2rem; height: 220px; position: relative; }
+
+/* ---------- controls ---------- */
+.vnt-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.vnt-search {
+  flex: 1 1 200px;
+  min-width: 160px;
+  height: 38px;
+  padding: 0 0.75rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 9px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-size: 0.88rem;
+}
+.vnt-search::placeholder { color: var(--vc-text-tertiary); }
+.vnt-search:focus {
+  outline: none;
+  border-color: var(--vc-data-live);
+}
+.vnt-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  height: 34px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.vnt-chip:hover { color: var(--vc-text-primary); }
+.vnt-chip[aria-pressed='true'] {
+  border-color: var(--vc-data-live);
+  background: color-mix(in srgb, var(--vc-data-live) 16%, transparent);
+  color: var(--vc-data-live);
+}
+.vnt-chip.warn[aria-pressed='true'] {
+  border-color: var(--vc-state-due);
+  background: color-mix(in srgb, var(--vc-state-due) 16%, transparent);
+  color: var(--vc-state-due);
+}
+.vnt-chip-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 4px;
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-primary);
+  font-size: 0.66rem;
+}
+.vnt-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--grp, var(--vc-text-tertiary));
+  flex-shrink: 0;
+}
+
+/* ---------- group + rows ---------- */
+.vnt-group + .vnt-group { margin-top: 0.6rem; }
+.vnt-group-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.55rem 0.9rem;
+  border: none;
+  background: var(--vc-bg-raised);
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-align: left;
+}
+.vnt-group-head:hover { color: var(--vc-data-live); }
+.vnt-group-meta {
+  margin-left: auto;
+  color: var(--vc-text-tertiary);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+/* One parameter, one line. The grid is fixed so every row's numbers land in
+   the same column and the list can be scanned down rather than read across. */
+.vnt-row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) 92px 84px 52px 20px;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.45rem 0.9rem;
+  border: none;
+  border-top: 1px solid var(--vc-line-hairline);
+  background: transparent;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-size: 0.85rem;
+  text-align: left;
+  cursor: pointer;
+}
+.vnt-row:hover { background: var(--vc-bg-raised); }
+button.vnt-row-name {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  align-items: flex-start;
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.vnt-row-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+.vnt-row-key {
+  font-family: var(--vc-font-mono);
+  font-size: 0.66rem;
+  color: var(--vc-text-tertiary);
+}
+.vnt-row-value {
+  font-family: var(--vc-font-mono);
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: right;
+}
+.vnt-row-value small {
+  font-size: 0.62rem;
+  font-weight: 400;
+  color: var(--vc-text-secondary);
+  margin-left: 0.2rem;
+}
+.vnt-row-range {
+  font-family: var(--vc-font-mono);
+  font-size: 0.7rem;
+  color: var(--vc-text-tertiary);
+  text-align: right;
+  white-space: nowrap;
+}
+.vnt-row-n {
+  font-family: var(--vc-font-mono);
+  font-size: 0.7rem;
+  color: var(--vc-text-tertiary);
+  text-align: right;
+}
+.vnt-row-chev { color: var(--vc-text-tertiary); justify-self: end; }
+.vnt-row.review .vnt-row-value { color: var(--vc-state-due); }
+
+/* Where the headline sits inside its own range. Not a sparkline — the day
+   payload carries no series — but it answers "is this pinned at an extreme?"
+   which is the question a 20px sparkline gets asked. */
+.vnt-pos {
+  grid-column: 3 / 5;
+  position: relative;
+  height: 3px;
+  margin-top: 3px;
+  border-radius: 2px;
+  background: var(--vc-line-hairline);
+}
+.vnt-pos-mark {
+  position: absolute;
+  top: -2px;
+  width: 3px;
+  height: 7px;
+  border-radius: 1px;
+  background: var(--vc-data-live);
+  transform: translateX(-1.5px);
+}
+.vnt-row.review .vnt-pos-mark { background: var(--vc-state-due); }
+
+.vnt-flags {
+  grid-column: 2 / 7;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.15rem;
+}
+.vnt-flag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  border: 1px solid currentColor;
+  font-family: var(--vc-font-mono);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.vnt-flag.alert { color: var(--vc-state-alert); }
+.vnt-flag.due { color: var(--vc-state-due); }
+.vnt-flag.idle { color: var(--vc-text-tertiary); }
+
+@media (max-width: 560px) {
+  .vnt-row { grid-template-columns: 28px minmax(0, 1fr) 84px 20px; }
+  .vnt-row-range, .vnt-row-n { display: none; }
+  .vnt-pos { grid-column: 3 / 4; }
+  .vnt-flags { grid-column: 2 / 5; }
+}
+
+/* ---------- pin toggle ---------- */
+.vnt-pinbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--vc-text-tertiary);
+  cursor: pointer;
+}
+.vnt-pinbtn:hover { background: var(--vc-bg-surface); color: var(--vc-text-secondary); }
+.vnt-pinbtn[aria-pressed='true'] { color: var(--vc-data-live); }
+
+/* ---------- states ---------- */
+.vnt-empty {
+  padding: 2.5rem 1rem;
+  text-align: center;
+  color: var(--vc-text-secondary);
+  font-size: 0.9rem;
+}
+.vnt-note {
+  margin: 0;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.74rem;
+  color: var(--vc-text-tertiary);
+}
+.vnt-error {
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--vc-state-alert);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
+  color: var(--vc-text-primary);
+  font-size: 0.88rem;
+}
+.vnt-setup {
+  padding: 2rem 1.25rem;
+  border: 1px dashed var(--vc-line-strong);
+  border-radius: 10px;
+  text-align: center;
+  color: var(--vc-text-secondary);
+  font-size: 0.9rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/src/pages/admin-v2/ventParameters.js
+++ b/frontend/src/pages/admin-v2/ventParameters.js
@@ -1,0 +1,174 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Reading one ventilator parameter's day.
+//
+// The device reports each parameter as up to four series per day — the 5th,
+// 50th and 95th percentile of each sampling window (suffixes '5' / '50' /
+// '95') and, for parameters it does not percentile, a single value ('N', or
+// no suffix at all). The API returns count/min/max/mean of each of those
+// series over the day. Everything below is about turning that into something
+// a person can read without being misled.
+//
+// What we can and cannot say about trust:
+//   We can flag *provenance* — no scale in the dictionary, no units, a
+//   parameter we have never seen, no median series, a percentile band that
+//   comes back inverted. We cannot flag *correctness*. PEEP #9404 carries a
+//   scale_factor of 1.0 and still reads 370 cmH2O; 1.0 is also the parser's
+//   fallback for unknown, so a "verified" badge would be green on a number
+//   that is plainly wrong. There is no verification step in this pipeline and
+//   the UI must not imply one.
+
+/* Provenance problems, worst first. `tone` drives the chip colour; nothing
+ * here asserts a value is right, only that we know where it came from. */
+export const FLAGS = {
+  unknown: {
+    label: 'Unknown parameter', tone: 'alert',
+    hint: 'Not in the vendor dictionary — no label, units or scale.',
+  },
+  rawOnly: {
+    label: 'Raw only', tone: 'due',
+    hint: 'No median series for this day; showing the device’s single value.',
+  },
+  noScale: {
+    label: 'No scale', tone: 'due',
+    hint: 'The dictionary has no scale factor, so the value is in vendor units.',
+  },
+  bandInverted: {
+    label: 'Band inverted', tone: 'due',
+    hint: 'The 5th percentile came back above the 95th; shown low–high.',
+  },
+  noUnits: {
+    label: 'No units', tone: 'idle',
+    hint: 'The dictionary does not say what this value is measured in.',
+  },
+};
+
+const FLAG_ORDER = ['unknown', 'rawOnly', 'noScale', 'bandInverted', 'noUnits'];
+
+const stat = (param, suffix) => param?.stats_by_suffix?.[suffix] ?? null;
+
+/** The value the row leads with, and where it came from.
+ *
+ * Prefers the median series. `mean` is the average of the day's medians, not
+ * a median of the day — the labelling has to say so, which is why `basis`
+ * comes back with it rather than being assumed by the caller.
+ */
+export function headlineOf(param) {
+  const median = stat(param, '50');
+  const raw = stat(param, 'N') ?? stat(param, '');
+  const source = median ? median : raw;
+  if (!source) return null;
+  return {
+    value: source.mean,
+    lo: source.lo,
+    hi: source.hi,
+    n: source.n,
+    basis: median ? 'median' : 'raw',
+  };
+}
+
+/** The 5th–95th percentile band, ordered low to high.
+ *
+ * Three of 44 parameters on a real day report p5 above p95, which printed as
+ * "660.7 – 40.4" before this sorted them. Sorting keeps the range readable;
+ * `inverted` keeps the fact that it happened.
+ */
+export function bandOf(param) {
+  const p5 = stat(param, '5');
+  const p95 = stat(param, '95');
+  const lo = p5?.mean ?? p5?.lo ?? null;
+  const hi = p95?.mean ?? p95?.hi ?? null;
+  if (lo == null || hi == null) return null;
+  const inverted = lo > hi;
+  return { lo: inverted ? hi : lo, hi: inverted ? lo : hi, inverted };
+}
+
+/** Is this parameter one we have never seen in the vendor dictionary?
+ *
+ * The API falls back to the bare key for the label when the join misses, so
+ * a label equal to its own key is the tell — paired with a missing type, so a
+ * dictionary entry that genuinely labels itself "9408" is not caught. */
+export function isUnknownParameter(param) {
+  if (!param) return false;
+  return !param.display_type
+    && String(param.display_label ?? '') === String(param.parameter_key ?? '');
+}
+
+/** Every provenance flag that applies, worst first. */
+export function flagsFor(param) {
+  if (!param) return [];
+  const band = bandOf(param);
+  const hit = {
+    unknown: isUnknownParameter(param),
+    rawOnly: !stat(param, '50'),
+    noScale: param.scale_factor == null,
+    bandInverted: Boolean(band?.inverted),
+    noUnits: !param.display_units,
+  };
+  // An unknown parameter is missing its units and scale by definition;
+  // listing all three says the same thing three times.
+  if (hit.unknown) { hit.noScale = false; hit.noUnits = false; }
+  return FLAG_ORDER.filter((key) => hit[key]).map((key) => ({ key, ...FLAGS[key] }));
+}
+
+/** Does this parameter want a human to look at it before it is trusted? */
+export function needsReview(param) {
+  return flagsFor(param).some((f) => f.tone === 'alert' || f.tone === 'due');
+}
+
+/** Where the headline sits inside its own range, 0–1, or null when it cannot
+ * be placed. Drives the little position strip on each row: a value pinned at
+ * one end of its day is worth seeing without opening a chart. */
+export function bandPosition(value, lo, hi) {
+  if (value == null || lo == null || hi == null) return null;
+  if (!(hi > lo)) return null;
+  const frac = (value - lo) / (hi - lo);
+  return Math.min(1, Math.max(0, frac));
+}
+
+/** Vendor precision, clamped. Values in the thousands never want decimals —
+ * a raw counter reading 3029.0 is noise dressed as precision. */
+export function formatValue(value, precision) {
+  if (value == null || Number.isNaN(value)) return null;
+  const abs = Math.abs(value);
+  const digits = abs >= 1000 ? 0 : Math.min(Math.max(precision ?? 1, 0), 4);
+  return value.toFixed(digits);
+}
+
+/** Flatten the API's groups into rows, keeping group order and membership. */
+export function rowsFrom(dayData) {
+  return (dayData?.groups || []).flatMap((group) =>
+    (group.parameters || []).map((param) => ({
+      group: group.name,
+      param,
+      headline: headlineOf(param),
+      band: bandOf(param),
+      flags: flagsFor(param),
+      review: needsReview(param),
+    })),
+  );
+}
+
+/** Rows matching a free-text query over label and vendor key. */
+export function matchesQuery(row, query) {
+  const q = (query || '').trim().toLowerCase();
+  if (!q) return true;
+  const p = row.param;
+  return String(p.display_label ?? '').toLowerCase().includes(q)
+    || String(p.parameter_key ?? '').toLowerCase().includes(q);
+}

--- a/frontend/src/pages/admin-v2/ventParameters.js
+++ b/frontend/src/pages/admin-v2/ventParameters.js
@@ -26,8 +26,8 @@
 //
 // What we can and cannot say about trust:
 //   We can flag *provenance* — no scale in the dictionary, no units, a
-//   parameter we have never seen, no median series, a percentile band that
-//   comes back inverted. We cannot flag *correctness*. PEEP #9404 carries a
+//   parameter we have never seen, no median series, or samples blended from
+//   more than one device message. We cannot flag *correctness*. PEEP #9404 carries a
 //   scale_factor of 1.0 and still reads 370 cmH2O; 1.0 is also the parser's
 //   fallback for unknown, so a "verified" badge would be green on a number
 //   that is plainly wrong. There is no verification step in this pipeline and
@@ -48,9 +48,16 @@ export const FLAGS = {
     label: 'No scale', tone: 'due',
     hint: 'The dictionary has no scale factor, so the value is in vendor units.',
   },
+  mixedSources: {
+    label: 'Mixed sources', tone: 'alert',
+    hint: 'Samples come from more than one device message — on this device that '
+      + 'means standby telemetry blended with active ventilation, so the value '
+      + 'is an average of two different things.',
+  },
   bandInverted: {
     label: 'Band inverted', tone: 'due',
-    hint: 'The 5th percentile came back above the 95th; shown low–high.',
+    hint: 'The 5th percentile averaged above the 95th over the day. Usually a '
+      + 'symptom of blended sources rather than anything the device did wrong.',
   },
   noUnits: {
     label: 'No units', tone: 'idle',
@@ -58,7 +65,8 @@ export const FLAGS = {
   },
 };
 
-const FLAG_ORDER = ['unknown', 'rawOnly', 'noScale', 'bandInverted', 'noUnits'];
+const FLAG_ORDER = ['unknown', 'mixedSources', 'rawOnly', 'noScale',
+  'bandInverted', 'noUnits'];
 
 const stat = (param, suffix) => param?.stats_by_suffix?.[suffix] ?? null;
 
@@ -84,9 +92,10 @@ export function headlineOf(param) {
 
 /** The 5th–95th percentile band, ordered low to high.
  *
- * Three of 44 parameters on a real day report p5 above p95, which printed as
- * "660.7 – 40.4" before this sorted them. Sorting keeps the range readable;
- * `inverted` keeps the fact that it happened.
+ * Three of 44 parameters on a real day average p5 above p95, which printed as
+ * "660.7 – 40.4" before this sorted them. That is almost always the blend of
+ * two device messages showing through rather than anything the device did, so
+ * sorting keeps the range readable and `inverted` keeps the symptom.
  */
 export function bandOf(param) {
   const p5 = stat(param, '5');
@@ -109,15 +118,24 @@ export function isUnknownParameter(param) {
     && String(param.display_label ?? '') === String(param.parameter_key ?? '');
 }
 
+/** How many distinct device messages fed this parameter's day. */
+export function sourceCount(param) {
+  return (param?.sources || []).length;
+}
+
 /** Every provenance flag that applies, worst first. */
 export function flagsFor(param) {
   if (!param) return [];
   const band = bandOf(param);
+  const mixed = sourceCount(param) > 1;
   const hit = {
     unknown: isUnknownParameter(param),
+    mixedSources: mixed,
     rawOnly: !stat(param, '50'),
     noScale: param.scale_factor == null,
-    bandInverted: Boolean(band?.inverted),
+    // An inverted band is nearly always the blend showing through. Saying both
+    // implies two problems where there is one, so the cause wins.
+    bandInverted: Boolean(band?.inverted) && !mixed,
     noUnits: !param.display_units,
   };
   // An unknown parameter is missing its units and scale by definition;

--- a/frontend/src/pages/admin-v2/ventParameters.js
+++ b/frontend/src/pages/admin-v2/ventParameters.js
@@ -26,7 +26,7 @@
 //
 // What we can and cannot say about trust:
 //   We can flag *provenance* — no scale in the dictionary, no units, a
-//   parameter we have never seen, no median series, or samples blended from
+//   parameter we have never seen, no median series, or samples that arrived on
 //   more than one device message. We cannot flag *correctness*. PEEP #9404 carries a
 //   scale_factor of 1.0 and still reads 370 cmH2O; 1.0 is also the parser's
 //   fallback for unknown, so a "verified" badge would be green on a number
@@ -49,10 +49,11 @@ export const FLAGS = {
     hint: 'The dictionary has no scale factor, so the value is in vendor units.',
   },
   mixedSources: {
-    label: 'Mixed sources', tone: 'alert',
-    hint: 'Samples come from more than one device message — on this device that '
-      + 'means standby telemetry blended with active ventilation, so the value '
-      + 'is an average of two different things.',
+    label: 'Other sources dropped', tone: 'idle',
+    hint: 'This parameter arrived on more than one device message. Only the one '
+      + 'carrying it most often is counted here — the others are a different '
+      + 'measurement under the same key, and averaging them together is what '
+      + 'used to put the 5th percentile above the 95th.',
   },
   bandInverted: {
     label: 'Band inverted', tone: 'due',
@@ -118,9 +119,20 @@ export function isUnknownParameter(param) {
     && String(param.display_label ?? '') === String(param.parameter_key ?? '');
 }
 
-/** How many distinct device messages fed this parameter's day. */
+/** How many distinct device messages carried this parameter over the day.
+ * Only the first is counted in the statistics; see the API's `used` flag. */
 export function sourceCount(param) {
   return (param?.sources || []).length;
+}
+
+/** The message the day's numbers were actually computed from. */
+export function usedSource(param) {
+  return (param?.sources || []).find((s) => s.used) ?? null;
+}
+
+/** Messages present but not counted. */
+export function droppedSources(param) {
+  return (param?.sources || []).filter((s) => !s.used);
 }
 
 /** Every provenance flag that applies, worst first. */
@@ -133,9 +145,9 @@ export function flagsFor(param) {
     mixedSources: mixed,
     rawOnly: !stat(param, '50'),
     noScale: param.scale_factor == null,
-    // An inverted band is nearly always the blend showing through. Saying both
-    // implies two problems where there is one, so the cause wins.
-    bandInverted: Boolean(band?.inverted) && !mixed,
+    // Now that only one message is counted, an inversion that survives is
+    // worth reporting on its own rather than being explained away.
+    bandInverted: Boolean(band?.inverted),
     noUnits: !param.display_units,
   };
   // An unknown parameter is missing its units and scale by definition;

--- a/frontend/src/pages/admin-v2/ventParameters.test.js
+++ b/frontend/src/pages/admin-v2/ventParameters.test.js
@@ -1,0 +1,210 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Reading a ventilator parameter. The fixtures are shaped after real rows
+// from 2026-05-31 — including the three parameters whose percentile band
+// comes back inverted, which is what printed "660.7 – 40.4" on the old page.
+import { describe, it, expect } from 'vitest';
+import {
+  headlineOf, bandOf, flagsFor, needsReview, bandPosition, formatValue,
+  isUnknownParameter, rowsFrom, matchesQuery,
+} from './ventParameters';
+
+const param = (over = {}) => ({
+  parameter_key: '9408',
+  display_label: 'BREATH RATE',
+  display_units: 'BPM',
+  display_type: 'NumericMonitor',
+  grouping: 'Ventilation',
+  scale_factor: 1.0,
+  precision: 1,
+  total_samples: 40,
+  stats_by_suffix: {
+    5: { n: 10, lo: 0, hi: 20, mean: 12 },
+    50: { n: 10, lo: 0, hi: 31, mean: 25 },
+    95: { n: 10, lo: 20, hi: 45, mean: 41 },
+  },
+  ...over,
+});
+
+describe('headlineOf', () => {
+  it('leads with the median series', () => {
+    expect(headlineOf(param())).toMatchObject({
+      value: 25, lo: 0, hi: 31, n: 10, basis: 'median',
+    });
+  });
+
+  it('falls back to the single value when the device sends no median', () => {
+    const p = param({ stats_by_suffix: { N: { n: 26, lo: 0, hi: 3029, mean: 370 } } });
+    expect(headlineOf(p)).toMatchObject({ value: 370, basis: 'raw' });
+  });
+
+  it('treats a bare suffix as the single value too', () => {
+    const p = param({ stats_by_suffix: { '': { n: 4, lo: 1, hi: 2, mean: 1.5 } } });
+    expect(headlineOf(p).basis).toBe('raw');
+  });
+
+  it('returns nothing rather than a zero for a parameter with no stats', () => {
+    expect(headlineOf(param({ stats_by_suffix: {} }))).toBeNull();
+  });
+});
+
+describe('bandOf', () => {
+  it('reports the 5th to 95th percentile band', () => {
+    expect(bandOf(param())).toEqual({ lo: 12, hi: 41, inverted: false });
+  });
+
+  it('orders an inverted band low to high and says that it was inverted', () => {
+    // Real condition on 3 of 44 parameters; the old page printed 660.7 – 40.4.
+    const p = param({
+      stats_by_suffix: {
+        5: { n: 9, lo: 0, hi: 900, mean: 660.7 },
+        50: { n: 9, lo: 0, hi: 100, mean: 94.9 },
+        95: { n: 9, lo: 0, hi: 80, mean: 40.4 },
+      },
+    });
+    expect(bandOf(p)).toEqual({ lo: 40.4, hi: 660.7, inverted: true });
+  });
+
+  it('has no band when a percentile series is missing', () => {
+    expect(bandOf(param({ stats_by_suffix: { 50: { n: 1, lo: 1, hi: 1, mean: 1 } } })))
+      .toBeNull();
+  });
+});
+
+describe('flagsFor', () => {
+  it('flags nothing on a well-described parameter', () => {
+    expect(flagsFor(param())).toEqual([]);
+    expect(needsReview(param())).toBe(false);
+  });
+
+  it('flags a parameter with no median series', () => {
+    const p = param({ stats_by_suffix: { N: { n: 26, lo: 0, hi: 3029, mean: 370 } } });
+    expect(flagsFor(p).map((f) => f.key)).toContain('rawOnly');
+    expect(needsReview(p)).toBe(true);
+  });
+
+  it('flags a missing scale factor', () => {
+    expect(flagsFor(param({ scale_factor: null })).map((f) => f.key)).toContain('noScale');
+  });
+
+  it('does not flag a scale of 1.0 as missing', () => {
+    // 1.0 is both a real scale and the parser's fallback for unknown. We
+    // cannot tell them apart, so we say nothing rather than guess either way.
+    expect(flagsFor(param({ scale_factor: 1.0 })).map((f) => f.key)).not.toContain('noScale');
+  });
+
+  it('flags missing units without calling it a review item', () => {
+    const flags = flagsFor(param({ display_units: null }));
+    expect(flags.map((f) => f.key)).toEqual(['noUnits']);
+    expect(needsReview(param({ display_units: null }))).toBe(false);
+  });
+
+  it('flags an unknown parameter once, not three times', () => {
+    // The API falls back to the bare key for the label, and such a row has no
+    // units or scale either — saying so three times is noise.
+    const unknown = param({
+      parameter_key: '16011', display_label: '16011', display_type: null,
+      display_units: null, scale_factor: null,
+    });
+    expect(isUnknownParameter(unknown)).toBe(true);
+    expect(flagsFor(unknown).map((f) => f.key)).toEqual(['unknown']);
+    expect(needsReview(unknown)).toBe(true);
+  });
+
+  it('does not mistake a dictionary entry that labels itself by its key', () => {
+    const odd = param({ display_label: '9408', display_type: 'NumericMonitor' });
+    expect(isUnknownParameter(odd)).toBe(false);
+  });
+
+  it('orders flags worst first', () => {
+    const p = param({
+      display_units: null, scale_factor: null,
+      stats_by_suffix: { N: { n: 3, lo: 0, hi: 9, mean: 4 } },
+    });
+    expect(flagsFor(p).map((f) => f.key)).toEqual(['rawOnly', 'noScale', 'noUnits']);
+  });
+});
+
+describe('bandPosition', () => {
+  it('places a value inside its range', () => {
+    expect(bandPosition(25, 0, 50)).toBe(0.5);
+    expect(bandPosition(0, 0, 50)).toBe(0);
+    expect(bandPosition(50, 0, 50)).toBe(1);
+  });
+
+  it('clamps a value that sits outside its own range', () => {
+    expect(bandPosition(60, 0, 50)).toBe(1);
+    expect(bandPosition(-5, 0, 50)).toBe(0);
+  });
+
+  it('refuses to place a value with nothing to place it against', () => {
+    expect(bandPosition(25, null, 50)).toBeNull();
+    expect(bandPosition(null, 0, 50)).toBeNull();
+    // A flat range would divide by zero and render as a bar at the far left.
+    expect(bandPosition(5, 5, 5)).toBeNull();
+  });
+});
+
+describe('formatValue', () => {
+  it('honours the vendor precision', () => {
+    expect(formatValue(20.74, 1)).toBe('20.7');
+    expect(formatValue(11.4912, 2)).toBe('11.49');
+  });
+
+  it('drops decimals on values in the thousands', () => {
+    expect(formatValue(3029.4, 2)).toBe('3029');
+  });
+
+  it('caps runaway precision', () => {
+    expect(formatValue(1.23456789, 9)).toBe('1.2346');
+  });
+
+  it('returns nothing for a missing value', () => {
+    expect(formatValue(null, 1)).toBeNull();
+    expect(formatValue(undefined, 1)).toBeNull();
+  });
+});
+
+describe('rowsFrom', () => {
+  const day = {
+    groups: [
+      { name: 'Ventilation', parameters: [param(), param({ parameter_key: '9406', display_label: 'VTE' })] },
+      { name: 'Oxygen', parameters: [param({ parameter_key: '16003', display_label: 'OA2 O2 Delivered' })] },
+    ],
+  };
+
+  it('flattens the groups while keeping membership and order', () => {
+    const rows = rowsFrom(day);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.group)).toEqual(['Ventilation', 'Ventilation', 'Oxygen']);
+    expect(rows[0].headline.value).toBe(25);
+  });
+
+  it('survives an empty day', () => {
+    expect(rowsFrom(null)).toEqual([]);
+    expect(rowsFrom({ groups: [] })).toEqual([]);
+  });
+
+  it('searches label and vendor key', () => {
+    const rows = rowsFrom(day);
+    expect(rows.filter((r) => matchesQuery(r, 'vte'))).toHaveLength(1);
+    expect(rows.filter((r) => matchesQuery(r, '16003'))).toHaveLength(1);
+    expect(rows.filter((r) => matchesQuery(r, ''))).toHaveLength(3);
+    expect(rows.filter((r) => matchesQuery(r, 'nope'))).toHaveLength(0);
+  });
+});

--- a/frontend/src/pages/admin-v2/ventParameters.test.js
+++ b/frontend/src/pages/admin-v2/ventParameters.test.js
@@ -21,7 +21,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   headlineOf, bandOf, flagsFor, needsReview, bandPosition, formatValue,
-  isUnknownParameter, rowsFrom, matchesQuery, sourceCount,
+  isUnknownParameter, rowsFrom, matchesQuery, sourceCount, usedSource,
+  droppedSources,
 } from './ventParameters';
 
 const param = (over = {}) => ({
@@ -216,46 +217,51 @@ describe('blended device messages', () => {
   // is what produced the square-wave trace and the apparent inversion.
   const blended = (over = {}) => param({
     sources: [
-      { message_type: 'M', message_id: 7201, n: 288 },
-      { message_type: 'M', message_id: 7204, n: 25 },
+      { message_type: 'M', message_id: 7201, n: 288, used: true },
+      { message_type: 'M', message_id: 7204, n: 25, used: false },
     ],
     ...over,
   });
 
   it('counts the messages behind a parameter', () => {
     expect(sourceCount(blended())).toBe(2);
-    expect(sourceCount(param({ sources: [{ message_type: 'M', message_id: 7201, n: 288 }] })))
-      .toBe(1);
+    expect(sourceCount(param({
+      sources: [{ message_type: 'M', message_id: 7201, n: 288, used: true }],
+    }))).toBe(1);
     // Absent entirely on an older payload — treated as nothing known, not as a blend.
     expect(sourceCount(param())).toBe(0);
   });
 
-  it('flags a blend as the worst thing about the parameter', () => {
-    const flags = flagsFor(blended());
-    expect(flags[0].key).toBe('mixedSources');
-    expect(flags[0].tone).toBe('alert');
-    expect(needsReview(blended())).toBe(true);
+  it('names which message the numbers came from and which were dropped', () => {
+    expect(usedSource(blended())).toMatchObject({ message_id: 7201, n: 288 });
+    expect(droppedSources(blended()).map((s) => s.message_id)).toEqual([7204]);
   });
 
-  it('does not also cry inversion when the blend explains it', () => {
-    // Saying both implies two problems where there is one.
-    const invertedAndBlended = blended({
+  it('reports the drop without calling it a review item', () => {
+    // The statistics are now from one coherent source, so this is a note about
+    // coverage rather than a reason to distrust the number.
+    const flags = flagsFor(blended());
+    expect(flags.map((f) => f.key)).toEqual(['mixedSources']);
+    expect(flags[0].tone).toBe('idle');
+    expect(needsReview(blended())).toBe(false);
+  });
+
+  it('still reports an inversion that survives the filtering', () => {
+    const stillInverted = blended({
       stats_by_suffix: {
         5: { n: 404, lo: -10, hi: 5000, mean: 1336 },
         50: { n: 182, lo: -5, hi: 1622, mean: 221 },
         95: { n: 186, lo: -4, hi: 406, mean: 61 },
       },
     });
-    const keys = flagsFor(invertedAndBlended).map((f) => f.key);
-    expect(keys).toContain('mixedSources');
-    expect(keys).not.toContain('bandInverted');
-    // The range is still ordered for display.
-    expect(bandOf(invertedAndBlended)).toMatchObject({ lo: 61, hi: 1336, inverted: true });
+    const keys = flagsFor(stillInverted).map((f) => f.key);
+    expect(keys).toContain('bandInverted');
+    expect(bandOf(stillInverted)).toMatchObject({ lo: 61, hi: 1336, inverted: true });
   });
 
   it('still reports an inversion that has no blend behind it', () => {
     const p = param({
-      sources: [{ message_type: 'M', message_id: 7201, n: 10 }],
+      sources: [{ message_type: 'M', message_id: 7201, n: 10, used: true }],
       stats_by_suffix: {
         5: { n: 9, lo: 0, hi: 900, mean: 660.7 },
         50: { n: 9, lo: 0, hi: 100, mean: 94.9 },
@@ -266,7 +272,9 @@ describe('blended device messages', () => {
   });
 
   it('says nothing about sources when there is only one', () => {
-    const single = param({ sources: [{ message_type: 'M', message_id: 7201, n: 288 }] });
+    const single = param({
+      sources: [{ message_type: 'M', message_id: 7201, n: 288, used: true }],
+    });
     expect(flagsFor(single)).toEqual([]);
   });
 });

--- a/frontend/src/pages/admin-v2/ventParameters.test.js
+++ b/frontend/src/pages/admin-v2/ventParameters.test.js
@@ -21,7 +21,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   headlineOf, bandOf, flagsFor, needsReview, bandPosition, formatValue,
-  isUnknownParameter, rowsFrom, matchesQuery,
+  isUnknownParameter, rowsFrom, matchesQuery, sourceCount,
 } from './ventParameters';
 
 const param = (over = {}) => ({
@@ -206,5 +206,67 @@ describe('rowsFrom', () => {
     expect(rows.filter((r) => matchesQuery(r, '16003'))).toHaveLength(1);
     expect(rows.filter((r) => matchesQuery(r, ''))).toHaveLength(3);
     expect(rows.filter((r) => matchesQuery(r, 'nope'))).toHaveLength(0);
+  });
+});
+
+describe('blended device messages', () => {
+  // A parameter key is not one measurement. On a real day, I:E ratio arrives
+  // from message 7201 (288 rows, mean -2 — continuous standby telemetry) and
+  // 7204 (25 rows, mean 1619 — active ventilation). Averaging them together
+  // is what produced the square-wave trace and the apparent inversion.
+  const blended = (over = {}) => param({
+    sources: [
+      { message_type: 'M', message_id: 7201, n: 288 },
+      { message_type: 'M', message_id: 7204, n: 25 },
+    ],
+    ...over,
+  });
+
+  it('counts the messages behind a parameter', () => {
+    expect(sourceCount(blended())).toBe(2);
+    expect(sourceCount(param({ sources: [{ message_type: 'M', message_id: 7201, n: 288 }] })))
+      .toBe(1);
+    // Absent entirely on an older payload — treated as nothing known, not as a blend.
+    expect(sourceCount(param())).toBe(0);
+  });
+
+  it('flags a blend as the worst thing about the parameter', () => {
+    const flags = flagsFor(blended());
+    expect(flags[0].key).toBe('mixedSources');
+    expect(flags[0].tone).toBe('alert');
+    expect(needsReview(blended())).toBe(true);
+  });
+
+  it('does not also cry inversion when the blend explains it', () => {
+    // Saying both implies two problems where there is one.
+    const invertedAndBlended = blended({
+      stats_by_suffix: {
+        5: { n: 404, lo: -10, hi: 5000, mean: 1336 },
+        50: { n: 182, lo: -5, hi: 1622, mean: 221 },
+        95: { n: 186, lo: -4, hi: 406, mean: 61 },
+      },
+    });
+    const keys = flagsFor(invertedAndBlended).map((f) => f.key);
+    expect(keys).toContain('mixedSources');
+    expect(keys).not.toContain('bandInverted');
+    // The range is still ordered for display.
+    expect(bandOf(invertedAndBlended)).toMatchObject({ lo: 61, hi: 1336, inverted: true });
+  });
+
+  it('still reports an inversion that has no blend behind it', () => {
+    const p = param({
+      sources: [{ message_type: 'M', message_id: 7201, n: 10 }],
+      stats_by_suffix: {
+        5: { n: 9, lo: 0, hi: 900, mean: 660.7 },
+        50: { n: 9, lo: 0, hi: 100, mean: 94.9 },
+        95: { n: 9, lo: 0, hi: 80, mean: 40.4 },
+      },
+    });
+    expect(flagsFor(p).map((f) => f.key)).toContain('bandInverted');
+  });
+
+  it('says nothing about sources when there is only one', () => {
+    const single = param({ sources: [{ message_type: 'M', message_id: 7201, n: 288 }] });
+    expect(flagsFor(single)).toEqual([]);
   });
 });


### PR DESCRIPTION
The ventilator page, tightened. Two commits: the pin storage, then the page.

## The problem

Every parameter got an equal-weight card. A real day carries **44 parameters**, so that's roughly five screens of scrolling before you reach Oxygen, with nothing distinguishing breath rate from `MANOMETER PRESSURE #9401`. It also had the 4px/5px left accent rails we don't use, was inline-styled shadcn while every neighbouring monitoring page is vc-native, and was the only Recharts page in a Chart.js codebase — part of why it had zero tests.

## What the mockup invented

Checked against the schema and a real day before building anything.

**Real:** parameter key, label, units, precision, scale factor, grouping, per-suffix n/lo/hi/mean, day totals and extent, the day pager. Groups are real but heuristic — `grouping` is NULL for ~405 of 528 VOCSN rows and gets backfilled into **eight** buckets, not the mockup's four.

**Invented:** every quality badge, pinning, and the session concept. The mockup's `8:00–8:44 PM · 1 OF 99` is the day extent plus the day pager, both of which already existed.

**One badge would have been actively wrong.** `PEEP #9404` carries `scale_factor = 1.0` in the dictionary and still reads 370 cmH2O — 1.0 is also the parser's fallback for unknown, so the two are indistinguishable. A green VERIFIED badge would sit on a parameter that is plainly wrong.

So the page flags **provenance**, never **correctness**. Counts from 2026-05-31:

| Flag | Condition | On that day |
|---|---|---|
| Raw only | no median series | 10 of 44 |
| Band inverted | p5 above p95 | 3 of 44 |
| No units | dictionary has none | 4 of 44 |
| No scale | `scale_factor IS NULL` | 2 of 44 |
| Unknown parameter | not in the dictionary | 2 of 44 |

Absence of flags is the good state. Nothing claims a verification we never performed.

## The design

**Pinned parameters lead** — a compact strip plus one Chart.js trend across them. Only pinned parameters fetch their series, so that's a handful of requests, not 44. A pin that produced nothing today shows as absent rather than vanishing.

**Everything else is one line**: name, vendor key, value, its range, sample count, flags, chevron. Grouped, collapsible, with search, group chips and a needs-review filter that the day strip's count toggles.

**No sparklines.** The day payload is aggregates only, so the mockup's per-row sparkline is 44 requests it doesn't show the cost of. Rows get a **position strip** instead — where the headline sits inside its own range — which is free and answers the question a 20px sparkline gets asked.

## Honesty fixes found while measuring

- The triplet was labelled `DAY LOW / MEDIAN / DAY HIGH` but holds min/mean/max of the **median series**. "Day high 1619" for I:E ratio was the largest median, not the day's peak.
- The 5–95 band printed **inverted** on 3 of 44 parameters — that's the `660.7 – 40.4` in the current screenshot. Now sorted, with the inversion stated.
- The parent's subtitle claimed every Monitoring tab showed "alerts and pulse oximetry history", including the two that show neither.

## Storage (migration 049)

Pins are keyed by vendor as well as parameter — 9408 is VOCSN's breath rate and means nothing elsewhere. A second small table records *that* a choice was made, because otherwise "no pin rows" means both "nobody has chosen" and "somebody chose nothing", and clearing the last pin would restore six defaults over a deliberate act.

Defaults are six respiratory parameters, all verified present in the shipped dictionary with a label, units and a scale.

## Verification

- 1076 frontend tests / 86 files, 742 backend tests, lint clean at `--max-warnings 0`, build fine
- Migration applied against the dev stack; `alembic current` reports 049
- New coverage where there was **none**: 25 tests on the reading logic (inverted bands, null-vs-zero bounds, unknown-parameter detection), 20 on the page, 11 on the pins API

**Not verified visually** — I can't log into the local stack. Worth a look on device before merge. `2026-05-31` is the interesting day (44 parameters, 10 raw-only, 3 inverted bands); `2026-06-01` is the short one for the sparse case.

## Out of scope

Session/import scoping (needs `import_id` threaded through three backend queries, and imports overlap by design so they aren't clean windows), per-row sparklines, and a bulk series endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131eFmnRFvybi3nrNHMWppP