### PR TITLE
Let the live board opt into the vc form skin

### DIFF
--- a/frontend/src/contexts/DashboardThemeContext.jsx
+++ b/frontend/src/contexts/DashboardThemeContext.jsx
@@ -54,10 +54,23 @@ export function DashboardThemeProvider({ children }) {
   // dashboard wrapper, so they can't inherit the board's dark tokens. Pin
   // them dark on <html> while the live dashboard is mounted (see the
   // `:root.dash-scheme-dark` block in App.css).
+  //
+  // `vc-form-skin` on <body> is the same opt-in the admin makes in
+  // AdminV2Layout: it turns on vc-forms.css for the shared shadcn primitives
+  // (the Equipment/Settings/Camera panels and the dialogs the rebuilt panels
+  // open). It goes on <body>, not the board wrapper, so it also reaches the
+  // portalled Select/Dialog content. /live and /care never co-mount, so the
+  // two owners can't strip each other's class. Both sheets gate on
+  // `:root:is(:not(.light), .dash-scheme-dark)`, so a light-theme user still
+  // gets the dark skin on the dark-only board.
   useEffect(() => {
     const el = document.documentElement;
     el.classList.add('dash-scheme-dark');
-    return () => el.classList.remove('dash-scheme-dark');
+    document.body.classList.add('vc-form-skin');
+    return () => {
+      el.classList.remove('dash-scheme-dark');
+      document.body.classList.remove('vc-form-skin');
+    };
   }, []);
 
   return (

--- a/frontend/src/contexts/DashboardThemeContext.test.jsx
+++ b/frontend/src/contexts/DashboardThemeContext.test.jsx
@@ -31,9 +31,11 @@ function Probe() {
 
 beforeEach(() => {
   document.documentElement.className = '';
+  document.body.className = '';
 });
 afterEach(() => {
   document.documentElement.className = '';
+  document.body.className = '';
 });
 
 describe('DashboardThemeProvider', () => {
@@ -55,6 +57,20 @@ describe('DashboardThemeProvider', () => {
     expect(document.documentElement.classList.contains('dash-scheme-dark')).toBe(true);
     unmount();
     expect(document.documentElement.classList.contains('dash-scheme-dark')).toBe(false);
+  });
+
+  // The admin's form skin (vc-forms.css) is opted into per surface via a body
+  // class; the live board opts in for its lifetime so shadcn primitives and
+  // portalled dialogs on /live get the same skin as under /care.
+  it('opts the live board into the vc form skin while mounted', () => {
+    const { unmount } = render(
+      <DashboardThemeProvider>
+        <Probe />
+      </DashboardThemeProvider>
+    );
+    expect(document.body.classList.contains('vc-form-skin')).toBe(true);
+    unmount();
+    expect(document.body.classList.contains('vc-form-skin')).toBe(false);
   });
 
   it('exposes a complete chrome for recharts consumers', () => {

--- a/frontend/src/pages/admin-v2/vc-content.css
+++ b/frontend/src/pages/admin-v2/vc-content.css
@@ -23,8 +23,10 @@
  * classes picks it up — the medications / care-tasks / nutrition families
  * are built almost entirely from them.
  *
- * DARK THEME ONLY (scoped :root:not(.light)). Tokens from
- * src/styles/vc-tokens.css; no raw hex.
+ * DARK THEME ONLY. Scoped `:root:is(:not(.light), .dash-scheme-dark)` — the
+ * admin's html theme class OR the live board's `dash-scheme-dark`, which is
+ * dark-only whatever the saved theme (same specificity as `:not(.light)`).
+ * Tokens from src/styles/vc-tokens.css; no raw hex.
  *
  * Color roles: schedule adherence is NEVER red — due/late/missed are
  * amber (--vc-state-due); green means done/active; cyan is the live or
@@ -37,7 +39,7 @@
    that class rather than through the html theme class. Without it, a user whose
    theme is light gets ScheduleList's bootstrap *light* fallbacks on the dark
    board. */
-:root:not(.light),
+:root:is(:not(.light), .dash-scheme-dark),
 .force-dark {
   --sched-ontime-bg: color-mix(in srgb, var(--vc-state-due) 8%, var(--vc-bg-raised));
   --sched-ontime-border: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
@@ -72,9 +74,9 @@
  * selects — re-reads its palette from the vc tokens in dark theme. Scoped
  * to the islands and the Radix portal slots, NOT :root, so legacy CSS that
  * reads the same var names keeps the old palette until its page is skinned. */
-:root:not(.light) .tw,
-:root:not(.light) [data-slot='dialog-content'],
-:root:not(.light) [data-slot='select-content'] {
+:root:is(:not(.light), .dash-scheme-dark) .tw,
+:root:is(:not(.light), .dash-scheme-dark) [data-slot='dialog-content'],
+:root:is(:not(.light), .dash-scheme-dark) [data-slot='select-content'] {
   --background: var(--vc-bg-base);
   --foreground: var(--vc-text-primary);
   --card: var(--vc-bg-surface);
@@ -99,7 +101,7 @@
 
 /* Legend dots / stat-icon chips on the schedule pages consume these as
  * inline-style vars (bootstrap-ish fallbacks keep the light theme). */
-:root:not(.light) {
+:root:is(:not(.light), .dash-scheme-dark) {
   --sched-ontime-chip: color-mix(in srgb, var(--vc-state-due) 15%, transparent);
   --sched-pending-chip: var(--vc-bg-raised);
   --sched-warning-chip: color-mix(in srgb, var(--vc-state-due) 20%, transparent);
@@ -109,27 +111,27 @@
 }
 
 /* ---------- Page headers / sections ---------- */
-:root:not(.light) .admin-v2-page-header h1,
-:root:not(.light) .admin-v2-section-title {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-page-header h1,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-section-title {
   font-family: var(--vc-font-mono);
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-text-muted { color: var(--vc-text-secondary); }
-:root:not(.light) .admin-v2-loading,
-:root:not(.light) .admin-v2-empty-state,
-:root:not(.light) .admin-v2-no-patient { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-text-muted { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-loading,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-empty-state,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-no-patient { color: var(--vc-text-secondary); }
 
 /* ---------- Tables ---------- */
-:root:not(.light) .admin-v2-table-container {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-table-container {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
   box-shadow: none;
 }
-:root:not(.light) .admin-v2-table th {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-table th {
   background: var(--vc-bg-surface);
   color: var(--vc-text-secondary);
   font-family: var(--vc-font-mono);
@@ -139,86 +141,86 @@
   text-transform: uppercase;
   border-bottom: 1px solid var(--vc-line-strong);
 }
-:root:not(.light) .admin-v2-table td {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-table td {
   border-bottom: 1px solid var(--vc-line-hairline);
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-table tr:hover { background: var(--vc-bg-raised); }
-:root:not(.light) .admin-v2-table tr.inactive-row td { color: var(--vc-text-tertiary); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-table tr:hover { background: var(--vc-bg-raised); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-table tr.inactive-row td { color: var(--vc-text-tertiary); }
 
 /* ---------- Stat cards as filter chips ---------- */
-:root:not(.light) .admin-v2-stat-card.selected {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-stat-card.selected {
   border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
   box-shadow: inset 0 -2px 0 var(--vc-data-live);
 }
-:root:not(.light) .admin-v2-stat-card.selected .admin-v2-stat-info h4 {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-stat-card.selected .admin-v2-stat-info h4 {
   color: var(--vc-data-live);
 }
 
 /* ---------- Action buttons (table row + card controls) ---------- */
-:root:not(.light) .admin-v2-action-btn {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn {
   background: transparent;
   border: 1px solid var(--vc-line-hairline);
   border-radius: 8px;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .admin-v2-action-btn:hover {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn:hover {
   border-color: var(--vc-line-strong);
   background: var(--vc-bg-raised);
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-action-btn-delete:hover {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn-delete:hover {
   border-color: color-mix(in srgb, var(--vc-state-alert) 60%, transparent);
   color: var(--vc-state-alert);
 }
-:root:not(.light) .admin-v2-action-btn-success:hover,
-:root:not(.light) .admin-v2-action-btn.resume:hover {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn-success:hover,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn.resume:hover {
   border-color: color-mix(in srgb, var(--vc-state-complete) 60%, transparent);
   color: var(--vc-state-complete);
 }
-:root:not(.light) .admin-v2-action-btn-warning:hover,
-:root:not(.light) .admin-v2-action-btn.pause:hover {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn-warning:hover,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn.pause:hover {
   border-color: color-mix(in srgb, var(--vc-state-due) 60%, transparent);
   color: var(--vc-state-due);
 }
 
 /* ---------- Buttons ---------- */
-:root:not(.light) .admin-v2-btn {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn {
   border-radius: 8px;
   font-family: var(--vc-font-mono);
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
-:root:not(.light) .admin-v2-btn-primary {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-primary {
   background: var(--vc-data-live);
   border-color: transparent;
   color: var(--vc-bg-base);
 }
-:root:not(.light) .admin-v2-btn-primary:hover {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-primary:hover {
   background: color-mix(in srgb, var(--vc-data-live) 85%, var(--vc-text-primary));
 }
-:root:not(.light) .admin-v2-btn-secondary,
-:root:not(.light) .admin-v2-btn-ghost {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-secondary,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-ghost {
   background: transparent;
   border: 1px solid var(--vc-line-strong);
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-btn-secondary:hover,
-:root:not(.light) .admin-v2-btn-ghost:hover { background: var(--vc-bg-raised); }
-:root:not(.light) .admin-v2-btn-danger {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-secondary:hover,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-ghost:hover { background: var(--vc-bg-raised); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-danger {
   background: var(--vc-state-alert);
   border-color: transparent;
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-btn-danger-ghost {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-danger-ghost {
   background: transparent;
   border: 1px solid color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
   color: var(--vc-state-alert);
 }
 
 /* ---------- Badges: outline pills, roles not rainbow ---------- */
-:root:not(.light) .admin-v2-badge {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge {
   background: transparent;
   border: 1px solid var(--vc-line-strong);
   border-radius: 999px;
@@ -229,32 +231,32 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
-:root:not(.light) .admin-v2-badge-success {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-success {
   border-color: color-mix(in srgb, var(--vc-state-complete) 50%, transparent);
   color: var(--vc-state-complete);
 }
-:root:not(.light) .admin-v2-badge-warning {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-warning {
   border-color: color-mix(in srgb, var(--vc-state-due) 50%, transparent);
   color: var(--vc-state-due);
 }
-:root:not(.light) .admin-v2-badge-danger,
-:root:not(.light) .admin-v2-badge-critical {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-danger,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-critical {
   border-color: color-mix(in srgb, var(--vc-state-alert) 50%, transparent);
   color: var(--vc-state-alert);
 }
-:root:not(.light) .admin-v2-badge-info,
-:root:not(.light) .admin-v2-badge-primary {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-info,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-primary {
   border-color: color-mix(in srgb, var(--vc-data-live) 50%, transparent);
   color: var(--vc-data-live);
 }
-:root:not(.light) .admin-v2-badge-secondary,
-:root:not(.light) .admin-v2-badge-muted {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-secondary,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-muted {
   border-color: var(--vc-line-hairline);
   color: var(--vc-text-tertiary);
 }
 
 /* Active/inactive status pills (meds, schedules, tasks) — dot + outline */
-:root:not(.light) .admin-v2-status-badge {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-status-badge {
   background: transparent;
   border: 1px solid var(--vc-line-strong);
   border-radius: 999px;
@@ -268,25 +270,25 @@
   align-items: center;
   gap: 0.35rem;
 }
-:root:not(.light) .admin-v2-status-badge::before {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-status-badge::before {
   content: '';
   width: 6px;
   height: 6px;
   border-radius: 50%;
   background: currentColor;
 }
-:root:not(.light) .admin-v2-status-badge.active {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-status-badge.active {
   color: var(--vc-state-complete);
   border-color: color-mix(in srgb, var(--vc-state-complete) 45%, transparent);
 }
-:root:not(.light) .admin-v2-status-badge.inactive {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-status-badge.inactive {
   color: var(--vc-text-tertiary);
   border-color: var(--vc-line-hairline);
 }
 
 /* History dose-status badges: 'danger' here means a LATE dose — schedule
  * adherence, so amber, not red. */
-:root:not(.light) .history-status-badge {
+:root:is(:not(.light), .dash-scheme-dark) .history-status-badge {
   border-radius: 999px;
   font-family: var(--vc-font-mono);
   font-size: 10px;
@@ -294,31 +296,31 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
-:root:not(.light) .history-status-badge.success {
+:root:is(:not(.light), .dash-scheme-dark) .history-status-badge.success {
   background: color-mix(in srgb, var(--vc-state-complete) 14%, transparent);
   color: var(--vc-state-complete);
 }
-:root:not(.light) .history-status-badge.warning {
+:root:is(:not(.light), .dash-scheme-dark) .history-status-badge.warning {
   background: color-mix(in srgb, var(--vc-state-due) 14%, transparent);
   color: var(--vc-state-due);
 }
-:root:not(.light) .history-status-badge.danger {
+:root:is(:not(.light), .dash-scheme-dark) .history-status-badge.danger {
   background: color-mix(in srgb, var(--vc-state-due) 22%, transparent);
   color: var(--vc-state-due);
 }
-:root:not(.light) .history-status-badge.muted {
+:root:is(:not(.light), .dash-scheme-dark) .history-status-badge.muted {
   background: var(--vc-bg-raised);
   color: var(--vc-text-tertiary);
 }
 
 /* ---------- History pages: filter bar, stats row, table cells ---------- */
-:root:not(.light) .history-filter-bar,
-:root:not(.light) .vitals-history-filters {
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-bar,
+:root:is(:not(.light), .dash-scheme-dark) .vitals-history-filters {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
 }
-:root:not(.light) .history-filter-group label {
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-group label {
   font-family: var(--vc-font-mono);
   font-size: 10px;
   font-weight: 500;
@@ -326,15 +328,15 @@
   text-transform: uppercase;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .history-filter-input,
-:root:not(.light) .history-filter-select {
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-input,
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-select {
   background: var(--vc-bg-raised);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 8px;
   color: var(--vc-text-primary);
 }
-:root:not(.light) .history-filter-input:focus,
-:root:not(.light) .history-filter-select:focus {
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-input:focus,
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-select:focus {
   border-color: var(--vc-data-live);
   outline: none;
   /* visible focus ring — border recolor alone is too weak (WCAG focus
@@ -344,18 +346,18 @@
 
 /* Stats row: mono tabular values; 'danger' counts late/missed doses —
  * schedule adherence, so amber, not red */
-:root:not(.light) .history-stat {
+:root:is(:not(.light), .dash-scheme-dark) .history-stat {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
 }
-:root:not(.light) .history-stat-value {
+:root:is(:not(.light), .dash-scheme-dark) .history-stat-value {
   font-family: var(--vc-font-mono);
   font-variant-numeric: tabular-nums;
   font-weight: 400;
   color: var(--vc-text-primary);
 }
-:root:not(.light) .history-stat-label {
+:root:is(:not(.light), .dash-scheme-dark) .history-stat-label {
   font-family: var(--vc-font-mono);
   font-size: 10px;
   font-weight: 500;
@@ -363,37 +365,37 @@
   text-transform: uppercase;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .history-stat.success .history-stat-value { color: var(--vc-state-complete); }
-:root:not(.light) .history-stat.warning .history-stat-value { color: var(--vc-state-due); }
-:root:not(.light) .history-stat.danger .history-stat-value { color: var(--vc-state-due); }
-:root:not(.light) .history-stat.muted .history-stat-value { color: var(--vc-text-tertiary); }
+:root:is(:not(.light), .dash-scheme-dark) .history-stat.success .history-stat-value { color: var(--vc-state-complete); }
+:root:is(:not(.light), .dash-scheme-dark) .history-stat.warning .history-stat-value { color: var(--vc-state-due); }
+:root:is(:not(.light), .dash-scheme-dark) .history-stat.danger .history-stat-value { color: var(--vc-state-due); }
+:root:is(:not(.light), .dash-scheme-dark) .history-stat.muted .history-stat-value { color: var(--vc-text-tertiary); }
 
 /* Table cell text */
-:root:not(.light) .history-med-name { color: var(--vc-text-primary); }
-:root:not(.light) .history-med-concentration { color: var(--vc-text-secondary); }
-:root:not(.light) .history-dose {
+:root:is(:not(.light), .dash-scheme-dark) .history-med-name { color: var(--vc-text-primary); }
+:root:is(:not(.light), .dash-scheme-dark) .history-med-concentration { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .history-dose {
   font-family: var(--vc-font-mono);
   font-variant-numeric: tabular-nums;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .history-dose.skipped {
+:root:is(:not(.light), .dash-scheme-dark) .history-dose.skipped {
   color: var(--vc-text-tertiary);
   text-decoration: line-through;
 }
-:root:not(.light) .history-datetime {
+:root:is(:not(.light), .dash-scheme-dark) .history-datetime {
   font-family: var(--vc-font-mono);
   font-variant-numeric: tabular-nums;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .history-unscheduled {
+:root:is(:not(.light), .dash-scheme-dark) .history-unscheduled {
   font-family: var(--vc-font-mono);
   font-size: 9.5px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--vc-text-tertiary);
 }
-:root:not(.light) .history-notes { color: var(--vc-text-secondary); }
-:root:not(.light) .history-category-badge {
+:root:is(:not(.light), .dash-scheme-dark) .history-notes { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .history-category-badge {
   background: transparent;
   border: 1px solid var(--vc-line-strong);
   border-radius: 999px;
@@ -405,7 +407,7 @@
 }
 
 /* Vitals history source badge (manual / device / integrations) */
-:root:not(.light) .admin-v2-source-badge {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-source-badge {
   background: transparent;
   border: 1px solid var(--vc-line-hairline);
   border-radius: 999px;
@@ -415,21 +417,21 @@
   text-transform: uppercase;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .admin-v2-source-badge.device,
-:root:not(.light) .admin-v2-source-badge.sensor {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-source-badge.device,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-source-badge.sensor {
   border-color: color-mix(in srgb, var(--vc-data-live) 45%, transparent);
   color: var(--vc-data-live);
 }
 
 /* ---------- List cards (manage pages) ---------- */
-:root:not(.light) .admin-v2-med-card {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-med-card {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
   box-shadow: none;
 }
-:root:not(.light) .admin-v2-med-card-inactive { opacity: 0.65; }
-:root:not(.light) .admin-v2-med-card-label {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-med-card-inactive { opacity: 0.65; }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-med-card-label {
   font-family: var(--vc-font-mono);
   font-size: 10px;
   font-weight: 500;
@@ -439,57 +441,57 @@
 }
 
 /* ---------- Filters / day picker ---------- */
-:root:not(.light) .admin-v2-filter-card {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-filter-card {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
 }
-:root:not(.light) .admin-v2-day-btn {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-day-btn {
   background: transparent;
   border: 1px solid var(--vc-line-hairline);
   border-radius: 8px;
   color: var(--vc-text-secondary);
   font-family: var(--vc-font-mono);
 }
-:root:not(.light) .admin-v2-day-btn:hover { border-color: var(--vc-line-strong); }
-:root:not(.light) .admin-v2-day-btn.selected {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-day-btn:hover { border-color: var(--vc-line-strong); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-day-btn.selected {
   background: color-mix(in srgb, var(--vc-data-live) 15%, transparent);
   border-color: var(--vc-data-live);
   color: var(--vc-data-live);
 }
 
 /* ---------- Schedule summary cards + legend + progress ---------- */
-:root:not(.light) .admin-v2-schedule-summary-card {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-summary-card {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
 }
-:root:not(.light) .admin-v2-schedule-summary-title {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-summary-title {
   font-family: var(--vc-font-mono);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-schedule-summary-detail { color: var(--vc-text-secondary); }
-:root:not(.light) .admin-v2-schedule-legend {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-summary-detail { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-legend {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
 }
-:root:not(.light) .admin-v2-legend-item { color: var(--vc-text-secondary); }
-:root:not(.light) .admin-v2-schedule-progress-bar.success { background: var(--vc-state-complete); }
-:root:not(.light) .admin-v2-schedule-progress-bar.good { background: var(--vc-data-live); }
-:root:not(.light) .admin-v2-schedule-progress-bar.warning { background: var(--vc-state-due); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-legend-item { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-progress-bar.success { background: var(--vc-state-complete); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-progress-bar.good { background: var(--vc-data-live); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-progress-bar.warning { background: var(--vc-state-due); }
 
 /* ---------- Medication stock bar (Overview / Manage entity cards) ---------- */
-:root:not(.light) .med-stock {
+:root:is(:not(.light), .dash-scheme-dark) .med-stock {
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
   padding: 0 0.9rem 0.7rem;
   font-family: var(--vc-font-mono);
 }
-:root:not(.light) .med-stock-label {
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-label {
   display: flex;
   justify-content: space-between;
   gap: 0.5rem;
@@ -497,27 +499,27 @@
   letter-spacing: 0.04em;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .med-stock-label .med-stock-status { text-transform: uppercase; font-weight: 600; }
-:root:not(.light) .med-stock-label.low .med-stock-status { color: var(--vc-state-due); }
-:root:not(.light) .med-stock-label.ok .med-stock-status { color: var(--vc-state-complete); }
-:root:not(.light) .med-stock-bar {
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-label .med-stock-status { text-transform: uppercase; font-weight: 600; }
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-label.low .med-stock-status { color: var(--vc-state-due); }
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-label.ok .med-stock-status { color: var(--vc-state-complete); }
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-bar {
   height: 6px;
   border-radius: 3px;
   background: var(--vc-bg-raised);
   overflow: hidden;
 }
-:root:not(.light) .med-stock-fill {
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-fill {
   height: 100%;
   border-radius: 3px;
   background: var(--vc-state-complete);
   transition: width 0.3s ease;
 }
-:root:not(.light) .med-stock-fill.low { background: var(--vc-state-due); }
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-fill.low { background: var(--vc-state-due); }
 
 /* ---------- Nutrition schedule: off-window confirm ---------- */
 /* Replaces a hard-coded amber hex and a text warning glyph. Amber is the
    attention role here — schedule timing is never red. */
-:root:not(.light) .nsched-warn-badge {
+:root:is(:not(.light), .dash-scheme-dark) .nsched-warn-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -527,7 +529,7 @@
   color: var(--vc-state-due);
   background: color-mix(in srgb, var(--vc-state-due) 20%, transparent);
 }
-:root:not(.light) .nsched-warn-heading {
+:root:is(:not(.light), .dash-scheme-dark) .nsched-warn-heading {
   margin-bottom: 0.375rem;
   font-weight: 600;
   color: var(--vc-state-due);

--- a/frontend/src/pages/admin-v2/vc-forms.css
+++ b/frontend/src/pages/admin-v2/vc-forms.css
@@ -26,8 +26,13 @@
  * class lives on <body> (not a page wrapper) so it also reaches Radix's
  * portalled Select/Dialog content, which renders outside the page tree.
  *
- * DARK THEME ONLY (scoped :root:not(.light)) — the vc aesthetic is dark by
- * design and the light theme keeps the stock shadcn palette.
+ * DARK THEME ONLY — the vc aesthetic is dark by design and the light theme
+ * keeps the stock shadcn palette. Every rule is scoped
+ * `:root:is(:not(.light), .dash-scheme-dark)`: the admin's html theme class,
+ * OR the live board's `dash-scheme-dark` (DashboardThemeProvider), which is
+ * dark-only regardless of the user's saved theme and also puts
+ * `vc-form-skin` on <body>. `:is()` keeps the specificity of `:not(.light)`
+ * so nothing in the cascade re-orders.
  *
  * Hooks: every primitive carries data-slot, and button/badge/alert also carry
  * data-variant / data-size, so nothing here depends on utility class names.
@@ -42,28 +47,28 @@
 /* vc-content.css already remaps the shared palette for every .tw island.
  * Destructive is deliberately left on the stock red there (it is still the
  * legacy admin language); inside the skin it moves onto the vc alert token. */
-:root:not(.light) body.vc-form-skin .tw,
-:root:not(.light) body.vc-form-skin [data-slot='dialog-content'],
-:root:not(.light) body.vc-form-skin [data-slot='select-content'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin .tw,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-content'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-content'] {
   --destructive: var(--vc-state-alert);
 }
 
 /* ---------- Cards / panels ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='card'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='card'] {
   background: var(--vc-bg-surface);
   border-color: var(--vc-line-hairline);
   border-radius: 12px;
   box-shadow: none;
   font-family: var(--vc-font-sans);
 }
-:root:not(.light) body.vc-form-skin [data-slot='card-header'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='card-header'] {
   border-bottom-color: var(--vc-line-hairline);
 }
-:root:not(.light) body.vc-form-skin [data-slot='card-footer'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='card-footer'] {
   border-top-color: var(--vc-line-hairline);
 }
-:root:not(.light) body.vc-form-skin [data-slot='card-title'],
-:root:not(.light) body.vc-form-skin [data-slot='dialog-title'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='card-title'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-title'] {
   font-family: var(--vc-font-mono);
   font-size: 14px;
   font-weight: 600;
@@ -72,8 +77,8 @@
   text-transform: uppercase;
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='card-description'],
-:root:not(.light) body.vc-form-skin [data-slot='dialog-description'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='card-description'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-description'] {
   font-family: var(--vc-font-sans);
   font-size: 13px;
   line-height: 1.5;
@@ -83,10 +88,10 @@
 /* Group headings inside a panel ("Dashboard Display", "Vital Sign Alert
  * Thresholds"): one step quieter than the panel title. tailwind.css zeroes
  * .tw h1–h6, so these carry no UA styling to fight. */
-:root:not(.light) body.vc-form-skin .tw h3,
-:root:not(.light) body.vc-form-skin .tw h4,
-:root:not(.light) body.vc-form-skin [data-slot='dialog-content'] h3,
-:root:not(.light) body.vc-form-skin [data-slot='dialog-content'] h4 {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin .tw h3,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin .tw h4,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-content'] h3,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-content'] h4 {
   font-family: var(--vc-font-mono);
   font-size: 12px;
   font-weight: 600;
@@ -96,7 +101,7 @@
 }
 
 /* ---------- Labels ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='label'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='label'] {
   font-family: var(--vc-font-mono);
   font-size: 11px;
   font-weight: 600;
@@ -107,9 +112,9 @@
 
 /* ---------- Text inputs / textareas / select triggers ---------- */
 /* Controls sit on the base surface so they read as wells inside a panel. */
-:root:not(.light) body.vc-form-skin [data-slot='input'],
-:root:not(.light) body.vc-form-skin [data-slot='textarea'],
-:root:not(.light) body.vc-form-skin [data-slot='select-trigger'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='input'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='textarea'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-trigger'] {
   min-height: 40px;
   background: var(--vc-bg-base);
   border-color: var(--vc-line-strong);
@@ -120,33 +125,33 @@
   font-size: 13.5px;
   letter-spacing: 0.03em;
 }
-:root:not(.light) body.vc-form-skin [data-slot='textarea'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='textarea'] {
   line-height: 1.5;
   padding-block: 0.55rem;
 }
-:root:not(.light) body.vc-form-skin [data-slot='input']::placeholder,
-:root:not(.light) body.vc-form-skin [data-slot='textarea']::placeholder {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='input']::placeholder,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='textarea']::placeholder {
   color: var(--vc-text-tertiary);
   letter-spacing: 0.06em;
 }
-:root:not(.light) body.vc-form-skin [data-slot='select-trigger'][data-placeholder] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-trigger'][data-placeholder] {
   color: var(--vc-text-tertiary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='input']:focus-visible,
-:root:not(.light) body.vc-form-skin [data-slot='textarea']:focus-visible,
-:root:not(.light) body.vc-form-skin [data-slot='select-trigger']:focus {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='input']:focus-visible,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='textarea']:focus-visible,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-trigger']:focus {
   outline: none;
   border-color: var(--vc-data-live);
   box-shadow: 0 0 0 1px var(--vc-data-live);
 }
-:root:not(.light) body.vc-form-skin [data-slot='input']:disabled,
-:root:not(.light) body.vc-form-skin [data-slot='textarea']:disabled,
-:root:not(.light) body.vc-form-skin [data-slot='select-trigger']:disabled {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='input']:disabled,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='textarea']:disabled,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-trigger']:disabled {
   background: var(--vc-bg-surface);
   color: var(--vc-text-tertiary);
 }
 /* File pickers (backup restore) keep the mono language on their button half. */
-:root:not(.light) body.vc-form-skin [data-slot='input']::file-selector-button {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='input']::file-selector-button {
   color: var(--vc-data-live);
   font-family: var(--vc-font-mono);
   font-size: 11px;
@@ -161,7 +166,7 @@
  * chrome (which paints its own light field over background-color); tapping
  * still opens the OS picker, and the option list stays OS-drawn. The chevron
  * is two gradient wedges rather than an SVG so it can ride on currentColor. */
-:root:not(.light) body.vc-form-skin .tw select {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin .tw select {
   appearance: none;
   -webkit-appearance: none;
   min-height: 40px;
@@ -180,20 +185,20 @@
   font-size: 13px;
   letter-spacing: 0.03em;
 }
-:root:not(.light) body.vc-form-skin .tw select:focus {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin .tw select:focus {
   outline: none;
   border-color: var(--vc-data-live);
   box-shadow: 0 0 0 1px var(--vc-data-live);
 }
 
 /* ---------- Select menu (portalled) ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='select-content'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-content'] {
   background: var(--vc-bg-raised);
   border-color: var(--vc-line-strong);
   border-radius: 10px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
 }
-:root:not(.light) body.vc-form-skin [data-slot='select-item'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-item'] {
   min-height: 38px;
   border-radius: 6px;
   color: var(--vc-text-primary);
@@ -203,17 +208,17 @@
 }
 /* --accent is bg-raised in the vc remap, i.e. the menu's own background, so
  * the stock focus style was invisible — highlight with the live accent. */
-:root:not(.light) body.vc-form-skin [data-slot='select-item']:focus,
-:root:not(.light) body.vc-form-skin [data-slot='select-item'][data-highlighted] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-item']:focus,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-item'][data-highlighted] {
   background: color-mix(in srgb, var(--vc-data-live) 18%, transparent);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='select-item'][data-state='checked'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-item'][data-state='checked'] {
   color: var(--vc-data-live);
 }
 
 /* ---------- Buttons ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='button'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'] {
   border-radius: 8px;
   font-family: var(--vc-font-mono);
   font-size: 11.5px;
@@ -221,57 +226,57 @@
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-size='default'] { min-height: 38px; }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-size='lg'] { min-height: 42px; }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-size='sm'] { font-size: 10.5px; }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='default'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-size='default'] { min-height: 38px; }
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-size='lg'] { min-height: 42px; }
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-size='sm'] { font-size: 10.5px; }
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='default'] {
   background: var(--vc-data-live);
   color: var(--vc-bg-base);
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='default']:hover {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='default']:hover {
   background: var(--vc-data-live);
   filter: brightness(1.08);
 }
 /* Secondary/outline read as quiet outlines rather than filled grey chips. */
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='secondary'],
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='outline'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='secondary'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='outline'] {
   background: transparent;
   border: 1px solid var(--vc-line-strong);
   color: var(--vc-text-secondary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='secondary']:hover,
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='outline']:hover {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='secondary']:hover,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='outline']:hover {
   background: var(--vc-bg-raised);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='ghost'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='ghost'] {
   color: var(--vc-text-secondary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='ghost']:hover {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='ghost']:hover {
   background: var(--vc-bg-raised);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='link'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='link'] {
   color: var(--vc-data-live);
   letter-spacing: 0.1em;
 }
-:root:not(.light) body.vc-form-skin [data-slot='button']:focus-visible {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button']:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--vc-bg-base), 0 0 0 4px var(--vc-data-live);
 }
 
 /* ---------- Checkbox ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='checkbox'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='checkbox'] {
   border-radius: 4px;
   border-color: var(--vc-line-strong);
   background: var(--vc-bg-base);
 }
-:root:not(.light) body.vc-form-skin [data-slot='checkbox'][data-state='checked'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='checkbox'][data-state='checked'] {
   background: var(--vc-data-live);
   border-color: var(--vc-data-live);
   color: var(--vc-bg-base);
 }
-:root:not(.light) body.vc-form-skin [data-slot='checkbox']:focus-visible {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='checkbox']:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--vc-bg-base), 0 0 0 4px var(--vc-data-live);
 }
@@ -279,21 +284,21 @@
 /* ---------- Switch ---------- */
 /* The thumb is stock `bg-background`, which on the dark scale is nearly the
  * same value as the track — it reads as a hole rather than a knob. */
-:root:not(.light) body.vc-form-skin [data-slot='switch'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='switch'] {
   background: var(--vc-bg-base);
   border: 1px solid var(--vc-line-strong);
 }
-:root:not(.light) body.vc-form-skin [data-slot='switch'][data-state='checked'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='switch'][data-state='checked'] {
   background: var(--vc-data-live);
   border-color: var(--vc-data-live);
 }
-:root:not(.light) body.vc-form-skin [data-slot='switch-thumb'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='switch-thumb'] {
   background: var(--vc-text-secondary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='switch'][data-state='checked'] [data-slot='switch-thumb'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='switch'][data-state='checked'] [data-slot='switch-thumb'] {
   background: var(--vc-bg-base);
 }
-:root:not(.light) body.vc-form-skin [data-slot='switch']:focus-visible {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='switch']:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--vc-bg-base), 0 0 0 4px var(--vc-data-live);
 }
@@ -301,7 +306,7 @@
 /* ---------- Badges ---------- */
 /* The stock variants carry GitHub-palette hex; restate them on the vc scale
  * so a badge next to a skinned control belongs to the same system. */
-:root:not(.light) body.vc-form-skin [data-slot='badge'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'] {
   border-radius: 999px;
   font-family: var(--vc-font-mono);
   font-size: 9.5px;
@@ -309,69 +314,69 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='default'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='default'] {
   background: color-mix(in srgb, var(--vc-data-live) 18%, transparent);
   border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
   color: var(--vc-data-live);
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='success'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='success'] {
   background: color-mix(in srgb, var(--vc-state-complete) 15%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-complete) 55%, transparent);
   color: var(--vc-state-complete);
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='warning'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='warning'] {
   background: color-mix(in srgb, var(--vc-state-due) 15%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
   color: var(--vc-state-due);
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='danger'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='danger'] {
   background: color-mix(in srgb, var(--vc-state-alert) 15%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
   color: var(--vc-state-alert);
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='info'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='info'] {
   background: color-mix(in srgb, var(--vc-data-live) 15%, transparent);
   border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
   color: var(--vc-data-live);
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='secondary'],
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='muted'],
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='outline'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='secondary'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='muted'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='outline'] {
   background: transparent;
   border-color: var(--vc-line-strong);
   color: var(--vc-text-secondary);
 }
 
 /* ---------- Alerts ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='alert'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='alert'] {
   border-radius: 8px;
   font-family: var(--vc-font-sans);
   font-size: 13.5px;
   line-height: 1.5;
 }
-:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='default'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='alert'][data-variant='default'] {
   background: var(--vc-bg-raised);
   border-color: var(--vc-line-hairline);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='destructive'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='alert'][data-variant='destructive'] {
   background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='success'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='alert'][data-variant='success'] {
   background: color-mix(in srgb, var(--vc-state-complete) 12%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-complete) 55%, transparent);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='warning'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='alert'][data-variant='warning'] {
   background: color-mix(in srgb, var(--vc-state-due) 12%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
   color: var(--vc-text-primary);
 }
 
 /* ---------- Dialogs ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='dialog-content'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-content'] {
   background: var(--vc-bg-sheet);
   border-color: var(--vc-line-strong);
   border-radius: 12px;

--- a/frontend/src/pages/admin-v2/vc-skin-gating.test.js
+++ b/frontend/src/pages/admin-v2/vc-skin-gating.test.js
@@ -1,0 +1,39 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The two vc skin sheets must stay reachable from the live board, which is
+// dark-only regardless of the user's saved theme. Every dark-gated rule is
+// therefore scoped `:root:is(:not(.light), .dash-scheme-dark)`; a bare
+// `:root:not(.light)` would silently drop the skin for a light-theme user on
+// /live (the board pins `dash-scheme-dark` on <html>, never removes `light`).
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const SHEETS = ['./vc-forms.css', './vc-content.css'];
+const GATE = ':root:is(:not(.light), .dash-scheme-dark)';
+
+describe('vc skin dark gating', () => {
+  for (const sheet of SHEETS) {
+    it(`${sheet} has no bare :root:not(.light) selectors`, () => {
+      const css = readFileSync(fileURLToPath(new URL(sheet, import.meta.url)), 'utf8');
+      const bare = css.split('\n').filter((l) => l.includes(':root:not(.light)'));
+      expect(bare).toEqual([]);
+      expect(css.includes(GATE)).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## What

- `DashboardThemeProvider` now puts `vc-form-skin` on `<body>` while `/live` is mounted (same opt-in `AdminV2Layout` makes for the admin), so the shadcn primitives and portalled dialogs on the live board get the vc skin instead of stock geometry on the GitHub palette.
- `vc-forms.css` / `vc-content.css` gating changed from `:root:not(.light)` to `:root:is(:not(.light), .dash-scheme-dark)` so a light-theme user still gets the dark skin on the dark-only board. `:is()` keeps the specificity of `:not(.light)`, nothing re-orders.
- Test: body class add/remove on the provider; a guard test that neither sheet regains a bare `:root:not(.light)`.

## Why

First step of the "remaining shadcn/legacy-CSS surfaces" pass. This is the stopgap that immediately fixes the PRN dose dialog, low-stock gate, off-window confirms and the Equipment/Settings/Camera chrome on `/live`; the Equipment and Settings panels get a real vc rebuild in follow-up PRs.

## Verified

- `npm run lint` clean, `npm test` 95 files / 1204 tests green.
- Playwright on `/live` (patient 5) at 1440×900: Equipment panel narrow + expanded, Settings, Medications → PRN → Record dose dialog — dark **and** with `localStorage.theme = 'light'`; body carries `vc-form-skin`, dialogs identical in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vgpstiNy2SiLZt6ALkKYW