### PR TITLE
Rebuild the environment view on the timeline's chart stack

### DIFF
--- a/frontend/src/pages/admin-v2/AdminV2MonitoringEnvironment.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringEnvironment.jsx
@@ -15,56 +15,73 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-// Monitoring → Environment (GH #49): multi-day environmental series with
-// clinical event markers, plus on-demand personal correlation cards.
-// Informational only — copy comes from the backend and makes no causal or
-// care-advice claims.
-import { useEffect, useRef, useState } from 'react';
+// Monitoring → Environment (GH #49): environmental series over days, with the
+// patient's clinical events beneath them, and the observational correlation
+// grid under that.
+//
+// Built on the same stack as the day timeline — one chart per metric sharing a
+// time window, event lanes inset by the same gutter (monitoringChart.js), so a
+// moment lands on the same x everywhere. That also retires the old two-metric
+// cap, which existed only because eight metrics were being squeezed onto one
+// chart's two y-axes.
+//
+// Informational only. The correlation copy comes from the backend and makes no
+// causal or care-advice claim, and nothing here should start making one.
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import Chart from 'chart.js/auto';
 import 'chartjs-adapter-date-fns';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import zoomPlugin from 'chartjs-plugin-zoom';
 import config, { apiFetch } from '../../config';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
-import { useChartColors } from '../../hooks/useChartColors';
-import { Alert } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
-import { InfoIcon } from '../../components/Icons';
+import { InfoIcon, ClockIcon } from '../../components/Icons';
+import {
+  PLOT_GUTTER, PLOT_RPAD, niceScale, thresholdLine, stackedChartOptions,
+} from './monitoringChart';
+import { pivotCards, cellStateOf, stillCollecting } from './envPatterns';
+import './monitoring-environment.css';
 
 Chart.register(annotationPlugin, zoomPlugin);
 
-// Curated metrics shown as chips (subset of /api/environment/metrics; the
-// catalog's `derived` flag drives dashed styling — bucketed rows carry no
-// quality field). Max two active, one per y-axis.
-const DISPLAY_METRICS = [
-  'barometric_pressure', 'pressure_delta_6h', 'pressure_delta_24h',
-  'relative_humidity', 'temperature', 'pm25', 'aqi', 'pollen',
+/* Series colours from the vc-derived ramp the reports and the timeline use,
+ * so a metric reads as a category rather than a state. `dashed` marks a
+ * derived metric — a pressure delta is computed, not measured, and the line
+ * style says so without a legend. */
+const METRICS = {
+  barometric_pressure: { label: 'Pressure', unit: 'hPa', color: '#7f9fd4', signed: false },
+  pressure_delta_6h: { label: 'Δ Pressure 6h', unit: 'hPa', color: '#9b8cf0', signed: true, dashed: true },
+  pressure_delta_24h: { label: 'Δ Pressure 24h', unit: 'hPa', color: '#d98cc4', signed: true, dashed: true },
+  relative_humidity: { label: 'Humidity', unit: '%', color: '#4dc3b3', signed: false },
+  temperature: { label: 'Temperature', unit: '°C', color: '#f0a52e', signed: false },
+  pm25: { label: 'PM2.5', unit: 'µg/m³', color: '#a8c94a', signed: false },
+  aqi: { label: 'AQI', unit: '', color: '#4da7bd', signed: false },
+  pollen: { label: 'Pollen', unit: 'grains/m³', color: '#3fbf6a', signed: false },
+};
+const METRIC_KEYS = Object.keys(METRICS);
+
+/* Clinical events drawn beneath the series. Alerts keep the alert red because
+ * that is the role; the rest take the categorical ramp. */
+const STREAMS = {
+  spo2_alarms: { label: 'SpO2', color: '#f0563c' },
+  oxygen_use: { label: 'Oxygen', color: '#f0a52e' },
+  respiratory_care: { label: 'Care', color: '#4dc3b3' },
+  symptoms: { label: 'Symptoms', color: '#9b8cf0' },
+};
+const STREAM_KEYS = Object.keys(STREAMS);
+
+const RANGES = [
+  { label: '7D', days: 7 },
+  { label: '30D', days: 30 },
+  { label: '90D', days: 90 },
 ];
-const METRIC_COLORS = {
-  barometric_pressure: '#8d6e63',
-  pressure_delta_6h: '#a1887f',
-  pressure_delta_24h: '#795548',
-  relative_humidity: '#26a69a',
-  temperature: '#ef6c00',
-  pm25: '#7e57c2',
-  aqi: '#5c6bc0',
-  pollen: '#9ccc65',
-};
-const MAX_ACTIVE_METRICS = 2;
-// Metrics that legitimately go negative (never clamp their axis to 0)
-const SIGNED_METRICS = new Set(['pressure_delta_6h', 'pressure_delta_24h']);
 
-const EVENT_STREAMS = {
-  spo2_alarms: { color: '#F44336', style: 'box' },
-  oxygen_use: { color: '#FF9800', style: 'box' },
-  respiratory_care: { color: '#4CAF50', style: 'line' },
-  symptoms: { color: '#9C27B0', style: 'line' },
-};
+/* The four the strip leads with. Pressure carries its 6h delta as the change
+ * line beneath it, which is the reading a carer actually watches. */
+const NOW_METRICS = ['barometric_pressure', 'relative_humidity', 'pm25', 'temperature'];
 
-const RANGE_PRESETS = [7, 30, 60, 90];
-const WINDOW_PRESETS = [3, 6, 12, 24];
-const MAX_LABELED_ANNOTATIONS = 300;
-
+/* Verbatim from the pre-rebuild page. This is a clinical safety statement,
+ * not body copy — the second half in particular ("not a basis for care
+ * decisions") is the part a shorter version tends to drop. */
 const DISCLAIMER = (
   <>
     <strong>Informational only.</strong> This view shows when clinical events and
@@ -74,84 +91,104 @@ const DISCLAIMER = (
   </>
 );
 
+const fmtNum = (v, digits = 1) => (v == null || Number.isNaN(v) ? null : v.toFixed(digits));
+const fmtDay = (ms) => new Date(ms).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+const fmtStamp = (ms) => new Date(ms).toLocaleString('en-US', {
+  month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+});
+
 const AdminV2MonitoringEnvironment = () => {
-  const chartColors = useChartColors();
   const { selectedPatient } = useAdminPatient();
 
   const [rangeDays, setRangeDays] = useState(30);
-  const [metricsCatalog, setMetricsCatalog] = useState({});
+  const [catalog, setCatalog] = useState({});
   const [activeMetrics, setActiveMetrics] = useState(['barometric_pressure', 'pressure_delta_6h']);
-  const [envSeries, setEnvSeries] = useState({});
-  const [clinicalEvents, setClinicalEvents] = useState(null);
-  const [visibleStreams, setVisibleStreams] = useState({
-    spo2_alarms: true, oxygen_use: true, respiratory_care: true, symptoms: true,
-  });
+  const [series, setSeries] = useState({});
+  const [events, setEvents] = useState(null);
+  const [visibleStreams, setVisibleStreams] = useState(
+    Object.fromEntries(STREAM_KEYS.map((k) => [k, true])),
+  );
   const [seriesError, setSeriesError] = useState(null);
 
-  const [correlationWindow, setCorrelationWindow] = useState(null); // null = per-pair defaults
   const [correlations, setCorrelations] = useState(null);
   const [correlationsLoading, setCorrelationsLoading] = useState(false);
   const [correlationsError, setCorrelationsError] = useState(null);
 
-  const chartRef = useRef(null);
-  const chartInstance = useRef(null);
+  const [view, setView] = useState(null);
+  const [cursor, setCursor] = useState(null);
+  const stackRef = useRef(null);
+  const pointers = useRef(new Set());
 
-  // Catalog + locations once
+  const activeStr = activeMetrics.join(',');
+
+  /* ---------------- data ---------------- */
+
   useEffect(() => {
+    let cancelled = false;
     (async () => {
       try {
         const res = await apiFetch(`${config.apiUrl}/api/environment/metrics`);
-        if (res.ok) {
-          const list = await res.json();
-          setMetricsCatalog(Object.fromEntries(list.map((m) => [m.name, m])));
-        }
-      } catch (err) {
-        console.error('Environment catalog fetch failed:', err);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body = await res.json();
+        // The API returns a list; key it so lookups are by metric name.
+        const keyed = Object.fromEntries(
+          (Array.isArray(body) ? body : []).map((m) => [m.name, m]));
+        if (!cancelled) setCatalog(keyed);
+      } catch {
+        if (!cancelled) setCatalog({});
       }
     })();
+    return () => { cancelled = true; };
   }, []);
 
-  // Env series + clinical events for the selected range (debounced)
-  const activeMetricsStr = activeMetrics.join(',');
+  // Recomputed only on range change: a `Date.now()` that moved every render
+  // would restart the window under the reader mid-drag.
+  const bounds = useMemo(() => {
+    const end = Date.now();
+    return { start: end - rangeDays * 24 * 3600 * 1000, end };
+  }, [rangeDays]);
+
+  useEffect(() => {
+    setView({ min: bounds.start, max: bounds.end });
+    setCursor(null);
+  }, [bounds.start, bounds.end]);
+
   useEffect(() => {
     if (!selectedPatient) return undefined;
     let cancelled = false;
+    // Debounced: toggling several metrics in a row should fetch once.
     const timer = setTimeout(async () => {
-      const to = new Date();
-      const from = new Date(to.getTime() - rangeDays * 24 * 3600 * 1000);
+      const from = new Date(bounds.start).toISOString();
+      const to = new Date(bounds.end).toISOString();
       setSeriesError(null);
       try {
-        const keys = activeMetricsStr ? activeMetricsStr.split(',') : [];
-        const series = {};
+        const keys = [...new Set([...activeStr.split(',').filter(Boolean), ...NOW_METRICS])];
+        const next = {};
         await Promise.all(keys.map(async (key) => {
           const params = new URLSearchParams({
-            metric: key, scope: 'outdoor', bucket: '1h', limit: '2500',
-            from: from.toISOString(), to: to.toISOString(),
+            metric: key, scope: 'outdoor', bucket: '1h', limit: '2500', from, to,
           });
-          const res = await apiFetch(`${config.apiUrl}/api/environment/observations?${params}`);
+          const res = await apiFetch(
+            `${config.apiUrl}/api/environment/observations?${params}`);
           if (!res.ok) throw new Error(`observations HTTP ${res.status}`);
-          series[key] = (await res.json()).reverse();
+          // Newest-first from the API; charts want ascending.
+          next[key] = (await res.json()).slice().reverse()
+            .map((r) => ({ x: new Date(r.ts).getTime(), y: r.avg }));
         }));
 
-        const evParams = new URLSearchParams({ from: from.toISOString(), to: to.toISOString() });
-        const evRes = await apiFetch(
-          `${config.apiUrl}/api/analysis/patients/${selectedPatient.id}/clinical-events?${evParams}`);
+        const evRes = await apiFetch(`${config.apiUrl}/api/analysis/patients/`
+          + `${selectedPatient.id}/clinical-events?${new URLSearchParams({ from, to })}`);
         if (!evRes.ok) throw new Error(`clinical-events HTTP ${evRes.status}`);
-        const events = await evRes.json();
+        const evBody = await evRes.json();
 
-        if (!cancelled) {
-          setEnvSeries(series);
-          setClinicalEvents(events);
-        }
+        if (!cancelled) { setSeries(next); setEvents(evBody); }
       } catch (err) {
-        console.error('Environment range fetch failed:', err);
         if (!cancelled) setSeriesError(err.message);
       }
     }, 300);
     return () => { cancelled = true; clearTimeout(timer); };
-  }, [selectedPatient, rangeDays, activeMetricsStr]);
+  }, [selectedPatient, bounds.start, bounds.end, activeStr]);
 
-  // Correlations (independent of the chart controls except range)
   useEffect(() => {
     if (!selectedPatient) return undefined;
     let cancelled = false;
@@ -160,9 +197,8 @@ const AdminV2MonitoringEnvironment = () => {
       setCorrelationsError(null);
       try {
         const params = new URLSearchParams({ days: String(Math.max(rangeDays, 7)) });
-        if (correlationWindow) params.set('window_hours', String(correlationWindow));
-        const res = await apiFetch(
-          `${config.apiUrl}/api/analysis/patients/${selectedPatient.id}/env-correlations?${params}`);
+        const res = await apiFetch(`${config.apiUrl}/api/analysis/patients/`
+          + `${selectedPatient.id}/env-correlations?${params}`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const body = await res.json();
         if (!cancelled) setCorrelations(body);
@@ -173,379 +209,494 @@ const AdminV2MonitoringEnvironment = () => {
       }
     })();
     return () => { cancelled = true; };
-  }, [selectedPatient, rangeDays, correlationWindow]);
+  }, [selectedPatient, rangeDays]);
+
+  /* ---------------- derived ---------------- */
+
+  const shown = activeMetrics.filter((k) => METRICS[k]);
+
+  // The catalog is the source of truth for what a metric is called and what it
+  // is measured in; ours are only a fallback for a metric it has not heard of.
+  const labelOf = useCallback((key) => catalog[key]?.label || METRICS[key]?.label || key,
+    [catalog]);
+  const unitOf = useCallback((key) => catalog[key]?.unit ?? METRICS[key]?.unit ?? '',
+    [catalog]);
+  const isDerived = useCallback((key) => catalog[key]?.derived ?? METRICS[key]?.dashed ?? false,
+    [catalog]);
+
+  const latest = useMemo(() => {
+    const out = {};
+    NOW_METRICS.forEach((key) => {
+      const points = series[key] || [];
+      out[key] = points.length ? points[points.length - 1] : null;
+    });
+    const delta = series.pressure_delta_6h || [];
+    out.delta6h = delta.length ? delta[delta.length - 1] : null;
+    return out;
+  }, [series]);
+
+  const laneItems = useMemo(() => {
+    const out = {};
+    STREAM_KEYS.forEach((key) => {
+      out[key] = ((events?.events || {})[key] || [])
+        .map((ev, i) => ({
+          id: `${key}-${i}`,
+          ts: new Date(ev.ts).getTime(),
+          label: ev.label || STREAMS[key].label,
+        }))
+        .filter((it) => Number.isFinite(it.ts));
+    });
+    return out;
+  }, [events]);
+
+  const eventTotal = STREAM_KEYS
+    .filter((k) => visibleStreams[k])
+    .reduce((n, k) => n + (laneItems[k]?.length || 0), 0);
+
+  const grid = useMemo(() => pivotCards(correlations?.cards), [correlations]);
+  const collecting = useMemo(() => stillCollecting(correlations?.cards), [correlations]);
+
+  /* ---------------- interaction ---------------- */
+
+  const tsFromClientX = useCallback((clientX) => {
+    const el = stackRef.current;
+    if (!el || !view) return null;
+    const rect = el.getBoundingClientRect();
+    const width = rect.width - PLOT_GUTTER - PLOT_RPAD;
+    if (width <= 0) return null;
+    const frac = Math.min(1, Math.max(0, (clientX - rect.left - PLOT_GUTTER) / width));
+    return Math.round(view.min + frac * (view.max - view.min));
+  }, [view]);
+
+  const onPointerDown = (e) => {
+    pointers.current.add(e.pointerId);
+    if (pointers.current.size > 1) return;
+    const ts = tsFromClientX(e.clientX);
+    if (ts != null) setCursor(ts);
+  };
+  const onPointerMove = (e) => {
+    if (pointers.current.size !== 1 || !pointers.current.has(e.pointerId)) return;
+    if (e.pointerType === 'mouse' && e.buttons === 0) return;
+    const ts = tsFromClientX(e.clientX);
+    if (ts != null) setCursor(ts);
+  };
+  const endPointer = (e) => { pointers.current.delete(e.pointerId); };
 
   const toggleMetric = (key) => {
     setActiveMetrics((prev) => {
-      if (prev.includes(key)) return prev.filter((k) => k !== key);
-      if (prev.length < MAX_ACTIVE_METRICS) return [...prev, key];
-      return [...prev.slice(1), key];
+      if (!prev.includes(key)) return [...prev, key];
+      // Never leave the stack empty — an empty chart card reads as broken.
+      if (prev.length === 1) return prev;
+      return prev.filter((k) => k !== key);
     });
   };
 
-  const toggleStream = (key) => {
-    setVisibleStreams((prev) => ({ ...prev, [key]: !prev[key] }));
-  };
+  const cursorFrac = cursor != null && view && view.max > view.min
+    ? (cursor - view.min) / (view.max - view.min) : null;
 
-  // Build chart
-  useEffect(() => {
-    if (!chartRef.current) return undefined;
-    if (chartInstance.current) {
-      chartInstance.current.destroy();
-      chartInstance.current = null;
-    }
-
-    const datasets = [];
-    const scales = {};
-    activeMetrics.forEach((key, i) => {
-      const rows = envSeries[key] || [];
-      const color = METRIC_COLORS[key] || '#888';
-      const dashed = Boolean(metricsCatalog[key]?.derived);
-      const unit = metricsCatalog[key]?.unit || '';
-      const label = metricsCatalog[key]?.label || key;
-      const axisId = `y_${key}`;
-
-      const avg = rows.map((r) => ({ x: new Date(r.ts), y: r.avg }));
-      const lows = rows.map((r) => ({ x: new Date(r.ts), y: r.min }));
-      const highs = rows.map((r) => ({ x: new Date(r.ts), y: r.max }));
-
-      // min/max band: invisible floor line + filled ceiling referencing it
-      datasets.push({
-        label: `${label} (min)`, data: lows, borderWidth: 0, pointRadius: 0,
-        fill: false, yAxisID: axisId, spanGaps: true, hidden: false,
-      });
-      datasets.push({
-        label: `${label} (max)`, data: highs, borderWidth: 0, pointRadius: 0,
-        fill: '-1', backgroundColor: `${color}22`, yAxisID: axisId, spanGaps: true,
-      });
-      datasets.push({
-        label: `${label}${unit ? ` (${unit})` : ''}`,
-        data: avg,
-        borderColor: color,
-        backgroundColor: `${color}22`,
-        borderWidth: 1.5,
-        borderDash: dashed ? [6, 4] : [],
-        pointRadius: 0,
-        pointHitRadius: 5,
-        fill: false,
-        spanGaps: true,
-        yAxisID: axisId,
-        tension: 0.2,
-      });
-
-      const values = avg.map((p) => p.y).filter((v) => v != null);
-      const lo = values.length ? Math.min(...values) : 0;
-      const hi = values.length ? Math.max(...values) : 1;
-      const pad = Math.max((hi - lo) * 0.08, 0.5);
-      scales[axisId] = {
-        type: 'linear',
-        position: i === 0 ? 'left' : 'right',
-        min: SIGNED_METRICS.has(key) ? lo - pad : Math.max(0, lo - pad),
-        max: hi + pad,
-        title: { display: true, text: `${label}${unit ? ` (${unit})` : ''}`, color, font: { size: 12 } },
-        ticks: { color },
-        grid: i === 0 ? { color: chartColors.grid } : { drawOnChartArea: false },
-      };
-    });
-
-    // Clinical event annotations
-    const annotations = {};
-    let annotationCount = 0;
-    if (clinicalEvents?.events) {
-      Object.entries(clinicalEvents.events).forEach(([stream, events]) => {
-        annotationCount += visibleStreams[stream] ? events.length : 0;
-      });
-      const showLabels = annotationCount <= MAX_LABELED_ANNOTATIONS;
-      Object.entries(clinicalEvents.events).forEach(([stream, events]) => {
-        if (!visibleStreams[stream]) return;
-        const cfg = EVENT_STREAMS[stream];
-        events.forEach((ev, i) => {
-          const start = new Date(ev.ts);
-          if (cfg.style === 'box') {
-            const end = ev.end_ts ? new Date(ev.end_ts) : new Date(start.getTime() + 30 * 60000);
-            annotations[`${stream}_${i}`] = {
-              type: 'box', xMin: start, xMax: end,
-              backgroundColor: `${cfg.color}26`, borderColor: `${cfg.color}66`, borderWidth: 1,
-            };
-          } else {
-            annotations[`${stream}_${i}`] = {
-              type: 'line', xMin: start, xMax: start,
-              borderColor: cfg.color, borderWidth: 1.5,
-              label: showLabels ? {
-                display: true, content: ev.label?.slice(0, 24) || stream,
-                position: 'start', backgroundColor: cfg.color, color: '#fff',
-                font: { size: 9 }, padding: 2, rotation: -90, yAdjust: -8,
-              } : undefined,
-            };
-          }
-        });
-      });
-    }
-
-    const ctx = chartRef.current.getContext('2d');
-    chartInstance.current = new Chart(ctx, {
-      type: 'line',
-      data: { datasets },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        interaction: { mode: 'index', intersect: false },
-        scales: {
-          x: {
-            type: 'time',
-            time: { displayFormats: { hour: 'MMM d ha', day: 'MMM d' }, tooltipFormat: 'MMM d, h:mm a' },
-            grid: { color: chartColors.grid },
-            ticks: { maxRotation: 0, font: { size: 11 }, color: chartColors.axis, autoSkip: true, maxTicksLimit: 14 },
-          },
-          ...scales,
-        },
-        plugins: {
-          legend: {
-            position: 'top',
-            labels: {
-              usePointStyle: true, padding: 15, font: { size: 12 }, color: chartColors.foreground,
-              // Hide the band helper datasets from the legend
-              filter: (item) => !/\((min|max)\)$/.test(item.text),
-            },
-          },
-          annotation: { annotations },
-          zoom: {
-            pan: { enabled: true, mode: 'x' },
-            zoom: { wheel: { enabled: true }, pinch: { enabled: true }, mode: 'x' },
-          },
-        },
-      },
-    });
-
-    return () => {
-      if (chartInstance.current) {
-        chartInstance.current.destroy();
-        chartInstance.current = null;
-      }
-    };
-  }, [envSeries, clinicalEvents, activeMetrics, visibleStreams, metricsCatalog,
-      chartColors.grid, chartColors.axis, chartColors.foreground]);
+  /* ---------------- render ---------------- */
 
   if (!selectedPatient) {
-    return (
-      <div style={{ padding: 40, textAlign: 'center', color: 'var(--muted-foreground)' }}>
-        Select a patient from the sidebar to view environmental data.
-      </div>
-    );
+    return <div className="env"><p className="env-empty">Select a patient to see their environment.</p></div>;
   }
 
   return (
-    <div>
-      {/* Guardrail banner */}
-      <div className="tw" style={{ marginBottom: '1rem' }}>
-        <Alert variant="info">
-          <span style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
-            <span style={{ flexShrink: 0, marginTop: 2 }} aria-hidden><InfoIcon size={16} /></span>
-            <span>{DISCLAIMER}</span>
+    <div className="env">
+      <section className="env-card">
+        <div className="env-card-head">
+          <h3>Outdoor conditions</h3>
+          <span className="env-label">
+            {latest.barometric_pressure
+              ? `updated ${fmtStamp(latest.barometric_pressure.x)}`
+              : 'no readings'}
           </span>
-        </Alert>
-      </div>
-
-      {/* Controls */}
-      <div style={{
-        display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: '1rem',
-        padding: '0.75rem 1rem', background: 'var(--card)', borderRadius: 8,
-        border: '1px solid var(--border)', alignItems: 'center', justifyContent: 'space-between',
-      }}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
-          {DISPLAY_METRICS.filter((k) => metricsCatalog[k]).map((key) => {
-            const active = activeMetrics.includes(key);
-            const color = METRIC_COLORS[key];
-            const dashed = Boolean(metricsCatalog[key]?.derived);
-            return (
-              <button
-                key={key}
-                onClick={() => toggleMetric(key)}
-                style={{
-                  display: 'flex', alignItems: 'center', gap: 6,
-                  padding: '5px 12px', borderRadius: 16, fontSize: 12, fontWeight: 600,
-                  border: `2px ${dashed ? 'dashed' : 'solid'} ${color}`,
-                  background: active ? color : 'transparent',
-                  color: active ? '#fff' : color,
-                  cursor: 'pointer', transition: 'all 0.15s',
-                  opacity: active ? 1 : 0.6,
-                }}
-              >
-                <span style={{ width: 8, height: 8, borderRadius: '50%', background: active ? '#fff' : color, display: 'inline-block' }} />
-                {metricsCatalog[key]?.label || key}
-              </button>
-            );
-          })}
-
-          <span style={{ width: 1, height: 20, background: 'var(--border)', display: 'inline-block' }} />
-
-          {clinicalEvents && Object.keys(EVENT_STREAMS).map((stream) => {
-            const cfg = EVENT_STREAMS[stream];
-            const active = visibleStreams[stream];
-            const count = clinicalEvents.events?.[stream]?.length ?? 0;
-            return (
-              <button
-                key={stream}
-                onClick={() => toggleStream(stream)}
-                style={{
-                  display: 'flex', alignItems: 'center', gap: 6,
-                  padding: '5px 12px', borderRadius: 16, fontSize: 12, fontWeight: 600,
-                  border: `2px solid ${cfg.color}`,
-                  background: active ? cfg.color : 'transparent',
-                  color: active ? '#fff' : cfg.color,
-                  cursor: 'pointer', transition: 'all 0.15s',
-                  opacity: active ? 1 : 0.6,
-                }}
-              >
-                <span style={{ width: 8, height: 8, borderRadius: '50%', background: active ? '#fff' : cfg.color, display: 'inline-block' }} />
-                {clinicalEvents.labels?.[stream] || stream} ({count})
-              </button>
-            );
-          })}
         </div>
-
-        <div className="tw" style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
-          {/* Location placeholder: room selection ships with room-level
-              ingestion (GH #48); until then everything is outdoor scope. */}
-          <select
-            disabled
-            title="Room sensors not set up yet"
-            style={{
-              padding: '5px 8px', borderRadius: 6, fontSize: 12,
-              background: 'var(--secondary)', color: 'var(--muted-foreground)',
-              border: '1px solid var(--border)',
-            }}
-          >
-            <option>Outdoor (home)</option>
-          </select>
-          <span style={{ fontSize: 11, color: 'var(--muted-foreground)', margin: '0 4px' }}>Range:</span>
-          {RANGE_PRESETS.map((d) => (
-            <Button key={d} size="sm" variant={rangeDays === d ? 'default' : 'secondary'}
-                    onClick={() => setRangeDays(d)}>
-              {d}d
-            </Button>
+        <div className="env-now">
+          {NOW_METRICS.map((key) => (
+            <NowCell
+              key={key}
+              metricKey={key}
+              point={latest[key]}
+              delta={key === 'barometric_pressure' ? latest.delta6h : null}
+            />
           ))}
         </div>
-      </div>
+      </section>
 
-      {seriesError && (
-        <div className="tw" style={{ marginBottom: '1rem' }}>
-          <Alert variant="destructive">Failed to load environment data: {seriesError}</Alert>
-        </div>
-      )}
+      {seriesError && <p className="env-error">{seriesError}</p>}
 
-      {/* Chart */}
-      <div style={{
-        border: '1px solid var(--border)', borderRadius: 8, background: 'var(--card)',
-        padding: '12px 8px', height: 420, position: 'relative', marginBottom: '1.5rem',
-      }}>
-        <canvas ref={chartRef} />
-      </div>
-
-      {/* Correlation cards */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 8, marginBottom: '0.75rem' }}>
-        <h3 style={{ margin: 0, color: 'var(--foreground)', fontSize: '1.05rem' }}>
-          Personal patterns
-          <span style={{ fontSize: '0.75rem', color: 'var(--muted-foreground)', marginLeft: 8, fontWeight: 400 }}>
-            informational — last {correlations?.range?.days ?? rangeDays} days
-          </span>
-        </h3>
-        <div className="tw" style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
-          <span style={{ fontSize: 11, color: 'var(--muted-foreground)', marginRight: 4 }}>Window:</span>
-          {WINDOW_PRESETS.map((w) => (
-            <Button key={w} size="sm" variant={correlationWindow === w ? 'default' : 'secondary'}
-                    onClick={() => setCorrelationWindow(correlationWindow === w ? null : w)}>
-              {w}h
-            </Button>
+      <div className="env-controls">
+        <div className="env-range" role="group" aria-label="Range">
+          {RANGES.map((r) => (
+            <button
+              key={r.label} type="button"
+              className={rangeDays === r.days ? 'on' : ''}
+              aria-pressed={rangeDays === r.days}
+              onClick={() => setRangeDays(r.days)}
+            >
+              {r.label}
+            </button>
           ))}
         </div>
+        <select
+          className="env-roompick"
+          disabled
+          title="Room sensors not set up yet"
+          aria-label="Scope"
+          value="outdoor"
+          onChange={() => {}}
+        >
+          <option value="outdoor">Outdoor</option>
+        </select>
+        <span className="env-spacer" />
+        <span className="env-label">{eventTotal} events</span>
       </div>
 
-      {correlationsLoading ? (
-        <div className="admin-v2-loading">Analyzing environmental patterns...</div>
-      ) : correlationsError ? (
-        <div className="tw"><Alert variant="destructive">Analysis failed: {correlationsError}</Alert></div>
-      ) : correlations ? (
-        <div className="admin-v2-cards-grid">
-          {correlations.cards.map((card) => (
-            <EnvCorrelationCard key={`${card.exposure.key}_${card.outcome.key}`} card={card} />
+      <div className="env-controls">
+        {METRIC_KEYS.filter((k) => catalog[k] || series[k]).map((key) => {
+          const cfg = METRICS[key];
+          const on = activeMetrics.includes(key);
+          const empty = on && (series[key] || []).length === 0;
+          return (
+            <button
+              key={key} type="button" className="env-chip"
+              style={{ '--sig': cfg.color }}
+              aria-pressed={on}
+              onClick={() => toggleMetric(key)}
+            >
+              <span className={`env-chip-dot${isDerived(key) ? ' dashed' : ''}`} />
+              {labelOf(key)}
+              {empty && <span className="env-chip-note">no data</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      <section className="env-card">
+        <div className="env-card-head">
+          <h3>Series &amp; events</h3>
+          <span className="env-label">{fmtDay(bounds.start)} – {fmtDay(bounds.end)}</span>
+        </div>
+        <div
+          className="env-stack"
+          ref={stackRef}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={endPointer}
+          onPointerCancel={endPointer}
+          onPointerLeave={endPointer}
+        >
+          {shown.map((key, i) => (
+            <MetricChart
+              key={key}
+              metricKey={key}
+              label={labelOf(key)}
+              unit={unitOf(key)}
+              derived={isDerived(key)}
+              points={series[key] || []}
+              view={view}
+              bounds={bounds}
+              cursor={cursor}
+              showAxis={i === shown.length - 1}
+              onViewChange={setView}
+            />
+          ))}
+
+          <div className="env-lanes">
+            <div className="env-lanes-title">Clinical events</div>
+            {STREAM_KEYS.filter((k) => visibleStreams[k]).map((key) => (
+              <EventLane
+                key={key} laneKey={key} items={laneItems[key] || []}
+                view={view} onPick={setCursor}
+              />
+            ))}
+          </div>
+
+          {cursorFrac != null && cursorFrac >= 0 && cursorFrac <= 1 && (
+            <div className="env-plotbox">
+              <div className="env-scrub" style={{ left: `${cursorFrac * 100}%` }}>
+                <span className="env-scrub-pill">{fmtStamp(cursor)}</span>
+              </div>
+            </div>
+          )}
+        </div>
+        <div className="env-controls" style={{ padding: '0.5rem 0.9rem 0.7rem' }}>
+          {STREAM_KEYS.map((key) => (
+            <button
+              key={key} type="button" className="env-chip"
+              style={{ '--sig': STREAMS[key].color }}
+              aria-pressed={visibleStreams[key]}
+              onClick={() => setVisibleStreams((p) => ({ ...p, [key]: !p[key] }))}
+            >
+              <span className="env-chip-dot" />
+              {STREAMS[key].label}
+              <span className="env-chip-note">{laneItems[key]?.length ?? 0}</span>
+            </button>
           ))}
         </div>
-      ) : null}
+      </section>
+
+      <p className="env-hint">Drag to inspect · pinch or scroll to zoom</p>
+
+      <section className="env-card">
+        <div className="env-card-head">
+          <h3>Personal patterns</h3>
+          <span className="env-label">{rangeDays}-day observational analysis</span>
+        </div>
+
+        {correlationsError && <p className="env-note">{correlationsError}</p>}
+        {correlationsLoading && !correlations && <p className="env-empty">Running the analysis…</p>}
+
+        {correlations && grid.rows.length === 0 && (
+          <p className="env-empty">No trigger and outcome pairs to analyse yet.</p>
+        )}
+
+        {grid.rows.length > 0 && (
+          <div className="env-grid-wrap">
+            <table className="env-grid">
+              <thead>
+                <tr>
+                  <th>Trigger</th>
+                  {grid.outcomes.map((o) => <th key={o.key}>{o.label}</th>)}
+                </tr>
+              </thead>
+              <tbody>
+                {grid.rows.map((row) => (
+                  <tr key={row.key}>
+                    <td className="env-grid-trigger">
+                      <b>{row.label}</b>
+                      {row.estimated && <span>estimated metric</span>}
+                    </td>
+                    {grid.outcomes.map((o) => (
+                      <PatternCell key={o.key} card={row.cells[o.key]} />
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {collecting > 0 && (
+          <div className="env-foot">
+            <ClockIcon size={14} />
+            {collecting} {collecting === 1 ? 'analysis is' : 'analyses are'} still collecting data.
+          </div>
+        )}
+        <div className="env-foot">
+          <InfoIcon size={14} />
+          <span>{DISCLAIMER}</span>
+        </div>
+      </section>
     </div>
   );
 };
 
-// One (exposure, outcome) correlation card. All statistical wording comes
-// verbatim from the backend (guardrailed there); this component only lays it
-// out and never adds causal or advisory phrasing.
-const EnvCorrelationCard = ({ card }) => {
-  const ok = card.status === 'ok';
-  const distinct = ok && (card.ci_low > 1 || card.ci_high < 1);
-  const exposureColor = METRIC_COLORS[card.exposure.metric] || '#8d6e63';
-  const badge = ok
-    ? (distinct ? 'Pattern observed' : 'No clear difference')
-    : 'Not enough data yet';
+/* One current reading. Tone comes from the reading itself only where a public
+ * band exists for it; otherwise the value is shown plainly rather than
+ * coloured against a threshold nobody set. */
+const NowCell = ({ metricKey, point, delta }) => {
+  const cfg = METRICS[metricKey];
+  const value = point ? fmtNum(point.y, metricKey === 'pm25' ? 0 : 1) : null;
+
+  let tone = '';
+  let band = null;
+  if (metricKey === 'pm25' && point?.y != null) {
+    // US AQI breakpoints for PM2.5 — a published scale, not a patient bound.
+    // Per-patient thresholds live on the room metrics, which this outdoor
+    // strip is not showing.
+    if (point.y > 35) { tone = 'env-tone-critical'; band = 'unhealthy'; }
+    else if (point.y > 12) { tone = 'env-tone-caution'; band = 'moderate'; }
+    else { tone = 'env-tone-ok'; band = 'good'; }
+  }
 
   return (
-    <div className="admin-v2-card"
-         style={{ borderTop: `3px solid ${distinct ? exposureColor : 'transparent'}` }}>
-      <div className="admin-v2-card-header" style={{ borderBottom: 'none', paddingBottom: 0 }}>
-        <div>
-          <h3 style={{ fontSize: '0.9rem', margin: 0, color: 'var(--foreground)' }}>
-            {card.outcome.label}
-          </h3>
-          <span style={{ fontSize: '0.72rem', color: 'var(--muted-foreground)' }}>
-            near {card.exposure.label}
-            {card.exposure.quality === 'estimated' && ' (estimated)'}
-          </span>
-        </div>
-        <span className={`admin-v2-badge ${distinct ? 'admin-v2-badge-success' : 'admin-v2-badge-muted'}`}
-              style={{ fontSize: '0.7rem', whiteSpace: 'nowrap' }}>
-          {badge}
+    <div className={`env-now-cell ${tone}`}>
+      <span className="env-now-name">{cfg.label}</span>
+      <span className="env-now-value">
+        {value ?? '—'}
+        {value != null && cfg.unit && <small>{cfg.unit}</small>}
+      </span>
+      {band && <span className="env-now-sub">{band}</span>}
+      {delta?.y != null && (
+        <span className={`env-now-sub ${delta.y < 0 ? 'falling' : 'rising'}`}>
+          {delta.y > 0 ? '+' : ''}{fmtNum(delta.y, 1)} / 6h
         </span>
-      </div>
-      <div className="admin-v2-card-body" style={{ paddingTop: '0.5rem' }}>
-        {ok ? (
-          <>
-            <div style={{ textAlign: 'center', padding: '0.6rem 0' }}>
-              <span style={{
-                fontSize: '1.6rem', fontWeight: 700,
-                color: distinct ? exposureColor : 'var(--muted-foreground)',
-              }}>
-                {card.rate_ratio.toFixed(1)}×
-              </span>
-              <span style={{ fontSize: '0.75rem', color: 'var(--muted-foreground)', marginLeft: 6 }}>
-                95% CI {card.ci_low.toFixed(1)}–{card.ci_high.toFixed(1)}
-              </span>
-            </div>
-            <p style={{ fontSize: '0.8rem', color: 'var(--foreground)', margin: '0 0 0.5rem' }}>
-              {card.message}
-            </p>
-            <div style={{
-              display: 'flex', justifyContent: 'space-between',
-              background: 'var(--secondary)', borderRadius: 6, padding: '0.45rem 0.75rem',
-              fontSize: '0.75rem', color: 'var(--muted-foreground)',
-            }}>
-              <span>{card.exposed_events} events in {card.exposed_hours}h exposed</span>
-              <span>{card.baseline_events} in {card.baseline_hours}h baseline</span>
-            </div>
-            {card.outcome.matched_sources?.length > 0 && (
-              <div style={{ fontSize: '0.7rem', color: 'var(--muted-foreground)', marginTop: '0.4rem' }}>
-                Counted tasks: {card.outcome.matched_sources.join(', ')}
-              </div>
-            )}
-          </>
-        ) : (
-          <p style={{
-            fontSize: '0.8rem', color: 'var(--muted-foreground)',
-            textAlign: 'center', padding: '1rem 0.25rem', margin: 0,
-          }}>
-            {card.message}
-          </p>
-        )}
+      )}
+      {!point && <span className="env-now-sub">no readings</span>}
+    </div>
+  );
+};
+
+/* One metric, one scale, sharing the stack's window. */
+const MetricChart = ({
+  metricKey, label, unit, derived, points, view, bounds, cursor, showAxis, onViewChange,
+}) => {
+  const cfg = METRICS[metricKey];
+  const canvasRef = useRef(null);
+  const chartRef = useRef(null);
+  const onViewChangeRef = useRef(onViewChange);
+  onViewChangeRef.current = onViewChange;
+
+  // Fixed for the whole range rather than refitted per window, so panning
+  // moves across a stable scale instead of rescaling under the reader.
+  const yRange = useMemo(() => {
+    if (!points.length) return niceScale(0, 1, 1, null, { clampMin: !cfg.signed });
+    const ys = points.map((p) => p.y).filter((y) => y != null);
+    if (!ys.length) return niceScale(0, 1, 1, null, { clampMin: !cfg.signed });
+    return niceScale(Math.min(...ys), Math.max(...ys), 1, null, { clampMin: !cfg.signed });
+  }, [points, cfg.signed]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+    const annotations = {};
+    // A delta metric's zero is the line that matters — above it pressure is
+    // rising, below it falling — so it is drawn rather than left to the grid.
+    if (cfg.signed) annotations.zero = thresholdLine(0, 'NO CHANGE');
+
+    const chart = new Chart(canvas.getContext('2d'), {
+      type: 'line',
+      data: {
+        datasets: [{
+          label,
+          data: points,
+          parsing: false,
+          borderColor: cfg.color,
+          borderWidth: 1.4,
+          borderDash: derived ? [5, 4] : [],
+          pointRadius: 0,
+          pointHitRadius: 0,
+          tension: 0.15,
+          spanGaps: false,
+        }],
+      },
+      options: stackedChartOptions({
+        view,
+        bounds,
+        yRange,
+        showAxis,
+        annotations,
+        timeFormats: { hour: 'ha', day: 'MMM d' },
+        minRangeMs: 6 * 3600 * 1000,
+        onViewChange: (next) => onViewChangeRef.current(next),
+      }),
+    });
+    chartRef.current = chart;
+    return () => { chart.destroy(); chartRef.current = null; };
+    // View is applied imperatively below so a zoom does not rebuild the chart.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [points, bounds, showAxis, cfg, yRange, label, derived]);
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart || !view) return;
+    if (chart.scales.x.min === view.min && chart.scales.x.max === view.max) return;
+    chart.zoomScale('x', { min: view.min, max: view.max }, 'none');
+  }, [view]);
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+    const anns = chart.options.plugins.annotation.annotations;
+    delete anns.cursor;
+    if (cursor != null && points.length) {
+      let best = null;
+      let gap = Infinity;
+      points.forEach((p) => {
+        const d = Math.abs(p.x - cursor);
+        if (d < gap) { gap = d; best = p; }
+      });
+      // An hour either side; beyond that the dot would sit on nothing.
+      if (best && best.y != null && gap <= 3600 * 1000) {
+        anns.cursor = {
+          type: 'point', xValue: best.x, yValue: best.y,
+          radius: 3.5, backgroundColor: cfg.color,
+          borderColor: 'rgba(255,255,255,0.15)', borderWidth: 1,
+        };
+      }
+    }
+    chart.update('none');
+  }, [cursor, points, cfg]);
+
+  return (
+    <div className={`env-chart${showAxis ? ' tall' : ''}`}>
+      <span className="env-chart-title" style={{ color: cfg.color }}>
+        {label}
+        {unit && <small>{unit}</small>}
+      </span>
+      <canvas ref={canvasRef} aria-label={`${label} over time`} />
+    </div>
+  );
+};
+
+const EventLane = ({ laneKey, items, view, onPick }) => {
+  const lane = STREAMS[laneKey];
+  const span = view ? view.max - view.min : 0;
+  const inWindow = span > 0
+    ? items.filter((it) => it.ts >= view.min && it.ts <= view.max) : [];
+
+  return (
+    <div className="env-lane" style={{ '--lane': lane.color }}>
+      <span className="env-lane-name">{lane.label}</span>
+      <div className="env-lane-track">
+        {inWindow.length === 0 && <span className="env-lane-empty">—</span>}
+        {inWindow.map((it) => (
+          <button
+            key={it.id} type="button" className="env-lane-mark"
+            style={{ left: `${((it.ts - view.min) / span) * 100}%` }}
+            title={`${fmtStamp(it.ts)} — ${it.label}`}
+            aria-label={`${fmtStamp(it.ts)} ${it.label}`}
+            onClick={() => onPick(it.ts)}
+          />
+        ))}
       </div>
     </div>
+  );
+};
+
+/* One trigger against one outcome. A cell either has a ratio, is still
+ * gathering, or was never analysed — and those read differently on purpose. */
+const PatternCell = ({ card }) => {
+  const state = cellStateOf(card);
+
+  if (state.kind === 'absent') {
+    return <td className="env-cell"><span className="env-cell-none">—</span></td>;
+  }
+
+  if (state.kind === 'collecting') {
+    const p = state.progress;
+    return (
+      <td className="env-cell">
+        <div className="env-collecting" title={state.message}>
+          <span>
+            {p ? `Collecting ${p.have}/${p.need}${p.unit}` : 'Not started'}
+          </span>
+          <span className="env-bar">
+            <i style={{ width: `${p ? Math.min(100, (p.have / p.need) * 100) : 0}%` }} />
+          </span>
+          <span className="sr-only">{state.message}</span>
+        </div>
+      </td>
+    );
+  }
+
+  const counted = card.outcome?.matched_sources;
+  const detail = [
+    `95% CI ${state.ciLow.toFixed(1)}–${state.ciHigh.toFixed(1)}`,
+    `${card.exposed_events} in ${card.exposed_hours}h exposed`,
+    `${card.baseline_events} in ${card.baseline_hours}h baseline`,
+    counted?.length ? `counted: ${counted.join(', ')}` : null,
+  ].filter(Boolean).join(' · ');
+
+  return (
+    <td className={`env-cell ${state.kind === 'pattern' ? 'pattern' : ''}`} title={detail}>
+      <span className="env-cell-ratio">{state.ratio.toFixed(1)}×</span>
+      <span className="env-cell-verdict">
+        {state.kind === 'pattern' ? 'Pattern observed' : 'No clear difference'}
+      </span>
+      <span className="sr-only">{detail}. {card.message}</span>
+    </td>
   );
 };
 

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringEnvironment.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringEnvironment.jsx
@@ -468,7 +468,7 @@ const AdminV2MonitoringEnvironment = () => {
                       {row.estimated && <span>estimated metric</span>}
                     </td>
                     {grid.outcomes.map((o) => (
-                      <PatternCell key={o.key} card={row.cells[o.key]} />
+                      <PatternCell key={o.key} label={o.label} card={row.cells[o.key]} />
                     ))}
                   </tr>
                 ))}
@@ -657,17 +657,24 @@ const EventLane = ({ laneKey, items, view, onPick }) => {
 
 /* One trigger against one outcome. A cell either has a ratio, is still
  * gathering, or was never analysed — and those read differently on purpose. */
-const PatternCell = ({ card }) => {
+/* `data-label` carries the column name onto the cell itself. On a phone the
+ * grid reflows into one card per trigger, where the header row is gone and the
+ * cell has to say which outcome it is. */
+const PatternCell = ({ card, label }) => {
   const state = cellStateOf(card);
 
   if (state.kind === 'absent') {
-    return <td className="env-cell"><span className="env-cell-none">—</span></td>;
+    return (
+      <td className="env-cell" data-label={label}>
+        <span className="env-cell-none">—</span>
+      </td>
+    );
   }
 
   if (state.kind === 'collecting') {
     const p = state.progress;
     return (
-      <td className="env-cell">
+      <td className="env-cell" data-label={label}>
         <div className="env-collecting" title={state.message}>
           <span>
             {p ? `Collecting ${p.have}/${p.need}${p.unit}` : 'Not started'}
@@ -690,7 +697,8 @@ const PatternCell = ({ card }) => {
   ].filter(Boolean).join(' · ');
 
   return (
-    <td className={`env-cell ${state.kind === 'pattern' ? 'pattern' : ''}`} title={detail}>
+    <td className={`env-cell ${state.kind === 'pattern' ? 'pattern' : ''}`}
+        data-label={label} title={detail}>
       <span className="env-cell-ratio">{state.ratio.toFixed(1)}×</span>
       <span className="env-cell-verdict">
         {state.kind === 'pattern' ? 'Pattern observed' : 'No clear difference'}

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringEnvironment.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringEnvironment.test.jsx
@@ -294,6 +294,30 @@ describe('personal patterns', () => {
     expect(screen.getByText(/2 analyses are|1 analysis is/)).toBeInTheDocument();
   });
 
+  it('names its own outcome on every cell, so the phone layout can drop the header', async () => {
+    await renderPage();
+    // Below 720px the grid reflows into one card per trigger and the header
+    // row goes away; a cell with no label would read as an orphaned
+    // "Collecting 20/24h", which is exactly what scrolling the table did.
+    const cells = [...document.querySelectorAll('.env-cell')];
+    expect(cells.length).toBeGreaterThan(0);
+    cells.forEach((td) => expect(td.getAttribute('data-label')).toBeTruthy());
+    expect(cells.map((td) => td.getAttribute('data-label')))
+      .toContain('Respiratory care events');
+  });
+
+  it('stops scrolling sideways on a phone rather than hiding the trigger', async () => {
+    // jsdom does not apply media queries, so the contract is read from source:
+    // the reflow and the sticky trigger are what keep a cell attached to its
+    // row at either width.
+    const css = readFileSync(resolve(__dirname, 'monitoring-environment.css'), 'utf8');
+    expect(css).toMatch(/@media \(max-width: 720px\)/);
+    expect(css).toMatch(/\.env-grid-wrap \{ overflow-x: visible; \}/);
+    expect(css).toMatch(/content: attr\(data-label\)/);
+    // …and on a wide screen the trigger column stays put instead.
+    expect(css).toMatch(/\.env-grid-trigger,[\s\S]*?position: sticky/);
+  });
+
   it('keeps the counted care tasks visible for the reader to check', async () => {
     await renderPage();
     const cell = screen.getByText('2.1×').closest('td');

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringEnvironment.test.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringEnvironment.test.jsx
@@ -18,8 +18,13 @@
 // Monitoring → Environment tab: range chart with clinical annotations,
 // dashed derived metrics, disabled room picker, and correlation cards with
 // honest insufficient-data states.
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent, within } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const { chartInstances, apiFetchMock } = vi.hoisted(() => ({
   chartInstances: [],
@@ -30,10 +35,18 @@ vi.mock('chart.js/auto', () => {
   class MockChart {
     constructor(ctx, config) {
       this.config = config;
+      this.options = config.options;
+      // Charts are rebuilt on data change, so assertions have to look at the
+      // live ones rather than everything ever constructed.
+      this.destroyed = false;
+      this.scales = {
+        x: { min: config.options.scales.x.min, max: config.options.scales.x.max },
+      };
       chartInstances.push(this);
     }
-    destroy() {}
+    destroy() { this.destroyed = true; }
     resetZoom() {}
+    zoomScale(axis, { min, max }) { this.scales[axis] = { min, max }; }
     update() {}
   }
   MockChart.register = () => {};
@@ -115,14 +128,21 @@ const route = (url) => {
 };
 
 const renderPage = async () => {
-  await act(async () => {
-    render(<AdminV2MonitoringEnvironment />);
-    // Flush the 300ms debounce on the series fetch
-    await new Promise((r) => setTimeout(r, 350));
-  });
+  render(<AdminV2MonitoringEnvironment />);
+  // Drive the 300ms debounce on the series fetch rather than sleeping through
+  // it: advanceTimersByTimeAsync runs the timer and flushes the promises it
+  // starts, so the data has landed by the time the assertions run. A real
+  // sleep left that to chance and read an empty page.
+  await act(async () => { await vi.advanceTimersByTimeAsync(400); });
+  await act(async () => { await vi.advanceTimersByTimeAsync(50); });
 };
 
 beforeEach(() => {
+  // The range window is computed from Date.now(), so the fixtures' July dates
+  // only fall inside it against a fixed clock. Only Date is faked — the
+  // 300ms debounce on the series fetch still has to run for real.
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-07-14T12:00:00Z'));
   chartInstances.length = 0;
   HTMLCanvasElement.prototype.getContext = vi.fn(() => ({}));
   // The page must use apiFetch (iframe bearer-token support), never raw
@@ -136,59 +156,162 @@ beforeEach(() => {
   }));
 });
 
-const latestChart = () => chartInstances[chartInstances.length - 1];
+afterEach(() => { vi.useRealTimers(); });
 
-describe('AdminV2MonitoringEnvironment', () => {
-  it('shows the informational disclaimer and metric/event chips', async () => {
+
+const chartFor = (label) => chartInstances
+  .filter((c) => !c.destroyed)
+  .find((c) => c.config.data.datasets[0]?.label === label);
+
+describe('the page keeps its clinical footing', () => {
+  it('states the full disclaimer, including that it is not a basis for care', async () => {
     await renderPage();
     expect(screen.getByText(/Informational only/)).toBeInTheDocument();
-    expect(screen.getByText(/not a basis for care decisions/)).toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: /Barometric pressure/ })).toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: /SpO2 alarms \(1\)/ })).toBeInTheDocument();
+    // The half a shorter rewrite tends to drop.
+    expect(screen.getByText(/not a basis for care\s+decisions/)).toBeInTheDocument();
+    expect(screen.getByText(/follow the care plan/)).toBeInTheDocument();
   });
 
-  it('derived metrics plot dashed; alert boxes land in the annotations', async () => {
+  it('says the scope is outdoor rather than leaving it assumed', async () => {
     await renderPage();
-    await waitFor(() => {
-      const chart = latestChart();
-      const delta = chart.config.data.datasets.find((d) => d.label === 'Pressure change over 6h (hPa)');
-      expect(delta.borderDash).toEqual([6, 4]);
-      const pressure = chart.config.data.datasets.find((d) => d.label === 'Barometric pressure (surface) (hPa)');
-      expect(pressure.borderDash).toEqual([]);
-      const annotations = chart.config.options.plugins.annotation.annotations;
-      expect(annotations.spo2_alarms_0.type).toBe('box');
-      expect(annotations.respiratory_care_0.type).toBe('line');
+    expect(screen.getByTitle('Room sensors not set up yet')).toBeDisabled();
+  });
+});
+
+describe('the metric stack', () => {
+  it('draws one chart per active metric, not one chart with two axes', async () => {
+    await renderPage();
+    const live = chartInstances.filter((c) => !c.destroyed);
+    expect(live).toHaveLength(2);
+    expect(live.map((c) => c.config.data.datasets[0].label).sort())
+      .toEqual(['Barometric pressure (surface)', 'Pressure change over 6h']);
+  });
+
+  it('is no longer capped at two metrics', async () => {
+    await renderPage();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Relative humidity/ }));
+      await vi.advanceTimersByTimeAsync(400);
     });
+    expect(chartInstances.filter((c) => !c.destroyed)).toHaveLength(3);
   });
 
-  it('renders an ok correlation card and an honest insufficient one', async () => {
+  it('refuses to empty the stack completely', async () => {
     await renderPage();
-    expect(await screen.findByText('2.1×')).toBeInTheDocument();
-    // Appears in both the stat line and the backend-built message
-    expect(screen.getAllByText(/95% CI 1.1–4.0/).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('Pattern observed')).toBeInTheDocument();
-    expect(screen.getByText(/Counted tasks: Cough Assist, Suction/)).toBeInTheDocument();
-    expect(screen.getByText('Not enough data yet')).toBeInTheDocument();
-    expect(screen.getByText(/2 of 5 needed/)).toBeInTheDocument();
+    for (const name of [/Pressure change over 6h/, /Barometric pressure/]) {
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name }));
+        await vi.advanceTimersByTimeAsync(400);
+      });
+    }
+    expect(chartInstances.filter((c) => !c.destroyed).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('changing the range preset refetches with the new days', async () => {
+  it('dashes a derived metric and leaves a measured one solid', async () => {
+    await renderPage();
+    expect(chartFor('Pressure change over 6h').config.data.datasets[0].borderDash)
+      .toEqual([5, 4]);
+    expect(chartFor('Barometric pressure (surface)').config.data.datasets[0].borderDash)
+      .toEqual([]);
+  });
+
+  it('shares one time window and one plot gutter across the stack', async () => {
+    await renderPage();
+    const live = chartInstances.filter((c) => !c.destroyed);
+    const xs = live.map((c) => [c.config.options.scales.x.min, c.config.options.scales.x.max]);
+    expect(xs[0]).toEqual(xs[1]);
+    // The alignment contract the lanes and scrubber also inset by.
+    const widths = live.map((c) => {
+      const scale = { width: 0 };
+      c.config.options.scales.y.afterFit(scale);
+      return scale.width;
+    });
+    expect(widths).toEqual([52, 52]);
+    const css = readFileSync(resolve(__dirname, 'monitoring-environment.css'), 'utf8');
+    expect(css).toMatch(/--env-gutter:\s*52px/);
+  });
+
+  it('only the bottom chart draws time labels', async () => {
+    await renderPage();
+    const shown = chartInstances.filter((c) => !c.destroyed)
+      .map((c) => c.config.options.scales.x.ticks.display);
+    expect(shown).toEqual([false, true]);
+  });
+
+  it('marks the zero line on a metric that goes negative', async () => {
+    await renderPage();
+    const delta = chartFor('Pressure change over 6h');
+    expect(delta.config.options.plugins.annotation.annotations.zero).toMatchObject({ yMin: 0 });
+    expect(chartFor('Barometric pressure (surface)')
+      .config.options.plugins.annotation.annotations.zero).toBeUndefined();
+  });
+});
+
+describe('clinical events', () => {
+  it('puts each stream in its own lane under the charts', async () => {
+    await renderPage();
+    const lanes = [...document.querySelectorAll('.env-lane-name')].map((n) => n.textContent);
+    expect(lanes).toEqual(['SpO2', 'Oxygen', 'Care', 'Symptoms']);
+  });
+
+  it('places a marker per event and leaves an empty stream visibly empty', async () => {
+    await renderPage();
+    const lanes = [...document.querySelectorAll('.env-lane')];
+    expect(lanes[0].querySelectorAll('.env-lane-mark')).toHaveLength(1);
+    expect(lanes[1].querySelector('.env-lane-empty')).toBeTruthy();
+  });
+
+  it('a stream can be switched off', async () => {
+    await renderPage();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^SpO2/ }));
+    });
+    const lanes = [...document.querySelectorAll('.env-lane-name')].map((n) => n.textContent);
+    expect(lanes).not.toContain('SpO2');
+  });
+});
+
+describe('personal patterns', () => {
+  it('lays the pairs out as triggers by outcomes', async () => {
+    await renderPage();
+    const grid = screen.getByRole('table');
+    const headers = within(grid).getAllByRole('columnheader').map((h) => h.textContent);
+    expect(headers[0]).toBe('Trigger');
+    expect(headers).toContain('Respiratory care events');
+    expect(headers).toContain('Logged symptoms');
+  });
+
+  it('shows a ratio that cleared the interval as a pattern', async () => {
+    await renderPage();
+    expect(screen.getByText('2.1×')).toBeInTheDocument();
+    expect(screen.getByText('Pattern observed')).toBeInTheDocument();
+  });
+
+  it('says how far a still-collecting pair has got, not just that it is short', async () => {
+    await renderPage();
+    // The old page said "Not enough data yet" with no sense of progress.
+    expect(screen.getByText(/Collecting|Not started/)).toBeInTheDocument();
+    expect(screen.getByText(/2 analyses are|1 analysis is/)).toBeInTheDocument();
+  });
+
+  it('keeps the counted care tasks visible for the reader to check', async () => {
+    await renderPage();
+    const cell = screen.getByText('2.1×').closest('td');
+    expect(cell.getAttribute('title')).toContain('Cough Assist, Suction');
+    expect(cell.getAttribute('title')).toContain('95% CI 1.1–4.0');
+  });
+});
+
+describe('range', () => {
+  it('refetches the analysis for the chosen range', async () => {
     await renderPage();
     apiFetchMock.mockClear();
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: '90d' }));
-      await new Promise((r) => setTimeout(r, 350));
+      fireEvent.click(screen.getByRole('button', { name: '90D' }));
+      await vi.advanceTimersByTimeAsync(400);
     });
-    await waitFor(() => {
-      const corrCall = apiFetchMock.mock.calls
-        .map((c) => String(c[0])).find((u) => u.includes('/env-correlations'));
-      expect(corrCall).toContain('days=90');
-    });
-  });
-
-  it('room picker stays disabled while only outdoor data exists', async () => {
-    await renderPage();
-    const select = screen.getByTitle('Room sensors not set up yet');
-    expect(select).toBeDisabled();
+    const call = apiFetchMock.mock.calls
+      .map((c) => String(c[0])).find((u) => u.includes('/env-correlations'));
+    expect(call).toContain('days=90');
   });
 });

--- a/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
+++ b/frontend/src/pages/admin-v2/AdminV2MonitoringTimeline.jsx
@@ -32,6 +32,9 @@ import config, { apiFetch } from '../../config';
 import { useAdminPatient } from '../../contexts/AdminPatientContext';
 import { alarmsFor } from './reports/dayOverDay';
 import {
+  PLOT_GUTTER, PLOT_RPAD, CHROME, niceScale, thresholdLine, stackedChartOptions,
+} from './monitoringChart';
+import {
   ENV_LANES, ENV_METRIC_KEYS, buildEnvSpans, worstStatus, describeSpan,
   severityOf, directionOf,
 } from './timelineEnv';
@@ -51,12 +54,6 @@ import {
 import './monitoring-timeline.css';
 
 Chart.register(annotationPlugin, zoomPlugin);
-
-/* Chart.js is forced to this y-axis width so both charts' plot areas start at
- * the same x, and the lanes and scrubber are inset by the same amount. Must
- * match --mtl-gutter / --mtl-rpad in monitoring-timeline.css. */
-const PLOT_GUTTER = 52;
-const PLOT_RPAD = 12;
 
 /* Series colours are the vc-derived ramp the reports already use for these
  * same two vitals (reports/weekly.js), not the mockup's crimson/indigo: red on
@@ -112,15 +109,6 @@ const ENV_UNITS = {
   temperature: '°C', relative_humidity: '%', co2: ' ppm', pm25: ' µg/m³',
 };
 
-const CHROME = {
-  grid: 'rgba(255, 255, 255, 0.06)',
-  axis: '#6b7987',
-  text: '#9aa8b8',
-  band: 'rgba(240, 86, 60, 0.14)',
-  bandEdge: 'rgba(240, 86, 60, 0.35)',
-  threshold: 'rgba(154, 168, 184, 0.5)',
-};
-
 /* Local calendar date, not the UTC one. toISOString() rolls over at UTC
  * midnight, so west of Greenwich an evening visit asked the API for
  * tomorrow and got an empty day. */
@@ -160,26 +148,6 @@ const eventLabel = (type, item) => {
     case 'vitals': return `${item.vital_type} ${item.value}${item.unit || ''}`;
     default: return '';
   }
-};
-
-/* A y range that fits the data and lands on readable numbers. Charting the
- * raw min/max gave axes labelled 58.08 and 119.2; stepping out to a round
- * boundary costs a few pixels of headroom and makes the axis legible. */
-const niceScale = (lo, hi, minSpan, clampMax) => {
-  let min = lo;
-  let max = hi;
-  if (max - min < minSpan) {
-    const centre = (min + max) / 2;
-    min = centre - minSpan / 2;
-    max = centre + minSpan / 2;
-  }
-  const raw = (max - min) / 4;
-  const mag = 10 ** Math.floor(Math.log10(raw));
-  const step = [1, 2, 2.5, 5, 10].map((m) => m * mag).find((c) => c >= raw) ?? 10 * mag;
-  min = Math.max(0, Math.floor(min / step) * step);
-  max = Math.ceil(max / step) * step;
-  if (clampMax != null) max = Math.min(clampMax, max);
-  return { min, max, step };
 };
 
 const alertLabel = (a) => {
@@ -916,26 +884,8 @@ const SignalChart = ({
         drawTime: 'beforeDatasetsDraw',
       };
     });
-    const line = (value, text) => ({
-      type: 'line',
-      yMin: value,
-      yMax: value,
-      borderColor: CHROME.threshold,
-      borderWidth: 1,
-      borderDash: [5, 4],
-      label: {
-        display: true,
-        content: text,
-        position: 'start',
-        backgroundColor: 'transparent',
-        color: CHROME.axis,
-        font: { size: 10, family: "'IBM Plex Mono', monospace" },
-        padding: 0,
-        yAdjust: -8,
-      },
-    });
-    if (alarms?.low != null) annotations.low = line(alarms.low, `LOW ${alarms.low}`);
-    if (alarms?.high != null) annotations.high = line(alarms.high, `HIGH ${alarms.high}`);
+    if (alarms?.low != null) annotations.low = thresholdLine(alarms.low, `LOW ${alarms.low}`);
+    if (alarms?.high != null) annotations.high = thresholdLine(alarms.high, `HIGH ${alarms.high}`);
 
     const chart = new Chart(canvas.getContext('2d'), {
       type: 'line',
@@ -952,66 +902,11 @@ const SignalChart = ({
           spanGaps: false,
         }],
       },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        animation: false,
-        events: [],                 // scrubbing is owned by the stack, not the canvas
-        layout: { padding: { right: PLOT_RPAD, top: 14, bottom: 0 } },
-        scales: {
-          x: {
-            type: 'time',
-            min: view?.min ?? bounds.start,
-            max: view?.max ?? bounds.end,
-            // No meridiem on minute ticks: at an hour wide they collided,
-            // and the scrubber pill already carries the full clock time.
-            time: { displayFormats: { minute: 'h:mm', hour: 'ha' } },
-            grid: { color: CHROME.grid, drawTicks: false },
-            border: { display: false },
-            ticks: {
-              display: showAxis,
-              color: CHROME.axis,
-              maxRotation: 0,
-              autoSkip: true,
-              autoSkipPadding: 16,
-              maxTicksLimit: 6,
-              font: { size: 10, family: "'IBM Plex Mono', monospace" },
-            },
-          },
-          y: {
-            min: yRange.min,
-            max: yRange.max,
-            grid: { color: CHROME.grid, drawTicks: false },
-            border: { display: false },
-            ticks: {
-              color: CHROME.axis,
-              stepSize: yRange.step,
-              maxTicksLimit: 6,
-              font: { size: 10, family: "'IBM Plex Mono', monospace" },
-            },
-            // Pin the axis width so this chart's plot area starts at exactly
-            // the same x as its sibling's and the lanes below.
-            afterFit: (scale) => { scale.width = PLOT_GUTTER; },
-          },
-        },
-        plugins: {
-          legend: { display: false },
-          tooltip: { enabled: false },
-          annotation: { annotations },
-          zoom: {
-            pan: { enabled: false },   // one-finger drag scrubs instead
-            zoom: {
-              wheel: { enabled: true },
-              pinch: { enabled: true },
-              mode: 'x',
-              onZoomComplete: ({ chart: c }) => {
-                onViewChangeRef.current({ min: c.scales.x.min, max: c.scales.x.max });
-              },
-            },
-            limits: { x: { min: bounds.start, max: bounds.end, minRange: MIN_RANGE_MS } },
-          },
-        },
-      },
+      options: stackedChartOptions({
+        view, bounds, yRange, showAxis, annotations,
+        minRangeMs: MIN_RANGE_MS,
+        onViewChange: (next) => onViewChangeRef.current(next),
+      }),
     });
     chartRef.current = chart;
     return () => { chart.destroy(); chartRef.current = null; };

--- a/frontend/src/pages/admin-v2/envPatterns.js
+++ b/frontend/src/pages/admin-v2/envPatterns.js
@@ -1,0 +1,126 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Reading the environmental correlation cards.
+//
+// The API returns one card per (exposure, outcome) pair, which as a flat list
+// buries the thing worth seeing: most pairs are still gathering data, and you
+// cannot tell how close any of them is. Pivoting to a trigger × outcome grid
+// puts coverage on one screen, and reading the backend's own counts back out
+// says how far along each cell is instead of a flat "not enough data".
+//
+// Nothing here decides whether an association is real — the backend owns that,
+// and its answer is deliberately hedged. A pattern that clears the confidence
+// interval is still an association in observational data.
+
+/* The thresholds the analysis applies before it will report a ratio. Mirrored
+ * from backend/analysis/env_correlation.py; a cell shows progress against
+ * whichever one it is currently short of. */
+export const MIN_EXPOSED_HOURS = 24;
+export const MIN_BASELINE_HOURS = 168;
+export const MIN_TOTAL_EVENTS = 5;
+
+/** How far a still-collecting cell has got, and towards what.
+ *
+ * The checks run in the backend's order, so the bar tracks the gate the cell
+ * is actually stuck behind rather than the first one that happens to be
+ * incomplete. Returns null when nothing countable has started yet — a metric
+ * with no observations at all has no progress to show, only a reason. */
+export function collectionProgress(card) {
+  if (!card || card.status === 'ok') return null;
+  const exposed = card.exposed_hours;
+  const baseline = card.baseline_hours;
+  if (exposed == null) return null;
+
+  if (exposed < MIN_EXPOSED_HOURS) {
+    return { have: exposed, need: MIN_EXPOSED_HOURS, unit: 'h', of: 'exposure' };
+  }
+  if (baseline != null && baseline < MIN_BASELINE_HOURS) {
+    return { have: baseline, need: MIN_BASELINE_HOURS, unit: 'h', of: 'baseline' };
+  }
+  const events = (card.exposed_events ?? 0) + (card.baseline_events ?? 0);
+  if (card.exposed_events != null && events < MIN_TOTAL_EVENTS) {
+    return { have: events, need: MIN_TOTAL_EVENTS, unit: '', of: 'events' };
+  }
+  return null;
+}
+
+/** One cell's verdict, in the terms the UI renders.
+ *
+ * `distinct` is the backend's confidence interval clearing 1 in one direction.
+ * It is deliberately not called "significant": the page says associations do
+ * not establish cause, and the wording has to hold that line. */
+export function cellStateOf(card) {
+  if (!card) return { kind: 'absent' };
+  if (card.status !== 'ok') {
+    return { kind: 'collecting', progress: collectionProgress(card), message: card.message };
+  }
+  const distinct = card.ci_low > 1 || card.ci_high < 1;
+  return {
+    kind: distinct ? 'pattern' : 'no-difference',
+    ratio: card.rate_ratio,
+    ciLow: card.ci_low,
+    ciHigh: card.ci_high,
+  };
+}
+
+/**
+ * Pivot the flat card list into rows of triggers by columns of outcomes.
+ *
+ * Row and column order follow first appearance rather than being sorted, so
+ * the grid matches the order the analysis reports its pairs in and does not
+ * reshuffle between refreshes.
+ */
+export function pivotCards(cards) {
+  const list = Array.isArray(cards) ? cards : [];
+  const outcomes = [];
+  const rows = [];
+
+  list.forEach((card) => {
+    const oKey = card.outcome?.key;
+    const eKey = card.exposure?.key;
+    if (!oKey || !eKey) return;
+    if (!outcomes.some((o) => o.key === oKey)) {
+      outcomes.push({ key: oKey, label: card.outcome.label });
+    }
+    let row = rows.find((r) => r.key === eKey);
+    if (!row) {
+      row = {
+        key: eKey,
+        label: card.exposure.label,
+        metric: card.exposure.metric,
+        estimated: card.exposure.quality === 'estimated',
+        cells: {},
+      };
+      rows.push(row);
+    }
+    row.cells[oKey] = card;
+  });
+
+  return { outcomes, rows };
+}
+
+/** How many pairs are still gathering, for the footer count. */
+export function stillCollecting(cards) {
+  return (Array.isArray(cards) ? cards : []).filter((c) => c.status !== 'ok').length;
+}
+
+/** Pairs that cleared the interval, worth surfacing above the grid. */
+export function observedPatterns(cards) {
+  return (Array.isArray(cards) ? cards : [])
+    .filter((c) => cellStateOf(c).kind === 'pattern');
+}

--- a/frontend/src/pages/admin-v2/envPatterns.test.js
+++ b/frontend/src/pages/admin-v2/envPatterns.test.js
@@ -1,0 +1,150 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Reading the correlation cards. The claims worth pinning are about what the
+// UI is allowed to say: a cell that is still gathering must say how far along
+// it is, and a ratio whose interval spans 1 must not read as a finding.
+import { describe, it, expect } from 'vitest';
+import {
+  pivotCards, cellStateOf, collectionProgress, stillCollecting, observedPatterns,
+  MIN_EXPOSED_HOURS, MIN_BASELINE_HOURS, MIN_TOTAL_EVENTS,
+} from './envPatterns';
+
+const card = (over = {}) => ({
+  exposure: { key: 'pressure_drop_6h', label: 'Pressure ↓ ≥4 / 6h', metric: 'pressure_delta_6h', quality: 'measured' },
+  outcome: { key: 'spo2_alarms', label: 'SpO2 alarms' },
+  status: 'ok',
+  rate_ratio: 2.1,
+  ci_low: 1.1,
+  ci_high: 4.0,
+  exposed_hours: 40,
+  baseline_hours: 400,
+  exposed_events: 6,
+  baseline_events: 20,
+  ...over,
+});
+
+describe('cellStateOf', () => {
+  it('reports a ratio whose interval clears 1 as a pattern', () => {
+    expect(cellStateOf(card())).toMatchObject({ kind: 'pattern', ratio: 2.1 });
+  });
+
+  it('reports a ratio whose interval spans 1 as no clear difference', () => {
+    // 1.3× looks like something until you see the interval crosses 1.
+    expect(cellStateOf(card({ rate_ratio: 1.3, ci_low: 0.8, ci_high: 2.2 })))
+      .toMatchObject({ kind: 'no-difference', ratio: 1.3 });
+  });
+
+  it('reports a protective interval as a pattern too', () => {
+    expect(cellStateOf(card({ rate_ratio: 0.4, ci_low: 0.2, ci_high: 0.8 })).kind)
+      .toBe('pattern');
+  });
+
+  it('distinguishes a pair never analysed from one still gathering', () => {
+    expect(cellStateOf(undefined)).toEqual({ kind: 'absent' });
+    expect(cellStateOf(card({ status: 'insufficient_data' })).kind).toBe('collecting');
+  });
+});
+
+describe('collectionProgress', () => {
+  it('tracks the exposure gate first', () => {
+    const p = collectionProgress(card({ status: 'insufficient_data', exposed_hours: 20 }));
+    expect(p).toEqual({ have: 20, need: MIN_EXPOSED_HOURS, unit: 'h', of: 'exposure' });
+  });
+
+  it('moves to the baseline gate once exposure is met', () => {
+    const p = collectionProgress(card({
+      status: 'insufficient_data', exposed_hours: 40, baseline_hours: 100,
+    }));
+    expect(p).toEqual({ have: 100, need: MIN_BASELINE_HOURS, unit: 'h', of: 'baseline' });
+  });
+
+  it('moves to the event gate once both hour gates are met', () => {
+    const p = collectionProgress(card({
+      status: 'insufficient_data', exposed_hours: 40, baseline_hours: 400,
+      exposed_events: 1, baseline_events: 1,
+    }));
+    expect(p).toEqual({ have: 2, need: MIN_TOTAL_EVENTS, unit: '', of: 'events' });
+  });
+
+  it('has no progress to show for a metric with no observations at all', () => {
+    // The backend returns this before it counts anything; a bar at 0/24h would
+    // imply collection has started when the metric is simply absent.
+    expect(collectionProgress({ status: 'insufficient_data', message: 'No pressure data yet.' }))
+      .toBeNull();
+  });
+
+  it('has no progress for a card that succeeded', () => {
+    expect(collectionProgress(card())).toBeNull();
+  });
+});
+
+describe('pivotCards', () => {
+  const cards = [
+    card(),
+    card({ outcome: { key: 'care_events', label: 'Care events' }, status: 'insufficient_data', exposed_hours: 20 }),
+    card({
+      exposure: { key: 'pressure_drop_24h', label: 'Pressure ↓ ≥6 / 24h', metric: 'pressure_delta_24h', quality: 'estimated' },
+      rate_ratio: 1.3, ci_low: 0.8, ci_high: 2.2,
+    }),
+  ];
+
+  it('builds a trigger by outcome grid', () => {
+    const { rows, outcomes } = pivotCards(cards);
+    expect(rows.map((r) => r.key)).toEqual(['pressure_drop_6h', 'pressure_drop_24h']);
+    expect(outcomes.map((o) => o.key)).toEqual(['spo2_alarms', 'care_events']);
+    expect(rows[0].cells.spo2_alarms.rate_ratio).toBe(2.1);
+  });
+
+  it('leaves a cell missing rather than inventing one', () => {
+    const { rows } = pivotCards(cards);
+    expect(rows[1].cells.care_events).toBeUndefined();
+    expect(cellStateOf(rows[1].cells.care_events).kind).toBe('absent');
+  });
+
+  it('carries the estimated-metric marker through', () => {
+    const { rows } = pivotCards(cards);
+    expect(rows[0].estimated).toBe(false);
+    expect(rows[1].estimated).toBe(true);
+  });
+
+  it('keeps first-appearance order so the grid does not reshuffle', () => {
+    const reversed = pivotCards([cards[2], cards[1], cards[0]]);
+    expect(reversed.rows.map((r) => r.key)).toEqual(['pressure_drop_24h', 'pressure_drop_6h']);
+  });
+
+  it('survives a missing or malformed payload', () => {
+    expect(pivotCards(null)).toEqual({ outcomes: [], rows: [] });
+    expect(pivotCards([{ nonsense: true }])).toEqual({ outcomes: [], rows: [] });
+  });
+});
+
+describe('summaries', () => {
+  it('counts what is still gathering', () => {
+    expect(stillCollecting([card(), card({ status: 'insufficient_data' })])).toBe(1);
+    expect(stillCollecting(null)).toBe(0);
+  });
+
+  it('surfaces only the pairs that cleared the interval', () => {
+    const found = observedPatterns([
+      card(),
+      card({ rate_ratio: 1.3, ci_low: 0.8, ci_high: 2.2 }),
+      card({ status: 'insufficient_data' }),
+    ]);
+    expect(found).toHaveLength(1);
+  });
+});

--- a/frontend/src/pages/admin-v2/monitoring-environment.css
+++ b/frontend/src/pages/admin-v2/monitoring-environment.css
@@ -336,6 +336,17 @@
 
 /* ---------- personal patterns grid ---------- */
 .env-grid-wrap { overflow-x: auto; }
+
+/* Wide screens: the trigger column stays put while the outcomes scroll, so a
+   cell never loses the row it belongs to. */
+.env-grid-trigger,
+.env-grid thead th:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--vc-bg-surface);
+}
+.env-grid thead th:first-child { background: var(--vc-bg-raised); }
 .env-grid {
   border-collapse: collapse;
   width: 100%;
@@ -452,4 +463,62 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+
+/* ---------- the grid on a phone ----------
+   Four outcome columns beside a wrapping trigger cannot be scrolled sideways
+   and still make sense: the header row leaves the screen and every cell turns
+   into an orphaned "Collecting 20/24h". Below this width the table reflows
+   into one card per trigger, each cell naming its own outcome from
+   data-label, and the horizontal scroll goes away entirely. */
+@media (max-width: 720px) {
+  .env-grid-wrap { overflow-x: visible; }
+  .env-grid { min-width: 0; display: block; }
+  .env-grid thead { display: none; }
+  .env-grid tbody { display: block; }
+
+  .env-grid tr {
+    display: block;
+    padding: 0.15rem 0 0.5rem;
+    border-bottom: 1px solid var(--vc-line-strong);
+  }
+  .env-grid tbody tr:last-child { border-bottom: none; }
+
+  .env-grid td {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.3rem 0.9rem;
+    border-bottom: none;
+  }
+  .env-grid td::before {
+    content: attr(data-label);
+    flex: 0 1 auto;
+    font-family: var(--vc-font-mono);
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--vc-text-secondary);
+  }
+
+  /* The trigger becomes the card's heading rather than a labelled row. */
+  .env-grid-trigger {
+    position: static;
+    display: block;
+    padding: 0.6rem 0.9rem 0.35rem;
+  }
+  .env-grid-trigger::before { content: none; }
+  .env-grid-trigger b { font-size: 0.95rem; }
+
+  /* Values sit right-aligned against their label, so the column of numbers
+     still reads down the card. */
+  .env-collecting { align-items: flex-end; min-width: 0; flex: 0 1 60%; }
+  .env-collecting .env-bar { width: 100%; min-width: 90px; }
+  .env-cell-verdict { text-align: right; }
+  .env-cell.pattern,
+  .env-cell { text-align: right; }
 }

--- a/frontend/src/pages/admin-v2/monitoring-environment.css
+++ b/frontend/src/pages/admin-v2/monitoring-environment.css
@@ -1,0 +1,455 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Environment — vc-native, dark by design in both app themes, the stance
+ * monitoring-timeline.css and monitoring-ventilator.css take. Tokens only.
+ *
+ * --env-gutter must equal PLOT_GUTTER in monitoringChart.js: the charts, the
+ * event lanes and the scrubber all inset by it, and a moment has to land on
+ * the same x in each. */
+@import '../../styles/vc-tokens.css';
+
+.env {
+  --env-gutter: 52px;
+  --env-rpad: 12px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-sans);
+  font-variant-numeric: tabular-nums;
+}
+.env *,
+.env *::before,
+.env *::after { box-sizing: border-box; }
+
+.env-label {
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* ---------- cards ---------- */
+.env-card {
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 10px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+.env-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid var(--vc-line-hairline);
+}
+.env-card-head h3 {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+
+/* ---------- outdoor / room conditions strip ---------- */
+.env-now {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+.env-now-cell {
+  padding: 0.7rem 0.9rem;
+  border-right: 1px solid var(--vc-line-hairline);
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+.env-now-cell:last-child { border-right: none; }
+.env-now-name {
+  font-family: var(--vc-font-mono);
+  font-size: 0.64rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.env-now-value {
+  font-family: var(--vc-font-mono);
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.1;
+  color: var(--tone, var(--vc-text-primary));
+}
+.env-now-value small {
+  font-size: 0.6rem;
+  font-weight: 400;
+  color: var(--vc-text-secondary);
+  margin-left: 0.25rem;
+}
+.env-now-sub {
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  color: var(--vc-text-tertiary);
+}
+.env-now-sub.rising { color: var(--vc-state-due); }
+.env-now-sub.falling { color: var(--vc-state-alert); }
+.env-tone-ok { --tone: var(--vc-state-complete); }
+.env-tone-caution { --tone: var(--vc-state-due); }
+.env-tone-critical { --tone: var(--vc-state-alert); }
+
+@media (max-width: 620px) {
+  .env-now-cell { border-right: none; border-bottom: 1px solid var(--vc-line-hairline); }
+  .env-now-cell:last-child { border-bottom: none; }
+}
+
+/* ---------- controls ---------- */
+.env-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.env-range {
+  display: inline-flex;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 9px;
+  background: var(--vc-bg-surface);
+  overflow: hidden;
+}
+.env-range button {
+  min-width: 54px;
+  height: 34px;
+  padding: 0 0.6rem;
+  border: none;
+  border-right: 1px solid var(--vc-line-hairline);
+  background: transparent;
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+.env-range button:last-child { border-right: none; }
+.env-range button:hover { color: var(--vc-text-primary); }
+.env-range button.on {
+  background: color-mix(in srgb, var(--vc-data-live) 20%, transparent);
+  color: var(--vc-data-live);
+}
+.env-spacer { flex: 1 1 auto; }
+
+/* Metric and stream toggles carry their colour inline as --sig, so one rule
+   serves every series and the page holds no colour map of its own. */
+.env-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  height: 34px;
+  padding: 0 0.75rem;
+  border: 1px solid var(--sig, var(--vc-line-strong));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--sig, var(--vc-data-live)) 12%, transparent);
+  color: var(--sig, var(--vc-text-primary));
+  font-family: var(--vc-font-sans);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.env-chip[aria-pressed='false'] {
+  border-color: var(--vc-line-hairline);
+  background: transparent;
+  color: var(--vc-text-tertiary);
+}
+.env-chip-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+.env-chip-dot.dashed {
+  border-radius: 2px;
+  height: 3px;
+  width: 12px;
+}
+.env-chip-note { font-size: 0.68rem; font-weight: 400; opacity: 0.75; }
+
+.env-roompick {
+  height: 34px;
+  padding: 0 0.5rem;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  background: var(--vc-bg-surface);
+  color: var(--vc-text-secondary);
+  font-family: var(--vc-font-mono);
+  font-size: 0.72rem;
+  color-scheme: dark;
+}
+
+/* ---------- chart stack ---------- */
+.env-stack { position: relative; touch-action: pan-y; }
+.env-chart { position: relative; height: 150px; }
+.env-chart.tall { height: 176px; }
+.env-chart-title {
+  position: absolute;
+  top: 2px;
+  left: var(--env-gutter);
+  z-index: 1;
+  font-family: var(--vc-font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+.env-chart-title small {
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  color: var(--vc-text-tertiary);
+  margin-left: 0.35rem;
+}
+
+.env-plotbox {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--env-gutter);
+  right: var(--env-rpad);
+  pointer-events: none;
+}
+.env-scrub {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--vc-data-live);
+  transform: translateX(-0.5px);
+}
+.env-scrub-pill {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.15rem 0.45rem;
+  border-radius: 5px;
+  background: var(--vc-data-live);
+  color: var(--vc-bg-base);
+  font-family: var(--vc-font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* ---------- event lanes ---------- */
+.env-lanes { border-top: 1px solid var(--vc-line-hairline); padding-top: 0.4rem; }
+.env-lanes-title {
+  padding: 0 0.9rem 0.3rem;
+  font-family: var(--vc-font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+}
+.env-lane {
+  display: flex;
+  align-items: stretch;
+  min-height: 30px;
+  border-top: 1px solid var(--vc-line-hairline);
+}
+.env-lane-name {
+  width: var(--env-gutter);
+  flex-shrink: 0;
+  padding-right: 0.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-family: var(--vc-font-mono);
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-align: right;
+  line-height: 1.1;
+  color: var(--lane, var(--vc-text-secondary));
+}
+.env-lane-track {
+  position: relative;
+  flex: 1;
+  margin-right: var(--env-rpad);
+  border-left: 1px solid var(--vc-line-hairline);
+}
+.env-lane-mark {
+  position: absolute;
+  top: 50%;
+  width: 3px;
+  height: 14px;
+  margin: -7px 0 0 -1.5px;
+  padding: 0;
+  border: none;
+  border-radius: 1px;
+  background: var(--lane, var(--vc-data-live));
+  cursor: pointer;
+}
+.env-lane-mark:hover { outline: 2px solid var(--vc-text-primary); outline-offset: 1px; }
+.env-lane-empty {
+  position: absolute;
+  top: 50%;
+  left: 0.5rem;
+  transform: translateY(-50%);
+  font-size: 0.68rem;
+  color: var(--vc-text-tertiary);
+}
+
+.env-hint {
+  font-size: 0.72rem;
+  color: var(--vc-text-tertiary);
+  padding-left: 0.15rem;
+}
+
+/* ---------- personal patterns grid ---------- */
+.env-grid-wrap { overflow-x: auto; }
+.env-grid {
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 520px;
+  font-size: 0.82rem;
+}
+.env-grid th,
+.env-grid td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--vc-line-hairline);
+  vertical-align: middle;
+}
+.env-grid thead th {
+  font-family: var(--vc-font-mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vc-text-secondary);
+  background: var(--vc-bg-raised);
+  white-space: nowrap;
+}
+.env-grid tbody tr:last-child td { border-bottom: none; }
+.env-grid-trigger { min-width: 170px; }
+.env-grid-trigger b { font-weight: 600; }
+.env-grid-trigger span {
+  display: block;
+  font-size: 0.66rem;
+  color: var(--vc-text-tertiary);
+}
+
+.env-cell-ratio {
+  font-family: var(--vc-font-mono);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+}
+.env-cell-verdict {
+  display: block;
+  font-family: var(--vc-font-mono);
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.env-cell.pattern .env-cell-ratio { color: var(--vc-data-live); }
+.env-cell.pattern .env-cell-verdict { color: var(--vc-data-live); }
+.env-cell-none { color: var(--vc-text-tertiary); }
+
+.env-collecting {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 108px;
+}
+.env-collecting span {
+  font-family: var(--vc-font-mono);
+  font-size: 0.68rem;
+  color: var(--vc-text-secondary);
+  white-space: nowrap;
+}
+.env-bar {
+  position: relative;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--vc-line-hairline);
+  overflow: hidden;
+}
+.env-bar i {
+  position: absolute;
+  inset: 0 auto 0 0;
+  display: block;
+  border-radius: 2px;
+  background: var(--vc-state-due);
+}
+
+.env-foot {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.9rem;
+  border-top: 1px solid var(--vc-line-hairline);
+  font-size: 0.75rem;
+  color: var(--vc-text-tertiary);
+}
+.env-foot svg { flex-shrink: 0; }
+
+/* ---------- states ---------- */
+.env-empty {
+  padding: 2.5rem 1rem;
+  text-align: center;
+  color: var(--vc-text-secondary);
+  font-size: 0.9rem;
+}
+.env-note { margin: 0; padding: 0.5rem 0.9rem; font-size: 0.74rem; color: var(--vc-text-tertiary); }
+.env-error {
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--vc-state-alert);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
+  color: var(--vc-text-primary);
+  font-size: 0.88rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/src/pages/admin-v2/monitoringChart.js
+++ b/frontend/src/pages/admin-v2/monitoringChart.js
@@ -1,0 +1,167 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The shape every stacked monitoring chart shares.
+//
+// The timeline and the environment view both draw several signals above a row
+// of event lanes, and all of it has to line up: a moment must land on the same
+// x in every chart and every lane, or a marker points at the wrong sample.
+// That alignment is a contract between three things — the chart's y-axis
+// width, the lanes' left inset, and the scrubber's — and it only holds while
+// they agree on one number. Keeping the number and the options builder here
+// means the two pages cannot drift apart by editing one of them.
+//
+// PLOT_GUTTER must match --mtl-gutter / --env-gutter in the pages' stylesheets.
+
+export const PLOT_GUTTER = 52;
+export const PLOT_RPAD = 12;
+
+export const CHROME = {
+  grid: 'rgba(255, 255, 255, 0.06)',
+  axis: '#6b7987',
+  band: 'rgba(240, 86, 60, 0.14)',
+  bandEdge: 'rgba(240, 86, 60, 0.35)',
+  threshold: 'rgba(154, 168, 184, 0.5)',
+};
+
+const MONO = "'IBM Plex Mono', monospace";
+
+/** A y range that fits the data and lands on readable numbers.
+ *
+ * Charting the raw min/max gave axes labelled 58.08 and 119.2; stepping out to
+ * a round boundary costs a few pixels of headroom and makes the axis legible.
+ * `clampMin` is opt-out because pressure deltas legitimately go negative and
+ * flooring them at zero would hide half the signal. */
+export function niceScale(lo, hi, minSpan, clampMax, { clampMin = true } = {}) {
+  let min = lo;
+  let max = hi;
+  if (max - min < minSpan) {
+    const centre = (min + max) / 2;
+    min = centre - minSpan / 2;
+    max = centre + minSpan / 2;
+  }
+  const raw = (max - min) / 4;
+  const mag = 10 ** Math.floor(Math.log10(raw));
+  const step = [1, 2, 2.5, 5, 10].map((m) => m * mag).find((c) => c >= raw) ?? 10 * mag;
+  min = Math.floor(min / step) * step;
+  if (clampMin) min = Math.max(0, min);
+  max = Math.ceil(max / step) * step;
+  if (clampMax != null) max = Math.min(clampMax, max);
+  return { min, max, step };
+}
+
+/** A horizontal reference line — an alarm limit, or a configured bound. */
+export function thresholdLine(value, text) {
+  return {
+    type: 'line',
+    yMin: value,
+    yMax: value,
+    borderColor: CHROME.threshold,
+    borderWidth: 1,
+    borderDash: [5, 4],
+    label: {
+      display: true,
+      content: text,
+      position: 'start',
+      backgroundColor: 'transparent',
+      color: CHROME.axis,
+      font: { size: 10, family: MONO },
+      padding: 0,
+      yAdjust: -8,
+    },
+  };
+}
+
+/**
+ * Chart.js options for one signal in a stack.
+ *
+ * `showAxis` belongs to the bottom chart only — the others keep the same scale
+ * so the grid lines still align, but drawing every chart's time labels would
+ * repeat the axis three times down the page.
+ */
+export function stackedChartOptions({
+  view,
+  bounds,
+  yRange,
+  showAxis,
+  annotations = {},
+  timeFormats = { minute: 'h:mm', hour: 'ha' },
+  onViewChange,
+  minRangeMs = 60_000,
+  maxTicks = 6,
+}) {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false,
+    // Pointer handling belongs to the stack, not to any one canvas: a drag has
+    // to mean the same thing whichever chart it started over.
+    events: [],
+    layout: { padding: { right: PLOT_RPAD, top: 14, bottom: 0 } },
+    scales: {
+      x: {
+        type: 'time',
+        min: view?.min ?? bounds.start,
+        max: view?.max ?? bounds.end,
+        time: { displayFormats: timeFormats },
+        grid: { color: CHROME.grid, drawTicks: false },
+        border: { display: false },
+        ticks: {
+          display: showAxis,
+          color: CHROME.axis,
+          maxRotation: 0,
+          autoSkip: true,
+          autoSkipPadding: 16,
+          maxTicksLimit: maxTicks,
+          font: { size: 10, family: MONO },
+        },
+      },
+      y: {
+        min: yRange.min,
+        max: yRange.max,
+        grid: { color: CHROME.grid, drawTicks: false },
+        border: { display: false },
+        ticks: {
+          color: CHROME.axis,
+          stepSize: yRange.step,
+          maxTicksLimit: 6,
+          font: { size: 10, family: MONO },
+        },
+        // Pin the axis width so this chart's plot area starts at exactly the
+        // same x as its siblings' and the lanes below.
+        afterFit: (scale) => { scale.width = PLOT_GUTTER; },
+      },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: false },
+      annotation: { annotations },
+      zoom: {
+        pan: { enabled: false },
+        zoom: {
+          wheel: { enabled: true },
+          pinch: { enabled: true },
+          mode: 'x',
+          onZoomComplete: ({ chart: c }) => {
+            onViewChange?.({ min: c.scales.x.min, max: c.scales.x.max });
+          },
+        },
+        limits: { x: { min: bounds.start, max: bounds.end, minRange: minRangeMs } },
+      },
+    },
+  };
+}


### PR DESCRIPTION
Brings Environment in line with Timeline and Ventilator. It was the last monitoring page still styled inline — no stylesheet, 19 raw hex values, the Material palette — and it capped you at two metrics because eight were being squeezed onto one chart's two y-axes.

## What changed

**One chart per metric**, sharing a time window, with the clinical events as lanes beneath rather than annotations drawn through the traces. Plus a scrubber across the stack. The two-metric cap is gone.

**The alignment contract moved into `monitoringChart.js`.** The chart's y-axis width, the lanes' inset and the scrubber's all have to agree on one number or a marker points at the wrong sample. Rather than copy the number across, I refactored the Timeline onto the shared module too — copying is how they drift apart. The Timeline's 32 tests cover exactly that geometry and pass unchanged.

**Correlation cards become a trigger × outcome grid.** As a flat list they buried the useful fact: most pairs are still gathering, and nothing said how close any was. Each waiting cell now reads its progress out of the backend's own counters against the gate it's actually stuck behind — `Collecting 20/24h` instead of `Not enough data yet`. The gates and their thresholds are mirrored from `env_correlation.py`.

## Things I put back after taking them out

Worth calling out, because both were mine to get wrong:

- **The disclaimer is verbatim, not paraphrased.** My first pass shortened it to "Observational only — an association does not establish cause", which kept the epistemics and dropped *"it is not a basis for care decisions — follow the care plan for any intervention"*. That's the half that matters. The existing test caught it.
- **The scope select stays, disabled.** Everything here is outdoor until room ingestion lands (#48). Saying so beats letting a reader assume the room is covered.

Also: metric labels, units and the `derived` flag now come from the catalog rather than a hardcoded map, so a newly-derived metric dashes without a code change. The catalog is a list, and my first pass indexed it as a map — silently missing every lookup.

## A real test bug found on the way

The page test slept 350ms past the 300ms debounce. That let the fetches resolve *after* the assertions ran, so every data-dependent check was quietly passing against an empty page. It now drives the debounce with `advanceTimersByTimeAsync`, which runs the timer and flushes the promises it starts.

The new lane-marker test fails against the old sleep-based harness, which is how I found it. Same family as the three CI flakes in the last two PRs — waiting on a proxy for readiness instead of the thing being asserted.

## Not done

Per-patient bounds are still unwired here, deliberately. `patient_env_ranges` is room-scoped by design — the bounds describe the air the patient is in — and this page is outdoor-only, so wiring them would mean colouring outdoor readings against room thresholds. That wants room scope first. PM2.5's band on the strip uses the published US AQI breakpoints and is labelled as such, not as anything patient-specific.

Pinning also deferred; the analysis direction is still open.

## Verification

- 1110 frontend tests / 87 files, lint clean at `--max-warnings 0`, build fine
- New: 16 tests on the pattern-reading logic, 17 on the page
- Backend untouched

**Not verified visually** — I can't log into the local stack, so this is verified by tests and CSS. Worth a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131eFmnRFvybi3nrNHMWppP