### PR TITLE
Rebuild the live Equipment panel on the docked-panel bones

### DIFF
--- a/frontend/src/components/EquipmentModal.jsx
+++ b/frontend/src/components/EquipmentModal.jsx
@@ -15,454 +15,207 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect } from 'react';
-import config from '../config';
+// Live-dashboard Equipment panel. Same bones as the medication / care-task
+// panels: ModalBase shell, a PanelViewSwitcher between Supplies and History,
+// the dock context (not the viewport) deciding narrow vs wide, and vc sheets
+// for anything that needs input — no window.prompt, no shadcn primitives.
+//
+// Data goes through equipmentService. The out-of-stock 409 on a change still
+// opens EquipmentRestockGate (shared with the admin inventory page), which
+// retries the change once a new on-hand count is saved.
+import { useCallback, useEffect, useState } from 'react';
 import ModalBase from './ModalBase';
 import EquipmentRestockGate from './EquipmentRestockGate';
-import { formatDateOnly } from '../utils/timezone';
+import PanelViewSwitcher from './section-panel/PanelViewSwitcher';
+import ConfirmSheet from './vc/ConfirmSheet';
+import EquipmentList from './equipment/EquipmentList';
+import EquipmentHistory from './equipment/EquipmentHistory';
+import StockActionSheet from './equipment/StockActionSheet';
+import { isDue } from './equipment/equipmentStatus';
+import { equipmentService } from '../services/equipment';
 import { useAdminPatient } from '../contexts/AdminPatientContext';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
+import { useModalDock } from '../contexts/ModalDockContext';
+import './equipment/equipment-panel.css';
 
-export default function EquipmentModal({ isOpen, onClose, noModal }) {
+const HISTORY_LIMIT = 20;
+
+export default function EquipmentModal({ isOpen = true, onClose }) {
   const { selectedPatient } = useAdminPatient();
-  const [tab, setTab] = useState('list');
+  const patientId = selectedPatient?.id ?? null;
+  // Wide only at the expanded dock stop; the narrow stop and the phone sheet
+  // both get the two-column facts (same rule as DoseScheduleView).
+  const { docked, expanded } = useModalDock();
+  const wide = docked && expanded;
+
+  const [view, setView] = useState('supplies');
   const [equipment, setEquipment] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [showConfirm, setShowConfirm] = useState(false);
-  const [selectedEquip, setSelectedEquip] = useState(null);
+  const [loadError, setLoadError] = useState(null);
+
+  const [history, setHistory] = useState({ rows: [], loading: false, error: null });
+  const [historyFilter, setHistoryFilter] = useState('');
+
+  // One pending action at a time: { kind: 'receive' | 'open' | 'change', item }
+  const [action, setAction] = useState(null);
+  const [actionBusy, setActionBusy] = useState(false);
+  const [actionError, setActionError] = useState(null);
   const [restockInfo, setRestockInfo] = useState(null);
-  const [historyTab, setHistoryTab] = useState({ filter: '', logs: [], loading: false, selectedEquipment: '' });
-  const [isMobile, setIsMobile] = useState(typeof window !== 'undefined' && window.innerWidth <= 768);
 
-  useEffect(() => {
-    const onResize = () => setIsMobile(window.innerWidth <= 768);
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, []);
-
-  useEffect(() => {
-    if (isOpen && selectedPatient) fetchEquipment();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchEquipment is recreated each render and selectedPatient is tracked via its id; effect is intentionally keyed on modal open/patient id only
-  }, [isOpen, selectedPatient?.id]);
-
-  const fetchEquipment = async () => {
-    if (!selectedPatient) return;
+  const loadEquipment = useCallback(async () => {
+    if (!patientId) { setEquipment([]); return; }
     setLoading(true);
+    setLoadError(null);
     try {
-      const res = await fetch(`${config.apiUrl}/api/equipment?patient_id=${selectedPatient.id}`, {
-        credentials: 'include',
-      });
-      const data = await res.json();
-      setEquipment(data);
-    } catch {
+      setEquipment(await equipmentService.list(patientId));
+    } catch (err) {
       setEquipment([]);
+      setLoadError(err.message || 'Could not load supplies');
     } finally {
       setLoading(false);
     }
+  }, [patientId]);
+
+  useEffect(() => {
+    if (isOpen) loadEquipment();
+  }, [isOpen, loadEquipment]);
+
+  useEffect(() => {
+    if (view !== 'history' || !patientId) return undefined;
+    let cancelled = false;
+    setHistory((h) => ({ ...h, loading: true, error: null }));
+    equipmentService
+      .changeHistory({ patientId, equipmentId: historyFilter || null, limit: HISTORY_LIMIT })
+      .then((data) => { if (!cancelled) setHistory({ rows: data?.history || [], loading: false, error: null }); })
+      .catch((err) => { if (!cancelled) setHistory({ rows: [], loading: false, error: err.message || 'Could not load history' }); });
+    return () => { cancelled = true; };
+  }, [view, patientId, historyFilter]);
+
+  const closeAction = () => { setAction(null); setActionError(null); };
+  const startAction = (kind) => (item) => { setAction({ kind, item }); setActionError(null); };
+
+  const runStockAction = async (amount) => {
+    if (!action) return;
+    setActionBusy(true);
+    setActionError(null);
+    try {
+      if (action.kind === 'receive') await equipmentService.receive(action.item.id, amount);
+      else await equipmentService.open(action.item.id, amount);
+      closeAction();
+      await loadEquipment();
+    } catch (err) {
+      setActionError(err.message || 'Could not save');
+    } finally {
+      setActionBusy(false);
+    }
   };
 
-  const handleChangeClick = (equip) => {
-    setSelectedEquip(equip);
-    setShowConfirm(true);
-  };
-
-  // Core change request. A 409 out-of-stock opens the restock gate, which
-  // retries this once the on-hand quantity has been updated.
-  const doChange = async (equipId) => {
-    const response = await fetch(`${config.apiUrl}/api/equipment/${equipId}/change`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ changed_at: new Date().toISOString() }),
-    });
-    if (response.ok) {
+  // A 409 out-of-stock opens the restock gate, which retries this once the
+  // on-hand quantity has been updated.
+  const doChange = async (equipmentId) => {
+    setActionBusy(true);
+    setActionError(null);
+    try {
+      await equipmentService.logChange(equipmentId, new Date().toISOString());
       setRestockInfo(null);
-      setSelectedEquip(null);
-      fetchEquipment();
-    } else {
-      const data = await response.json().catch(() => ({}));
-      if (response.status === 409 && data.error === 'insufficient_quantity') {
-        setRestockInfo(data);
+      closeAction();
+      await loadEquipment();
+    } catch (err) {
+      if (err.status === 409 && err.payload?.error === 'insufficient_quantity') {
+        setRestockInfo(err.payload);
+        closeAction();
       } else {
-        alert('Failed to mark equipment as changed.');
+        setActionError(err.message || 'Could not record the change');
       }
+    } finally {
+      setActionBusy(false);
     }
-  };
-
-  const handleConfirmChange = () => {
-    setShowConfirm(false);
-    if (!selectedEquip) return;
-    doChange(selectedEquip.id);
-  };
-
-  const handleReceive = async (equip) => {
-    const amount = prompt('How many to receive?', '1');
-    if (!amount || isNaN(amount)) return;
-    await fetch(`${config.apiUrl}/api/equipment/${equip.id}/receive`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ amount: parseInt(amount) }),
-    });
-    fetchEquipment();
-  };
-
-  const handleOpen = async (equip) => {
-    const amount = prompt('How many to open/use?', '1');
-    if (!amount || isNaN(amount)) return;
-    const numAmount = parseInt(amount);
-    if (numAmount > equip.quantity) {
-      alert(`Cannot open ${numAmount} items. Only ${equip.quantity} available.`);
-      return;
-    }
-    const response = await fetch(`${config.apiUrl}/api/equipment/${equip.id}/open`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ amount: numAmount }),
-    });
-    const result = await response.json();
-    if (result.success) {
-      fetchEquipment();
-    } else {
-      alert('Failed to open equipment. Please try again.');
-    }
-  };
-
-  const handleHistoryTab = async () => {
-    if (tab === 'history') return;
-    setTab('history');
-    setHistoryTab(t => ({ ...t, loading: true }));
-    try {
-      let logs = [];
-      for (const equip of equipment) {
-        const res = await fetch(`${config.apiUrl}/api/equipment/${equip.id}/history`, { credentials: 'include' });
-        const data = await res.json();
-        logs = logs.concat(data.map(log => ({ ...log, equipment: equip.name, equipment_id: equip.id })));
-      }
-      logs.sort((a, b) => new Date(b.changed_at) - new Date(a.changed_at));
-      logs = logs.slice(0, 20);
-      setHistoryTab(t => ({ ...t, logs, loading: false }));
-    } catch {
-      setHistoryTab(t => ({ ...t, logs: [], loading: false }));
-    }
-  };
-
-  const handleEquipmentHistoryFilter = async (equipmentId) => {
-    setHistoryTab(t => ({ ...t, selectedEquipment: equipmentId, loading: true }));
-    try {
-      if (!equipmentId) {
-        let logs = [];
-        for (const equip of equipment) {
-          const res = await fetch(`${config.apiUrl}/api/equipment/${equip.id}/history`, { credentials: 'include' });
-          const data = await res.json();
-          logs = logs.concat(data.map(log => ({ ...log, equipment: equip.name, equipment_id: equip.id })));
-        }
-        logs.sort((a, b) => new Date(b.changed_at) - new Date(a.changed_at));
-        logs = logs.slice(0, 20);
-        setHistoryTab(t => ({ ...t, logs, loading: false }));
-      } else {
-        const res = await fetch(`${config.apiUrl}/api/equipment/${equipmentId}/history`, { credentials: 'include' });
-        const data = await res.json();
-        const equipName = equipment.find(e => e.id == equipmentId)?.name || '';
-        const logs = data.map(log => ({ ...log, equipment: equipName, equipment_id: equipmentId }));
-        setHistoryTab(t => ({ ...t, logs, loading: false }));
-      }
-    } catch {
-      setHistoryTab(t => ({ ...t, logs: [], loading: false }));
-    }
-  };
-
-  const formatDate = (dateString) => {
-    if (!dateString) return '—';
-    return formatDateOnly(dateString) || '—';
-  };
-
-  const formatDateTime = (iso) => {
-    if (!iso) return '—';
-    return new Date(iso).toLocaleString(undefined, {
-      month: 'short', day: 'numeric',
-      hour: 'numeric', minute: '2-digit', hour12: true,
-    });
-  };
-
-  const isDue = (item) => {
-    if (!item.scheduled_replacement || !item.due_date) return false;
-    return new Date(item.due_date) <= new Date();
   };
 
   const dueCount = equipment.filter(isDue).length;
+  const views = [
+    {
+      value: 'supplies',
+      label: 'Supplies',
+      // The trigger shows the sublabel, so the due count lives there; the
+      // note/tone pair colours the same fact inside the menu.
+      sublabel: !equipment.length ? 'On hand and due'
+        : dueCount > 0 ? `${dueCount} due for change` : 'All on schedule',
+      note: equipment.length ? (dueCount > 0 ? `${dueCount} due` : 'All on schedule') : null,
+      tone: dueCount > 0 ? 'due' : 'given',
+    },
+    { value: 'history', label: 'History', sublabel: 'Recent changes' },
+  ];
 
-  // ===== Status mapping (matches AlertsList pattern) =====
-  const STATUS = {
-    due:        { color: '#dc3545', bg: 'rgba(220,53,69,0.12)', label: 'Due Now' },
-    scheduled:  { color: '#3fb950', bg: 'rgba(63,185,80,0.12)', label: 'On Schedule' },
-    consumable: { color: '#6f42c1', bg: 'rgba(111,66,193,0.12)', label: 'Consumable' },
-  };
-  const getStatus = (equip) => {
-    if (!equip.scheduled_replacement) return STATUS.consumable;
-    if (isDue(equip)) return STATUS.due;
-    return STATUS.scheduled;
-  };
+  const title = (
+    <span className="mp-modal-title">
+      <span>Equipment</span>
+      <span className="mp-modal-title-sub">
+        {selectedPatient
+          ? `${selectedPatient.first_name} ${selectedPatient.last_name} · ${view === 'history' ? 'History' : 'Supplies'}`
+          : 'No patient selected'}
+      </span>
+    </span>
+  );
 
-  // ===== Reusable tile (matches AlertsList metric tile) =====
-  const metricTile = (label, value, accent = 'gray', highlight = false) => {
-    const palette = {
-      blue:   { bg: 'rgba(96,165,250,0.1)',  border: 'rgba(96,165,250,0.3)', label: 'var(--ring)' },
-      green:  { bg: 'rgba(72,187,120,0.1)',  border: 'rgba(72,187,120,0.3)', label: 'var(--success)' },
-      red:    { bg: 'rgba(245,101,101,0.1)', border: 'rgba(245,101,101,0.3)', label: 'var(--destructive)' },
-      gray:   { bg: 'var(--dash-surface-2)', border: 'var(--dash-border)', label: 'var(--dash-text-muted)' },
-    }[accent];
-    return (
-      <div style={{
-        background: palette.bg,
-        border: `1px solid ${palette.border}`,
-        borderRadius: 8, padding: '8px 12px',
-      }}>
-        <div style={{
-          color: palette.label, fontSize: 11, fontWeight: 600,
-          textTransform: 'uppercase', letterSpacing: 0.5,
-        }}>{label}</div>
-        <div style={{
-          color: highlight ? 'var(--destructive)' : 'var(--dash-text)',
-          fontSize: 16, fontWeight: 700, marginTop: 2,
-        }}>{value}</div>
-      </div>
-    );
-  };
-
-  const renderContent = () => (
-    <div style={{
-      height: '100%',
-      display: 'flex',
-      flexDirection: 'column',
-      minHeight: 0,
-    }}>
-      <div style={{
-        flex: 1,
-        overflowY: 'auto',
-        WebkitOverflowScrolling: 'touch',
-        paddingBottom: isMobile ? 80 : 16,
-      }}>
-      {tab === 'history' ? (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-          {/* Controls */}
-          <div className="tw" style={{
-            display: 'flex', alignItems: isMobile ? 'stretch' : 'center',
-            flexDirection: isMobile ? 'column' : 'row',
-            gap: isMobile ? 8 : 12,
-            padding: '12px 14px',
-            background: 'var(--dash-surface-2)',
-            border: '1px solid var(--dash-border)',
-            borderRadius: 8,
-          }}>
-            <Label className="text-muted-foreground">Equipment</Label>
-            <Select
-              value={historyTab.selectedEquipment || '__all__'}
-              onValueChange={(v) => handleEquipmentHistoryFilter(v === '__all__' ? '' : v)}
-            >
-              <SelectTrigger className={isMobile ? 'w-full' : 'w-[280px]'}><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__all__">All Equipment (Last 20)</SelectItem>
-                {equipment.map(equip => (
-                  <SelectItem key={equip.id} value={String(equip.id)}>{equip.name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+  return (
+    <>
+      <ModalBase isOpen={isOpen} onClose={onClose} title={title}>
+        <div className={`eq-panel ${wide ? 'wide' : 'narrow'}`}>
+          <PanelViewSwitcher views={views} value={view} onChange={setView} />
+          <div className="eq-scroll">
+            {!patientId ? (
+              <div className="ld-dose-empty">Select a patient to see their supplies</div>
+            ) : view === 'history' ? (
+              <EquipmentHistory
+                items={equipment}
+                rows={history.rows}
+                loading={history.loading}
+                error={history.error}
+                filter={historyFilter}
+                onFilter={setHistoryFilter}
+              />
+            ) : (
+              <EquipmentList
+                items={equipment}
+                loading={loading}
+                error={loadError}
+                onReceive={startAction('receive')}
+                onOpen={startAction('open')}
+                onChange={startAction('change')}
+              />
+            )}
           </div>
-
-          {historyTab.loading ? (
-            <div style={{ textAlign: 'center', padding: 40, color: 'var(--dash-text-muted)' }}>Loading…</div>
-          ) : historyTab.logs.length === 0 ? (
-            <div style={{
-              textAlign: 'center', padding: 40,
-              background: 'var(--dash-surface-2)',
-              border: '1px dashed var(--dash-border-strong)',
-              borderRadius: 8, color: 'var(--dash-text-muted)', fontStyle: 'italic',
-            }}>No history found</div>
-          ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              {historyTab.logs.map((log, i) => (
-                <div key={i} style={{
-                  background: 'var(--dash-surface)',
-                  border: '1px solid var(--dash-border)',
-                  borderLeft: '4px solid #6c757d',
-                  borderRadius: 8,
-                  padding: '10px 14px',
-                  display: 'flex', justifyContent: 'space-between',
-                  alignItems: 'center', gap: 12,
-                }}>
-                  <span style={{ color: 'var(--dash-text)', fontSize: 14, fontWeight: 600 }}>
-                    {log.equipment}
-                  </span>
-                  <span style={{ color: 'var(--dash-text-muted)', fontSize: 12, fontWeight: 500 }}>
-                    {formatDateTime(log.changed_at)}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
         </div>
-      ) : loading ? (
-        <div style={{ textAlign: 'center', padding: 40, color: 'var(--dash-text-muted)' }}>Loading…</div>
-      ) : equipment.length === 0 ? (
-        <div style={{
-          textAlign: 'center', padding: 40,
-          background: 'var(--dash-surface-2)',
-          border: '1px dashed var(--dash-border-strong)',
-          borderRadius: 8, color: 'var(--dash-text-muted)', fontStyle: 'italic',
-        }}>No equipment found</div>
-      ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {equipment.map(equip => {
-            const status = getStatus(equip);
-            const due = isDue(equip);
-            return (
-              <div
-                key={equip.id}
-                style={{
-                  position: 'relative',
-                  background: 'var(--dash-surface)',
-                  border: '1px solid var(--dash-border)',
-                  borderLeft: `5px solid ${status.color}`,
-                  borderRadius: 10,
-                  padding: '14px 16px',
-                  display: 'flex', flexDirection: 'column', gap: 12,
-                  boxShadow: '0 2px 6px rgba(0,0,0,0.25)',
-                }}
-              >
-                {/* Top row: name + status pill */}
-                <div style={{
-                  display: 'flex', justifyContent: 'space-between',
-                  alignItems: 'center', flexWrap: 'wrap', gap: 8,
-                }}>
-                  <h4 style={{ margin: 0, color: 'var(--dash-text)', fontSize: 16, fontWeight: 700, lineHeight: 1.3 }}>
-                    {equip.name}
-                  </h4>
-                  <span style={{
-                    display: 'inline-flex', alignItems: 'center', gap: 6,
-                    padding: '4px 10px', borderRadius: 12,
-                    background: status.bg, color: status.color,
-                    fontSize: 12, fontWeight: 700,
-                    border: `1px solid ${status.color}40`,
-                  }}>{status.label}</span>
-                </div>
+      </ModalBase>
 
-                {/* Metric grid */}
-                <div style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))',
-                  gap: 10,
-                }}>
-                  {metricTile('On Hand', equip.quantity, 'blue')}
-                  {equip.scheduled_replacement && (
-                    <>
-                      {metricTile('Due Next', formatDate(equip.due_date), due ? 'red' : 'green', due)}
-                      {metricTile('Last Changed', formatDate(equip.last_changed), 'gray')}
-                      {metricTile('Useful Days', equip.useful_days || '—', 'gray')}
-                    </>
-                  )}
-                </div>
+      <StockActionSheet
+        open={!!action && action.kind !== 'change'}
+        mode={action?.kind}
+        item={action?.item}
+        busy={actionBusy}
+        error={actionError}
+        onSubmit={runStockAction}
+        onClose={closeAction}
+      />
 
-                {/* Actions */}
-                <div className="tw" style={{
-                  display: 'flex', justifyContent: 'flex-end', gap: 8, flexWrap: 'wrap',
-                  borderTop: '1px solid var(--dash-border)',
-                  paddingTop: 10,
-                }}>
-                  <Button size="sm" onClick={() => handleReceive(equip)}>Receive</Button>
-                  {equip.scheduled_replacement ? (
-                    due ? (
-                      <Button size="sm" variant="destructive" onClick={() => handleChangeClick(equip)}>Change Now</Button>
-                    ) : (
-                      <Button size="sm" className="bg-[#3b82f6] text-white hover:bg-[#3b82f6]/90" onClick={() => handleChangeClick(equip)}>Change</Button>
-                    )
-                  ) : (
-                    <Button size="sm" className="bg-[#6f42c1] text-white hover:bg-[#6f42c1]/90" onClick={() => handleOpen(equip)}>Open</Button>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
-      </div>
-
-      {/* Confirm Change Modal */}
-      <Dialog open={showConfirm} onOpenChange={(o) => { if (!o) setShowConfirm(false); }}>
-        <DialogContent className="sm:max-w-[420px]">
-          <DialogHeader>
-            <DialogTitle>Confirm Change</DialogTitle>
-            <DialogDescription>
-              Mark <strong className="text-foreground">{selectedEquip?.name}</strong> as changed?
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => setShowConfirm(false)}>Cancel</Button>
-            <Button onClick={handleConfirmChange}>Confirm</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmSheet
+        open={!!action && action.kind === 'change'}
+        onOpenChange={(o) => { if (!o) closeAction(); }}
+        title="Mark as changed"
+        confirmLabel="Mark changed"
+        busy={actionBusy}
+        error={actionError}
+        onConfirm={() => action && doChange(action.item.id)}
+      >
+        Record <strong>{action?.item?.name}</strong> as changed now?
+        {action?.item?.useful_days ? ` The next change falls due in ${action.item.useful_days} days.` : ''}
+      </ConfirmSheet>
 
       <EquipmentRestockGate
         info={restockInfo}
         onClose={() => setRestockInfo(null)}
         onUpdated={() => doChange(restockInfo.equipment_id)}
       />
-    </div>
-  );
-
-  if (noModal) {
-    return (
-      <div className="equipment-tracker-inner" style={{ height: '100%', width: '100%' }}>
-        {renderContent()}
-      </div>
-    );
-  }
-
-  return (
-    <ModalBase isOpen={isOpen} onClose={onClose} title={
-      isMobile ? (
-        <div className="tw flex w-full items-center gap-2">
-          <Select
-            value={tab === 'history' ? 'history' : 'list'}
-            onValueChange={(v) => { if (v === 'history') handleHistoryTab(); else setTab(v); }}
-          >
-            <SelectTrigger className="flex-1"><SelectValue /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="list">Equipment List{dueCount > 0 ? ` (${dueCount} due)` : ''}</SelectItem>
-              <SelectItem value="history">History</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      ) : (
-        <div className="tw flex items-center gap-2">
-          <Button size="sm" variant={tab === 'list' ? 'default' : 'secondary'} onClick={() => setTab('list')}>
-            Equipment List
-            {dueCount > 0 && <Badge variant="danger" className="ml-1.5">{dueCount} To Do</Badge>}
-          </Button>
-          <Button size="sm" variant={tab === 'history' ? 'default' : 'secondary'} onClick={handleHistoryTab}>History</Button>
-        </div>
-      )
-    }>
-      {renderContent()}
-    </ModalBase>
+    </>
   );
 }

--- a/frontend/src/components/EquipmentModal.test.jsx
+++ b/frontend/src/components/EquipmentModal.test.jsx
@@ -1,0 +1,156 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The live Equipment panel: supplies view, its three bedside actions through
+// vc sheets (no window.prompt), the out-of-stock gate, and the dock-driven
+// layout. History's Radix view switch is exercised in EquipmentHistory.test.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+
+import EquipmentModal from './EquipmentModal';
+import { ModalDockProvider } from '../contexts/ModalDockContext';
+
+const svc = vi.hoisted(() => ({
+  list: vi.fn(),
+  changeHistory: vi.fn(),
+  receive: vi.fn(),
+  open: vi.fn(),
+  logChange: vi.fn(),
+}));
+vi.mock('../services/equipment', () => ({ equipmentService: svc }));
+
+vi.mock('../contexts/AdminPatientContext', () => ({
+  useAdminPatient: () => ({ selectedPatient: { id: 5, first_name: 'Test', last_name: 'Testerson' } }),
+}));
+
+// The gate does its own fetch; stand in for it so the test sees it open.
+vi.mock('./EquipmentRestockGate', () => ({
+  default: ({ info }) => (info ? <div data-testid="restock-gate">{info.equipment_name}</div> : null),
+}));
+
+const yesterday = new Date(Date.now() - 86400000).toISOString();
+const nextWeek = new Date(Date.now() + 7 * 86400000).toISOString();
+const ITEMS = [
+  { id: 1, name: 'Trach tie', quantity: 4, unit_of_measure: 'EA', scheduled_replacement: true, due_date: yesterday, last_changed: yesterday, useful_days: 7 },
+  { id: 2, name: 'HME filter', quantity: 12, scheduled_replacement: true, due_date: nextWeek, last_changed: yesterday, useful_days: 14 },
+  { id: 3, name: 'Suction catheter', quantity: 2, scheduled_replacement: false, due_date: null },
+];
+
+const renderAt = (dock = {}) => render(
+  <ModalDockProvider value={{ docked: true, expanded: false, toggleExpand: vi.fn(), setExpanded: vi.fn(), ...dock }}>
+    <EquipmentModal isOpen onClose={vi.fn()} />
+  </ModalDockProvider>
+);
+
+const card = (name) => screen.getByText(name).closest('[data-testid="eq-card"]');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  svc.list.mockResolvedValue(ITEMS);
+  svc.changeHistory.mockResolvedValue({ history: [] });
+  svc.receive.mockResolvedValue({ success: true });
+  svc.open.mockResolvedValue({ success: true });
+  svc.logChange.mockResolvedValue({ success: true });
+});
+
+describe('EquipmentModal — supplies', () => {
+  it('lists the patient\'s supplies with status badges and a due note', async () => {
+    renderAt();
+    expect(await screen.findByText('Trach tie')).toBeInTheDocument();
+    expect(svc.list).toHaveBeenCalledWith(5);
+    expect(within(card('Trach tie')).getByText('Due now')).toBeInTheDocument();
+    expect(within(card('HME filter')).getByText('On schedule')).toBeInTheDocument();
+    expect(within(card('Suction catheter')).getByText('Consumable')).toBeInTheDocument();
+    expect(screen.getByText('1 due for change')).toBeInTheDocument();
+    // a consumable has no schedule facts, only what is on hand
+    expect(within(card('Suction catheter')).queryByText('Due next')).toBeNull();
+  });
+
+  it('follows the dock, not the viewport', async () => {
+    const { container, unmount } = renderAt({ expanded: false });
+    await screen.findByText('Trach tie');
+    expect(container.querySelector('.eq-panel.narrow')).toBeInTheDocument();
+    unmount();
+    const wide = renderAt({ expanded: true });
+    await screen.findByText('Trach tie');
+    expect(wide.container.querySelector('.eq-panel.wide')).toBeInTheDocument();
+  });
+
+  it('records a change through the confirm sheet and refetches', async () => {
+    renderAt();
+    await screen.findByText('Trach tie');
+    fireEvent.click(within(card('Trach tie')).getByRole('button', { name: 'Change now' }));
+    expect(await screen.findByText('Mark as changed')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Mark changed' }));
+    await waitFor(() => expect(svc.logChange).toHaveBeenCalledTimes(1));
+    expect(svc.logChange.mock.calls[0][0]).toBe(1);
+    expect(typeof svc.logChange.mock.calls[0][1]).toBe('string');
+    await waitFor(() => expect(svc.list).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByText('Mark as changed')).toBeNull());
+  });
+
+  it('opens the restock gate when the change is refused for no stock', async () => {
+    const err = Object.assign(new Error('out'), {
+      status: 409,
+      payload: { error: 'insufficient_quantity', equipment_id: 1, equipment_name: 'Trach tie', current_quantity: 0 },
+    });
+    svc.logChange.mockRejectedValueOnce(err);
+    renderAt();
+    await screen.findByText('Trach tie');
+    fireEvent.click(within(card('Trach tie')).getByRole('button', { name: 'Change now' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark changed' }));
+    expect(await screen.findByTestId('restock-gate')).toHaveTextContent('Trach tie');
+  });
+
+  it('receives stock through a sheet instead of window.prompt', async () => {
+    const prompt = vi.spyOn(window, 'prompt').mockImplementation(() => '1');
+    renderAt();
+    await screen.findByText('HME filter');
+    fireEvent.click(within(card('HME filter')).getByRole('button', { name: 'Receive' }));
+    expect(await screen.findByText('Receive — HME filter')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/How many arrived/), { target: { value: '3' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add to stock' }));
+    await waitFor(() => expect(svc.receive).toHaveBeenCalledWith(2, 3));
+    await waitFor(() => expect(svc.list).toHaveBeenCalledTimes(2));
+    expect(prompt).not.toHaveBeenCalled();
+    prompt.mockRestore();
+  });
+
+  it('refuses to use more than is on hand, inline', async () => {
+    renderAt();
+    await screen.findByText('Suction catheter');
+    fireEvent.click(within(card('Suction catheter')).getByRole('button', { name: 'Use' }));
+    await screen.findByText('Use — Suction catheter');
+    fireEvent.change(screen.getByLabelText(/How many used/), { target: { value: '5' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Take from stock' }));
+    expect(await screen.findByText('Only 2 on hand.')).toBeInTheDocument();
+    expect(svc.open).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed save in the sheet rather than an alert', async () => {
+    const alert = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    svc.open.mockRejectedValueOnce(new Error('Failed to record what was used'));
+    renderAt();
+    await screen.findByText('Suction catheter');
+    fireEvent.click(within(card('Suction catheter')).getByRole('button', { name: 'Use' }));
+    await screen.findByText('Use — Suction catheter');
+    fireEvent.click(screen.getByRole('button', { name: 'Take from stock' }));
+    expect(await screen.findByText('Failed to record what was used')).toBeInTheDocument();
+    expect(alert).not.toHaveBeenCalled();
+    alert.mockRestore();
+  });
+});

--- a/frontend/src/components/equipment/EquipmentHistory.jsx
+++ b/frontend/src/components/equipment/EquipmentHistory.jsx
@@ -1,0 +1,64 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// History view of the live Equipment panel: the most recent scheduled
+// changes for the patient, optionally narrowed to one supply. One line per
+// change, hairline-separated inside a single box.
+import { EmSelect } from '../vc/EntityModal';
+import { formatChangedAt } from './equipmentStatus';
+import '../schedule/schedule-panel.css';
+import './equipment-panel.css';
+
+export default function EquipmentHistory({ items, rows, loading, error, filter, onFilter }) {
+  return (
+    <div>
+      <div className="eq-filter">
+        <label className="eq-filter-label" htmlFor="eq-hist-filter">Show</label>
+        <EmSelect id="eq-hist-filter" value={filter} onChange={(e) => onFilter(e.target.value)}>
+          <option value="">All supplies</option>
+          {items.map((it) => (
+            <option key={it.id} value={String(it.id)}>{it.name}</option>
+          ))}
+        </EmSelect>
+      </div>
+
+      {error ? (
+        <div className="em-error">{error}</div>
+      ) : loading ? (
+        <div className="ld-dose-empty">Loading history…</div>
+      ) : !rows.length ? (
+        <div className="ld-dose-empty">No changes recorded</div>
+      ) : (
+        <ul className="eq-hist">
+          {rows.map((row) => (
+            <li key={row.id} className="eq-hist-row">
+              <span className="eq-hist-name">{row.equipment_name}</span>
+              <span className="eq-hist-when">{formatChangedAt(row.changed_at)}</span>
+              {(row.changed_by_name || row.notes) && (
+                <span className="eq-hist-meta">
+                  {row.changed_by_name}
+                  {row.changed_by_name && row.notes ? ' · ' : ''}
+                  {row.notes}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/equipment/EquipmentHistory.test.jsx
+++ b/frontend/src/components/equipment/EquipmentHistory.test.jsx
@@ -1,0 +1,50 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// History view of the live Equipment panel: one row per change, and the
+// filter that narrows the request to a single supply.
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import EquipmentHistory from './EquipmentHistory';
+
+const ITEMS = [{ id: 1, name: 'Trach tie' }, { id: 2, name: 'HME filter' }];
+const ROWS = [
+  { id: 10, equipment_name: 'Trach tie', changed_at: '2026-08-20T14:05:00Z', changed_by_name: 'Claude', notes: null },
+  { id: 11, equipment_name: 'HME filter', changed_at: '2026-08-19T09:00:00Z', changed_by_name: null, notes: 'torn' },
+];
+
+describe('EquipmentHistory', () => {
+  it('renders one line per change with who/notes as meta', () => {
+    const { container } = render(<EquipmentHistory items={ITEMS} rows={ROWS} loading={false} error={null} filter="" onFilter={vi.fn()} />);
+    const list = within(container.querySelector('.eq-hist'));
+    expect(list.getAllByText('Trach tie')).toHaveLength(1);
+    expect(list.getByText('Claude')).toBeInTheDocument();
+    expect(list.getByText('torn')).toBeInTheDocument();
+  });
+
+  it('narrows to one supply through the filter', () => {
+    const onFilter = vi.fn();
+    render(<EquipmentHistory items={ITEMS} rows={ROWS} loading={false} error={null} filter="" onFilter={onFilter} />);
+    fireEvent.change(screen.getByLabelText('Show'), { target: { value: '2' } });
+    expect(onFilter).toHaveBeenCalledWith('2');
+  });
+
+  it('says so when nothing has been recorded', () => {
+    render(<EquipmentHistory items={ITEMS} rows={[]} loading={false} error={null} filter="" onFilter={vi.fn()} />);
+    expect(screen.getByText('No changes recorded')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/equipment/EquipmentList.jsx
+++ b/frontend/src/components/equipment/EquipmentList.jsx
@@ -1,0 +1,97 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Supplies view of the live Equipment panel: one tight card per supply with
+// its facts and the actions a caregiver takes at the bedside (receive stock,
+// use a consumable, mark a scheduled item changed). Status rides on the
+// badge — amber for due, green for on schedule, neutral for consumables.
+import { formatDateOnly } from '../../utils/timezone';
+import { isDue } from './equipmentStatus';
+import '../schedule/schedule-panel.css';
+import './equipment-panel.css';
+
+const dateOrDash = (iso) => (iso ? (formatDateOnly(iso) || '—') : '—');
+
+function status(item) {
+  if (!item.scheduled_replacement) return { tone: 'skipped', label: 'Consumable' };
+  if (isDue(item)) return { tone: 'due', label: 'Due now' };
+  return { tone: 'given', label: 'On schedule' };
+}
+
+function Fact({ label, value, unit, due = false }) {
+  return (
+    <div className={`eq-fact${due ? ' due' : ''}`}>
+      <span className="eq-fact-label">{label}</span>
+      <span className="eq-fact-value">
+        {value}
+        {unit && <span className="eq-fact-unit">{unit}</span>}
+      </span>
+    </div>
+  );
+}
+
+export default function EquipmentList({ items, loading, error, onReceive, onOpen, onChange }) {
+  if (error) return <div className="em-error">{error}</div>;
+  if (loading) return <div className="ld-dose-empty">Loading supplies…</div>;
+  if (!items.length) return <div className="ld-dose-empty">No supplies for this patient</div>;
+
+  return (
+    <ul className="eq-list">
+      {items.map((item) => {
+        const s = status(item);
+        const due = s.tone === 'due';
+        return (
+          <li key={item.id} className={`eq-card${due ? ' due' : ''}`} data-testid="eq-card">
+            <div className="eq-card-head">
+              <span className="eq-name">{item.name}</span>
+              <span className={`ld-dose-badge ${s.tone}`}>
+                {due && <span className="ld-dose-dot" />}
+                {s.label}
+              </span>
+            </div>
+
+            <div className="eq-facts">
+              <Fact label="On hand" value={item.quantity ?? 0} unit={item.unit_of_measure} />
+              {item.scheduled_replacement && (
+                <>
+                  <Fact label="Due next" value={dateOrDash(item.due_date)} due={due} />
+                  <Fact label="Last changed" value={dateOrDash(item.last_changed)} />
+                  <Fact label="Every" value={item.useful_days ? `${item.useful_days} d` : '—'} />
+                </>
+              )}
+            </div>
+
+            <div className="eq-card-actions">
+              <button type="button" className="ld-dose-btn sm ghost" onClick={() => onReceive(item)}>
+                Receive
+              </button>
+              {item.scheduled_replacement ? (
+                <button type="button" className="ld-dose-btn sm primary" onClick={() => onChange(item)}>
+                  {due ? 'Change now' : 'Change'}
+                </button>
+              ) : (
+                <button type="button" className="ld-dose-btn sm primary" onClick={() => onOpen(item)}>
+                  Use
+                </button>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/src/components/equipment/StockActionSheet.jsx
+++ b/frontend/src/components/equipment/StockActionSheet.jsx
@@ -1,0 +1,94 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// "How many?" sheet for a supply — receiving stock in, or opening/using it.
+// Replaces the window.prompt() + alert() pair the live Equipment panel used:
+// one number field, validated against what is on hand, errors shown inline.
+import { useEffect, useState } from 'react';
+import EntityModal, { EmField } from '../vc/EntityModal';
+import './equipment-panel.css';
+
+const COPY = {
+  receive: {
+    title: (name) => `Receive — ${name}`,
+    label: 'How many arrived?',
+    submit: 'Add to stock',
+  },
+  open: {
+    title: (name) => `Use — ${name}`,
+    label: 'How many used?',
+    submit: 'Take from stock',
+  },
+};
+
+export default function StockActionSheet({ open, mode, item, busy = false, error = null, onSubmit, onClose }) {
+  const [amount, setAmount] = useState('1');
+  const [localError, setLocalError] = useState(null);
+
+  useEffect(() => {
+    if (open) { setAmount('1'); setLocalError(null); }
+  }, [open, item?.id, mode]);
+
+  if (!item || !COPY[mode]) return null;
+  const copy = COPY[mode];
+  const onHand = Number(item.quantity) || 0;
+  const unit = item.unit_of_measure ? ` ${item.unit_of_measure}` : '';
+
+  const submit = (e) => {
+    e.preventDefault();
+    const n = Number(amount);
+    if (!Number.isInteger(n) || n < 1) {
+      setLocalError('Enter a whole number of 1 or more.');
+      return;
+    }
+    if (mode === 'open' && n > onHand) {
+      setLocalError(`Only ${onHand}${unit} on hand.`);
+      return;
+    }
+    setLocalError(null);
+    onSubmit(n);
+  };
+
+  const shown = localError || error;
+  return (
+    <EntityModal open={open} onOpenChange={(o) => { if (!o) onClose(); }} title={copy.title(item.name)}>
+      <form className="em-form" onSubmit={submit} noValidate>
+        {shown && <div className="em-error">{shown}</div>}
+        <p className="eq-sheet-hint"><strong>{onHand}{unit}</strong> on hand now</p>
+        <EmField label={copy.label} required htmlFor="eq-amount">
+          <input
+            id="eq-amount"
+            className="em-input"
+            type="number"
+            inputMode="numeric"
+            min="1"
+            step="1"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            autoFocus
+          />
+        </EmField>
+        <div className="em-footer">
+          <button type="button" className="em-cancel" onClick={onClose} disabled={busy}>Cancel</button>
+          <button type="submit" className="em-submit" disabled={busy}>
+            {busy ? 'Saving…' : copy.submit}
+          </button>
+        </div>
+      </form>
+    </EntityModal>
+  );
+}

--- a/frontend/src/components/equipment/equipment-panel.css
+++ b/frontend/src/components/equipment/equipment-panel.css
@@ -1,0 +1,213 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/* Live-dashboard Equipment panel (Supplies + History views).
+ *
+ * Built tight on purpose: 4px radii, half-rem padding, one hairline box per
+ * card with flat facts inside, single-line history rows separated by
+ * hairlines rather than boxed. The numbers live in the token block below so
+ * a later density pass can retarget every eq-* rule at once.
+ *
+ * Status is carried by the badge (ld-dose-badge from schedule-panel.css),
+ * never a coloured stripe: amber = due for a change (attention), green = on
+ * schedule, neutral = consumable with no schedule. Red is not used here. */
+@import '../../styles/vc-tokens.css';
+
+.eq-panel {
+  --eq-radius: 4px;
+  --eq-radius-inner: 2px;
+  --eq-pad: 0.5rem;
+  --eq-pad-x: 0.6rem;
+  --eq-gap: 0.4rem;
+  --eq-gap-tight: 0.3rem;
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.eq-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: calc(var(--eq-pad) + env(safe-area-inset-bottom, 0px));
+}
+
+/* ---------- Supplies ---------- */
+.eq-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--eq-gap);
+}
+.eq-card {
+  background: var(--vc-bg-surface);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: var(--eq-radius);
+  padding: var(--eq-pad) var(--eq-pad-x);
+  display: flex;
+  flex-direction: column;
+  gap: var(--eq-gap);
+}
+.eq-card.due { border-color: color-mix(in srgb, var(--vc-state-due) 45%, transparent); }
+
+.eq-card-head {
+  display: flex;
+  align-items: center;
+  gap: var(--eq-gap);
+  min-width: 0;
+}
+.eq-name {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--vc-font-sans);
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.eq-facts {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--eq-gap-tight);
+}
+.eq-panel.narrow .eq-facts { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.eq-fact {
+  background: var(--vc-bg-base);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: var(--eq-radius-inner);
+  padding: 0.3rem 0.45rem;
+  min-width: 0;
+}
+.eq-fact-label {
+  display: block;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+}
+.eq-fact-value {
+  display: block;
+  font-family: var(--vc-font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.eq-fact.due .eq-fact-value { color: var(--vc-state-due); }
+.eq-fact-unit {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--vc-text-secondary);
+  margin-left: 0.2rem;
+}
+
+.eq-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--eq-gap-tight);
+  border-top: 1px solid var(--vc-line-hairline);
+  padding-top: var(--eq-gap);
+}
+/* schedule-panel's buttons, squared to the panel's radius */
+.eq-card-actions .ld-dose-btn { border-radius: var(--eq-radius); }
+
+/* ---------- History ---------- */
+.eq-filter {
+  display: flex;
+  align-items: center;
+  gap: var(--eq-gap);
+  margin-bottom: var(--eq-gap);
+}
+.eq-filter-label {
+  font-family: var(--vc-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  white-space: nowrap;
+}
+.eq-filter .em-select-wrap { flex: 1; min-width: 0; }
+.eq-filter .em-input {
+  min-height: 34px;
+  padding: 0 2rem 0 0.55rem;
+  border-radius: var(--eq-radius);
+  font-size: 12.5px;
+}
+
+.eq-hist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: var(--eq-radius);
+  background: var(--vc-bg-surface);
+}
+.eq-hist-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: var(--eq-gap);
+  row-gap: 0.1rem;
+  align-items: baseline;
+  padding: 0.45rem var(--eq-pad-x);
+  border-top: 1px solid var(--vc-line-hairline);
+}
+.eq-hist-row:first-child { border-top: 0; }
+.eq-hist-name {
+  font-family: var(--vc-font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--vc-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.eq-hist-when {
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  color: var(--vc-text-secondary);
+  white-space: nowrap;
+}
+.eq-hist-meta {
+  grid-column: 1 / -1;
+  font-family: var(--vc-font-mono);
+  font-size: 10.5px;
+  color: var(--vc-text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ---------- Sheets (receive / use) ---------- */
+.eq-sheet-hint {
+  margin: 0;
+  font-family: var(--vc-font-mono);
+  font-size: 11px;
+  color: var(--vc-text-secondary);
+}
+.eq-sheet-hint strong { color: var(--vc-text-primary); font-weight: 600; }

--- a/frontend/src/components/equipment/equipmentStatus.js
+++ b/frontend/src/components/equipment/equipmentStatus.js
@@ -1,0 +1,33 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Status helpers for supplies, kept out of the component files so fast
+// refresh stays happy and the modal/test can share them.
+
+/** A scheduled item whose computed due date is today or earlier. */
+export function isDue(item) {
+  if (!item?.scheduled_replacement || !item.due_date) return false;
+  return new Date(item.due_date) <= new Date();
+}
+
+/** "Aug 22, 2:14 PM" in the viewer's locale; dash when missing. */
+export function formatChangedAt(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true,
+  });
+}

--- a/frontend/src/components/section-panel/PanelViewSwitcher.jsx
+++ b/frontend/src/components/section-panel/PanelViewSwitcher.jsx
@@ -24,12 +24,15 @@
 // skinned from the vc tokens; the menu portals to <body>, so the vc class rides
 // along on SelectContent rather than being inherited.
 import * as SelectPrimitive from '@radix-ui/react-select';
-import { ChevronDownIcon, CheckIcon, CalendarIcon, ClipboardListIcon } from '../Icons';
+import { ChevronDownIcon, CheckIcon, CalendarIcon, ClipboardListIcon, PackageIcon, HistoryIcon } from '../Icons';
 import './section-panel.css';
 
+// Keyed by view value; a view without an entry simply renders without an icon.
 const VIEW_ICON = {
   scheduled: CalendarIcon,
   active: ClipboardListIcon,
+  supplies: PackageIcon,
+  history: HistoryIcon,
 };
 
 /**

--- a/frontend/src/components/vc/ConfirmSheet.jsx
+++ b/frontend/src/components/vc/ConfirmSheet.jsx
@@ -1,0 +1,67 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The vc yes/no sheet. Pairs with EntityModal the way the shadcn confirm
+// Dialog paired with the admin forms, so a panel that needs "are you sure?"
+// has one answer and no reason to reach for ui/dialog.
+//
+//   <ConfirmSheet open={!!pending} onOpenChange={(o) => !o && setPending(null)}
+//                 title="Mark as changed" confirmLabel="Mark changed"
+//                 busy={saving} error={error} onConfirm={doChange}>
+//     Mark <strong>Trach tie</strong> as changed now?
+//   </ConfirmSheet>
+//
+// `tone="destructive"` turns the confirm button red — reserved for actions
+// that delete or clinically escalate; supply and schedule confirms stay on
+// the primary cyan.
+import EntityModal from './EntityModal';
+import './confirm-sheet.css';
+
+export default function ConfirmSheet({
+  open,
+  onOpenChange,
+  title,
+  children,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  tone = 'primary',
+  busy = false,
+  error = null,
+  onConfirm,
+}) {
+  return (
+    <EntityModal open={open} onOpenChange={onOpenChange} title={title}>
+      <div className="em-form cs-form">
+        {error && <div className="em-error">{error}</div>}
+        <p className="cs-body">{children}</p>
+        <div className="em-footer">
+          <button type="button" className="em-cancel" onClick={() => onOpenChange(false)} disabled={busy}>
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className={`em-submit${tone === 'destructive' ? ' destructive' : ''}`}
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {busy ? 'Working…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </EntityModal>
+  );
+}

--- a/frontend/src/components/vc/ConfirmSheet.test.jsx
+++ b/frontend/src/components/vc/ConfirmSheet.test.jsx
@@ -1,0 +1,60 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The vc yes/no sheet.
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConfirmSheet from './ConfirmSheet';
+
+describe('ConfirmSheet', () => {
+  it('shows the question and fires confirm / cancel', () => {
+    const onConfirm = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ConfirmSheet open onOpenChange={onOpenChange} title="Mark as changed" confirmLabel="Mark changed" onConfirm={onConfirm}>
+        Record <strong>Trach tie</strong> as changed now?
+      </ConfirmSheet>
+    );
+    expect(screen.getByText('Mark as changed')).toBeInTheDocument();
+    expect(screen.getByText('Trach tie')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Mark changed' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('marks destructive confirms and disables both buttons while busy', () => {
+    render(
+      <ConfirmSheet open onOpenChange={vi.fn()} title="Delete" confirmLabel="Delete" tone="destructive" busy onConfirm={vi.fn()}>
+        Gone for good.
+      </ConfirmSheet>
+    );
+    const confirm = screen.getByRole('button', { name: /Working/ });
+    expect(confirm).toHaveClass('em-submit', 'destructive');
+    expect(confirm).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+
+  it('shows an error above the question', () => {
+    render(
+      <ConfirmSheet open onOpenChange={vi.fn()} title="T" error="Could not record the change" onConfirm={vi.fn()}>
+        Q
+      </ConfirmSheet>
+    );
+    expect(screen.getByText('Could not record the change')).toHaveClass('em-error');
+  });
+});

--- a/frontend/src/components/vc/confirm-sheet.css
+++ b/frontend/src/components/vc/confirm-sheet.css
@@ -1,0 +1,38 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/* ConfirmSheet — body copy + the destructive confirm variant. The panel,
+ * footer and buttons come from entity-card.css (EntityModal). */
+@import '../../styles/vc-tokens.css';
+
+.cs-form { gap: 0.6rem; }
+.cs-body {
+  margin: 0;
+  font-family: var(--vc-font-sans);
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--vc-text-secondary);
+}
+.cs-body strong { color: var(--vc-text-primary); font-weight: 600; }
+
+.em-submit.destructive {
+  background: color-mix(in srgb, var(--vc-state-alert) 40%, var(--vc-bg-surface));
+  border-color: color-mix(in srgb, var(--vc-state-alert) 50%, transparent);
+}
+.em-submit.destructive:hover {
+  border-color: color-mix(in srgb, var(--vc-state-alert) 70%, transparent);
+}

--- a/frontend/src/contexts/DashboardThemeContext.jsx
+++ b/frontend/src/contexts/DashboardThemeContext.jsx
@@ -54,10 +54,23 @@ export function DashboardThemeProvider({ children }) {
   // dashboard wrapper, so they can't inherit the board's dark tokens. Pin
   // them dark on <html> while the live dashboard is mounted (see the
   // `:root.dash-scheme-dark` block in App.css).
+  //
+  // `vc-form-skin` on <body> is the same opt-in the admin makes in
+  // AdminV2Layout: it turns on vc-forms.css for the shared shadcn primitives
+  // (the Equipment/Settings/Camera panels and the dialogs the rebuilt panels
+  // open). It goes on <body>, not the board wrapper, so it also reaches the
+  // portalled Select/Dialog content. /live and /care never co-mount, so the
+  // two owners can't strip each other's class. Both sheets gate on
+  // `:root:is(:not(.light), .dash-scheme-dark)`, so a light-theme user still
+  // gets the dark skin on the dark-only board.
   useEffect(() => {
     const el = document.documentElement;
     el.classList.add('dash-scheme-dark');
-    return () => el.classList.remove('dash-scheme-dark');
+    document.body.classList.add('vc-form-skin');
+    return () => {
+      el.classList.remove('dash-scheme-dark');
+      document.body.classList.remove('vc-form-skin');
+    };
   }, []);
 
   return (

--- a/frontend/src/contexts/DashboardThemeContext.test.jsx
+++ b/frontend/src/contexts/DashboardThemeContext.test.jsx
@@ -31,9 +31,11 @@ function Probe() {
 
 beforeEach(() => {
   document.documentElement.className = '';
+  document.body.className = '';
 });
 afterEach(() => {
   document.documentElement.className = '';
+  document.body.className = '';
 });
 
 describe('DashboardThemeProvider', () => {
@@ -55,6 +57,20 @@ describe('DashboardThemeProvider', () => {
     expect(document.documentElement.classList.contains('dash-scheme-dark')).toBe(true);
     unmount();
     expect(document.documentElement.classList.contains('dash-scheme-dark')).toBe(false);
+  });
+
+  // The admin's form skin (vc-forms.css) is opted into per surface via a body
+  // class; the live board opts in for its lifetime so shadcn primitives and
+  // portalled dialogs on /live get the same skin as under /care.
+  it('opts the live board into the vc form skin while mounted', () => {
+    const { unmount } = render(
+      <DashboardThemeProvider>
+        <Probe />
+      </DashboardThemeProvider>
+    );
+    expect(document.body.classList.contains('vc-form-skin')).toBe(true);
+    unmount();
+    expect(document.body.classList.contains('vc-form-skin')).toBe(false);
   });
 
   it('exposes a complete chrome for recharts consumers', () => {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1235,10 +1235,9 @@ export default function Dashboard() {
 
       {/* Equipment Modal */}
       {isVentModalOpen && (
-        <EquipmentModal 
-          isOpen={isVentModalOpen} 
-          onClose={() => { setIsVentModalOpen(false); fetchEquipmentDueCount(); }} 
-          equipmentDueCount={equipmentDueCount} 
+        <EquipmentModal
+          isOpen={isVentModalOpen}
+          onClose={() => { setIsVentModalOpen(false); fetchEquipmentDueCount(); }}
         />
       )}
 

--- a/frontend/src/pages/admin-v2/vc-content.css
+++ b/frontend/src/pages/admin-v2/vc-content.css
@@ -23,8 +23,10 @@
  * classes picks it up — the medications / care-tasks / nutrition families
  * are built almost entirely from them.
  *
- * DARK THEME ONLY (scoped :root:not(.light)). Tokens from
- * src/styles/vc-tokens.css; no raw hex.
+ * DARK THEME ONLY. Scoped `:root:is(:not(.light), .dash-scheme-dark)` — the
+ * admin's html theme class OR the live board's `dash-scheme-dark`, which is
+ * dark-only whatever the saved theme (same specificity as `:not(.light)`).
+ * Tokens from src/styles/vc-tokens.css; no raw hex.
  *
  * Color roles: schedule adherence is NEVER red — due/late/missed are
  * amber (--vc-state-due); green means done/active; cyan is the live or
@@ -37,7 +39,7 @@
    that class rather than through the html theme class. Without it, a user whose
    theme is light gets ScheduleList's bootstrap *light* fallbacks on the dark
    board. */
-:root:not(.light),
+:root:is(:not(.light), .dash-scheme-dark),
 .force-dark {
   --sched-ontime-bg: color-mix(in srgb, var(--vc-state-due) 8%, var(--vc-bg-raised));
   --sched-ontime-border: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
@@ -72,9 +74,9 @@
  * selects — re-reads its palette from the vc tokens in dark theme. Scoped
  * to the islands and the Radix portal slots, NOT :root, so legacy CSS that
  * reads the same var names keeps the old palette until its page is skinned. */
-:root:not(.light) .tw,
-:root:not(.light) [data-slot='dialog-content'],
-:root:not(.light) [data-slot='select-content'] {
+:root:is(:not(.light), .dash-scheme-dark) .tw,
+:root:is(:not(.light), .dash-scheme-dark) [data-slot='dialog-content'],
+:root:is(:not(.light), .dash-scheme-dark) [data-slot='select-content'] {
   --background: var(--vc-bg-base);
   --foreground: var(--vc-text-primary);
   --card: var(--vc-bg-surface);
@@ -99,7 +101,7 @@
 
 /* Legend dots / stat-icon chips on the schedule pages consume these as
  * inline-style vars (bootstrap-ish fallbacks keep the light theme). */
-:root:not(.light) {
+:root:is(:not(.light), .dash-scheme-dark) {
   --sched-ontime-chip: color-mix(in srgb, var(--vc-state-due) 15%, transparent);
   --sched-pending-chip: var(--vc-bg-raised);
   --sched-warning-chip: color-mix(in srgb, var(--vc-state-due) 20%, transparent);
@@ -109,27 +111,27 @@
 }
 
 /* ---------- Page headers / sections ---------- */
-:root:not(.light) .admin-v2-page-header h1,
-:root:not(.light) .admin-v2-section-title {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-page-header h1,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-section-title {
   font-family: var(--vc-font-mono);
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-text-muted { color: var(--vc-text-secondary); }
-:root:not(.light) .admin-v2-loading,
-:root:not(.light) .admin-v2-empty-state,
-:root:not(.light) .admin-v2-no-patient { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-text-muted { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-loading,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-empty-state,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-no-patient { color: var(--vc-text-secondary); }
 
 /* ---------- Tables ---------- */
-:root:not(.light) .admin-v2-table-container {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-table-container {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
   box-shadow: none;
 }
-:root:not(.light) .admin-v2-table th {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-table th {
   background: var(--vc-bg-surface);
   color: var(--vc-text-secondary);
   font-family: var(--vc-font-mono);
@@ -139,86 +141,86 @@
   text-transform: uppercase;
   border-bottom: 1px solid var(--vc-line-strong);
 }
-:root:not(.light) .admin-v2-table td {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-table td {
   border-bottom: 1px solid var(--vc-line-hairline);
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-table tr:hover { background: var(--vc-bg-raised); }
-:root:not(.light) .admin-v2-table tr.inactive-row td { color: var(--vc-text-tertiary); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-table tr:hover { background: var(--vc-bg-raised); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-table tr.inactive-row td { color: var(--vc-text-tertiary); }
 
 /* ---------- Stat cards as filter chips ---------- */
-:root:not(.light) .admin-v2-stat-card.selected {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-stat-card.selected {
   border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
   box-shadow: inset 0 -2px 0 var(--vc-data-live);
 }
-:root:not(.light) .admin-v2-stat-card.selected .admin-v2-stat-info h4 {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-stat-card.selected .admin-v2-stat-info h4 {
   color: var(--vc-data-live);
 }
 
 /* ---------- Action buttons (table row + card controls) ---------- */
-:root:not(.light) .admin-v2-action-btn {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn {
   background: transparent;
   border: 1px solid var(--vc-line-hairline);
   border-radius: 8px;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .admin-v2-action-btn:hover {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn:hover {
   border-color: var(--vc-line-strong);
   background: var(--vc-bg-raised);
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-action-btn-delete:hover {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn-delete:hover {
   border-color: color-mix(in srgb, var(--vc-state-alert) 60%, transparent);
   color: var(--vc-state-alert);
 }
-:root:not(.light) .admin-v2-action-btn-success:hover,
-:root:not(.light) .admin-v2-action-btn.resume:hover {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn-success:hover,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn.resume:hover {
   border-color: color-mix(in srgb, var(--vc-state-complete) 60%, transparent);
   color: var(--vc-state-complete);
 }
-:root:not(.light) .admin-v2-action-btn-warning:hover,
-:root:not(.light) .admin-v2-action-btn.pause:hover {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn-warning:hover,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-action-btn.pause:hover {
   border-color: color-mix(in srgb, var(--vc-state-due) 60%, transparent);
   color: var(--vc-state-due);
 }
 
 /* ---------- Buttons ---------- */
-:root:not(.light) .admin-v2-btn {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn {
   border-radius: 8px;
   font-family: var(--vc-font-mono);
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
-:root:not(.light) .admin-v2-btn-primary {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-primary {
   background: var(--vc-data-live);
   border-color: transparent;
   color: var(--vc-bg-base);
 }
-:root:not(.light) .admin-v2-btn-primary:hover {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-primary:hover {
   background: color-mix(in srgb, var(--vc-data-live) 85%, var(--vc-text-primary));
 }
-:root:not(.light) .admin-v2-btn-secondary,
-:root:not(.light) .admin-v2-btn-ghost {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-secondary,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-ghost {
   background: transparent;
   border: 1px solid var(--vc-line-strong);
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-btn-secondary:hover,
-:root:not(.light) .admin-v2-btn-ghost:hover { background: var(--vc-bg-raised); }
-:root:not(.light) .admin-v2-btn-danger {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-secondary:hover,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-ghost:hover { background: var(--vc-bg-raised); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-danger {
   background: var(--vc-state-alert);
   border-color: transparent;
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-btn-danger-ghost {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-btn-danger-ghost {
   background: transparent;
   border: 1px solid color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
   color: var(--vc-state-alert);
 }
 
 /* ---------- Badges: outline pills, roles not rainbow ---------- */
-:root:not(.light) .admin-v2-badge {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge {
   background: transparent;
   border: 1px solid var(--vc-line-strong);
   border-radius: 999px;
@@ -229,32 +231,32 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
-:root:not(.light) .admin-v2-badge-success {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-success {
   border-color: color-mix(in srgb, var(--vc-state-complete) 50%, transparent);
   color: var(--vc-state-complete);
 }
-:root:not(.light) .admin-v2-badge-warning {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-warning {
   border-color: color-mix(in srgb, var(--vc-state-due) 50%, transparent);
   color: var(--vc-state-due);
 }
-:root:not(.light) .admin-v2-badge-danger,
-:root:not(.light) .admin-v2-badge-critical {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-danger,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-critical {
   border-color: color-mix(in srgb, var(--vc-state-alert) 50%, transparent);
   color: var(--vc-state-alert);
 }
-:root:not(.light) .admin-v2-badge-info,
-:root:not(.light) .admin-v2-badge-primary {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-info,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-primary {
   border-color: color-mix(in srgb, var(--vc-data-live) 50%, transparent);
   color: var(--vc-data-live);
 }
-:root:not(.light) .admin-v2-badge-secondary,
-:root:not(.light) .admin-v2-badge-muted {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-secondary,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-badge-muted {
   border-color: var(--vc-line-hairline);
   color: var(--vc-text-tertiary);
 }
 
 /* Active/inactive status pills (meds, schedules, tasks) — dot + outline */
-:root:not(.light) .admin-v2-status-badge {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-status-badge {
   background: transparent;
   border: 1px solid var(--vc-line-strong);
   border-radius: 999px;
@@ -268,25 +270,25 @@
   align-items: center;
   gap: 0.35rem;
 }
-:root:not(.light) .admin-v2-status-badge::before {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-status-badge::before {
   content: '';
   width: 6px;
   height: 6px;
   border-radius: 50%;
   background: currentColor;
 }
-:root:not(.light) .admin-v2-status-badge.active {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-status-badge.active {
   color: var(--vc-state-complete);
   border-color: color-mix(in srgb, var(--vc-state-complete) 45%, transparent);
 }
-:root:not(.light) .admin-v2-status-badge.inactive {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-status-badge.inactive {
   color: var(--vc-text-tertiary);
   border-color: var(--vc-line-hairline);
 }
 
 /* History dose-status badges: 'danger' here means a LATE dose — schedule
  * adherence, so amber, not red. */
-:root:not(.light) .history-status-badge {
+:root:is(:not(.light), .dash-scheme-dark) .history-status-badge {
   border-radius: 999px;
   font-family: var(--vc-font-mono);
   font-size: 10px;
@@ -294,31 +296,31 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
-:root:not(.light) .history-status-badge.success {
+:root:is(:not(.light), .dash-scheme-dark) .history-status-badge.success {
   background: color-mix(in srgb, var(--vc-state-complete) 14%, transparent);
   color: var(--vc-state-complete);
 }
-:root:not(.light) .history-status-badge.warning {
+:root:is(:not(.light), .dash-scheme-dark) .history-status-badge.warning {
   background: color-mix(in srgb, var(--vc-state-due) 14%, transparent);
   color: var(--vc-state-due);
 }
-:root:not(.light) .history-status-badge.danger {
+:root:is(:not(.light), .dash-scheme-dark) .history-status-badge.danger {
   background: color-mix(in srgb, var(--vc-state-due) 22%, transparent);
   color: var(--vc-state-due);
 }
-:root:not(.light) .history-status-badge.muted {
+:root:is(:not(.light), .dash-scheme-dark) .history-status-badge.muted {
   background: var(--vc-bg-raised);
   color: var(--vc-text-tertiary);
 }
 
 /* ---------- History pages: filter bar, stats row, table cells ---------- */
-:root:not(.light) .history-filter-bar,
-:root:not(.light) .vitals-history-filters {
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-bar,
+:root:is(:not(.light), .dash-scheme-dark) .vitals-history-filters {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
 }
-:root:not(.light) .history-filter-group label {
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-group label {
   font-family: var(--vc-font-mono);
   font-size: 10px;
   font-weight: 500;
@@ -326,15 +328,15 @@
   text-transform: uppercase;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .history-filter-input,
-:root:not(.light) .history-filter-select {
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-input,
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-select {
   background: var(--vc-bg-raised);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 8px;
   color: var(--vc-text-primary);
 }
-:root:not(.light) .history-filter-input:focus,
-:root:not(.light) .history-filter-select:focus {
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-input:focus,
+:root:is(:not(.light), .dash-scheme-dark) .history-filter-select:focus {
   border-color: var(--vc-data-live);
   outline: none;
   /* visible focus ring — border recolor alone is too weak (WCAG focus
@@ -344,18 +346,18 @@
 
 /* Stats row: mono tabular values; 'danger' counts late/missed doses —
  * schedule adherence, so amber, not red */
-:root:not(.light) .history-stat {
+:root:is(:not(.light), .dash-scheme-dark) .history-stat {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
 }
-:root:not(.light) .history-stat-value {
+:root:is(:not(.light), .dash-scheme-dark) .history-stat-value {
   font-family: var(--vc-font-mono);
   font-variant-numeric: tabular-nums;
   font-weight: 400;
   color: var(--vc-text-primary);
 }
-:root:not(.light) .history-stat-label {
+:root:is(:not(.light), .dash-scheme-dark) .history-stat-label {
   font-family: var(--vc-font-mono);
   font-size: 10px;
   font-weight: 500;
@@ -363,37 +365,37 @@
   text-transform: uppercase;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .history-stat.success .history-stat-value { color: var(--vc-state-complete); }
-:root:not(.light) .history-stat.warning .history-stat-value { color: var(--vc-state-due); }
-:root:not(.light) .history-stat.danger .history-stat-value { color: var(--vc-state-due); }
-:root:not(.light) .history-stat.muted .history-stat-value { color: var(--vc-text-tertiary); }
+:root:is(:not(.light), .dash-scheme-dark) .history-stat.success .history-stat-value { color: var(--vc-state-complete); }
+:root:is(:not(.light), .dash-scheme-dark) .history-stat.warning .history-stat-value { color: var(--vc-state-due); }
+:root:is(:not(.light), .dash-scheme-dark) .history-stat.danger .history-stat-value { color: var(--vc-state-due); }
+:root:is(:not(.light), .dash-scheme-dark) .history-stat.muted .history-stat-value { color: var(--vc-text-tertiary); }
 
 /* Table cell text */
-:root:not(.light) .history-med-name { color: var(--vc-text-primary); }
-:root:not(.light) .history-med-concentration { color: var(--vc-text-secondary); }
-:root:not(.light) .history-dose {
+:root:is(:not(.light), .dash-scheme-dark) .history-med-name { color: var(--vc-text-primary); }
+:root:is(:not(.light), .dash-scheme-dark) .history-med-concentration { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .history-dose {
   font-family: var(--vc-font-mono);
   font-variant-numeric: tabular-nums;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .history-dose.skipped {
+:root:is(:not(.light), .dash-scheme-dark) .history-dose.skipped {
   color: var(--vc-text-tertiary);
   text-decoration: line-through;
 }
-:root:not(.light) .history-datetime {
+:root:is(:not(.light), .dash-scheme-dark) .history-datetime {
   font-family: var(--vc-font-mono);
   font-variant-numeric: tabular-nums;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .history-unscheduled {
+:root:is(:not(.light), .dash-scheme-dark) .history-unscheduled {
   font-family: var(--vc-font-mono);
   font-size: 9.5px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--vc-text-tertiary);
 }
-:root:not(.light) .history-notes { color: var(--vc-text-secondary); }
-:root:not(.light) .history-category-badge {
+:root:is(:not(.light), .dash-scheme-dark) .history-notes { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .history-category-badge {
   background: transparent;
   border: 1px solid var(--vc-line-strong);
   border-radius: 999px;
@@ -405,7 +407,7 @@
 }
 
 /* Vitals history source badge (manual / device / integrations) */
-:root:not(.light) .admin-v2-source-badge {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-source-badge {
   background: transparent;
   border: 1px solid var(--vc-line-hairline);
   border-radius: 999px;
@@ -415,21 +417,21 @@
   text-transform: uppercase;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .admin-v2-source-badge.device,
-:root:not(.light) .admin-v2-source-badge.sensor {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-source-badge.device,
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-source-badge.sensor {
   border-color: color-mix(in srgb, var(--vc-data-live) 45%, transparent);
   color: var(--vc-data-live);
 }
 
 /* ---------- List cards (manage pages) ---------- */
-:root:not(.light) .admin-v2-med-card {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-med-card {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
   box-shadow: none;
 }
-:root:not(.light) .admin-v2-med-card-inactive { opacity: 0.65; }
-:root:not(.light) .admin-v2-med-card-label {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-med-card-inactive { opacity: 0.65; }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-med-card-label {
   font-family: var(--vc-font-mono);
   font-size: 10px;
   font-weight: 500;
@@ -439,57 +441,57 @@
 }
 
 /* ---------- Filters / day picker ---------- */
-:root:not(.light) .admin-v2-filter-card {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-filter-card {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
 }
-:root:not(.light) .admin-v2-day-btn {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-day-btn {
   background: transparent;
   border: 1px solid var(--vc-line-hairline);
   border-radius: 8px;
   color: var(--vc-text-secondary);
   font-family: var(--vc-font-mono);
 }
-:root:not(.light) .admin-v2-day-btn:hover { border-color: var(--vc-line-strong); }
-:root:not(.light) .admin-v2-day-btn.selected {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-day-btn:hover { border-color: var(--vc-line-strong); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-day-btn.selected {
   background: color-mix(in srgb, var(--vc-data-live) 15%, transparent);
   border-color: var(--vc-data-live);
   color: var(--vc-data-live);
 }
 
 /* ---------- Schedule summary cards + legend + progress ---------- */
-:root:not(.light) .admin-v2-schedule-summary-card {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-summary-card {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
 }
-:root:not(.light) .admin-v2-schedule-summary-title {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-summary-title {
   font-family: var(--vc-font-mono);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--vc-text-primary);
 }
-:root:not(.light) .admin-v2-schedule-summary-detail { color: var(--vc-text-secondary); }
-:root:not(.light) .admin-v2-schedule-legend {
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-summary-detail { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-legend {
   background: var(--vc-bg-surface);
   border: 1px solid var(--vc-line-hairline);
   border-radius: 10px;
 }
-:root:not(.light) .admin-v2-legend-item { color: var(--vc-text-secondary); }
-:root:not(.light) .admin-v2-schedule-progress-bar.success { background: var(--vc-state-complete); }
-:root:not(.light) .admin-v2-schedule-progress-bar.good { background: var(--vc-data-live); }
-:root:not(.light) .admin-v2-schedule-progress-bar.warning { background: var(--vc-state-due); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-legend-item { color: var(--vc-text-secondary); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-progress-bar.success { background: var(--vc-state-complete); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-progress-bar.good { background: var(--vc-data-live); }
+:root:is(:not(.light), .dash-scheme-dark) .admin-v2-schedule-progress-bar.warning { background: var(--vc-state-due); }
 
 /* ---------- Medication stock bar (Overview / Manage entity cards) ---------- */
-:root:not(.light) .med-stock {
+:root:is(:not(.light), .dash-scheme-dark) .med-stock {
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
   padding: 0 0.9rem 0.7rem;
   font-family: var(--vc-font-mono);
 }
-:root:not(.light) .med-stock-label {
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-label {
   display: flex;
   justify-content: space-between;
   gap: 0.5rem;
@@ -497,27 +499,27 @@
   letter-spacing: 0.04em;
   color: var(--vc-text-secondary);
 }
-:root:not(.light) .med-stock-label .med-stock-status { text-transform: uppercase; font-weight: 600; }
-:root:not(.light) .med-stock-label.low .med-stock-status { color: var(--vc-state-due); }
-:root:not(.light) .med-stock-label.ok .med-stock-status { color: var(--vc-state-complete); }
-:root:not(.light) .med-stock-bar {
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-label .med-stock-status { text-transform: uppercase; font-weight: 600; }
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-label.low .med-stock-status { color: var(--vc-state-due); }
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-label.ok .med-stock-status { color: var(--vc-state-complete); }
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-bar {
   height: 6px;
   border-radius: 3px;
   background: var(--vc-bg-raised);
   overflow: hidden;
 }
-:root:not(.light) .med-stock-fill {
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-fill {
   height: 100%;
   border-radius: 3px;
   background: var(--vc-state-complete);
   transition: width 0.3s ease;
 }
-:root:not(.light) .med-stock-fill.low { background: var(--vc-state-due); }
+:root:is(:not(.light), .dash-scheme-dark) .med-stock-fill.low { background: var(--vc-state-due); }
 
 /* ---------- Nutrition schedule: off-window confirm ---------- */
 /* Replaces a hard-coded amber hex and a text warning glyph. Amber is the
    attention role here — schedule timing is never red. */
-:root:not(.light) .nsched-warn-badge {
+:root:is(:not(.light), .dash-scheme-dark) .nsched-warn-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -527,7 +529,7 @@
   color: var(--vc-state-due);
   background: color-mix(in srgb, var(--vc-state-due) 20%, transparent);
 }
-:root:not(.light) .nsched-warn-heading {
+:root:is(:not(.light), .dash-scheme-dark) .nsched-warn-heading {
   margin-bottom: 0.375rem;
   font-weight: 600;
   color: var(--vc-state-due);

--- a/frontend/src/pages/admin-v2/vc-forms.css
+++ b/frontend/src/pages/admin-v2/vc-forms.css
@@ -26,8 +26,13 @@
  * class lives on <body> (not a page wrapper) so it also reaches Radix's
  * portalled Select/Dialog content, which renders outside the page tree.
  *
- * DARK THEME ONLY (scoped :root:not(.light)) — the vc aesthetic is dark by
- * design and the light theme keeps the stock shadcn palette.
+ * DARK THEME ONLY — the vc aesthetic is dark by design and the light theme
+ * keeps the stock shadcn palette. Every rule is scoped
+ * `:root:is(:not(.light), .dash-scheme-dark)`: the admin's html theme class,
+ * OR the live board's `dash-scheme-dark` (DashboardThemeProvider), which is
+ * dark-only regardless of the user's saved theme and also puts
+ * `vc-form-skin` on <body>. `:is()` keeps the specificity of `:not(.light)`
+ * so nothing in the cascade re-orders.
  *
  * Hooks: every primitive carries data-slot, and button/badge/alert also carry
  * data-variant / data-size, so nothing here depends on utility class names.
@@ -42,28 +47,28 @@
 /* vc-content.css already remaps the shared palette for every .tw island.
  * Destructive is deliberately left on the stock red there (it is still the
  * legacy admin language); inside the skin it moves onto the vc alert token. */
-:root:not(.light) body.vc-form-skin .tw,
-:root:not(.light) body.vc-form-skin [data-slot='dialog-content'],
-:root:not(.light) body.vc-form-skin [data-slot='select-content'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin .tw,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-content'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-content'] {
   --destructive: var(--vc-state-alert);
 }
 
 /* ---------- Cards / panels ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='card'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='card'] {
   background: var(--vc-bg-surface);
   border-color: var(--vc-line-hairline);
   border-radius: 12px;
   box-shadow: none;
   font-family: var(--vc-font-sans);
 }
-:root:not(.light) body.vc-form-skin [data-slot='card-header'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='card-header'] {
   border-bottom-color: var(--vc-line-hairline);
 }
-:root:not(.light) body.vc-form-skin [data-slot='card-footer'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='card-footer'] {
   border-top-color: var(--vc-line-hairline);
 }
-:root:not(.light) body.vc-form-skin [data-slot='card-title'],
-:root:not(.light) body.vc-form-skin [data-slot='dialog-title'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='card-title'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-title'] {
   font-family: var(--vc-font-mono);
   font-size: 14px;
   font-weight: 600;
@@ -72,8 +77,8 @@
   text-transform: uppercase;
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='card-description'],
-:root:not(.light) body.vc-form-skin [data-slot='dialog-description'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='card-description'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-description'] {
   font-family: var(--vc-font-sans);
   font-size: 13px;
   line-height: 1.5;
@@ -83,10 +88,10 @@
 /* Group headings inside a panel ("Dashboard Display", "Vital Sign Alert
  * Thresholds"): one step quieter than the panel title. tailwind.css zeroes
  * .tw h1–h6, so these carry no UA styling to fight. */
-:root:not(.light) body.vc-form-skin .tw h3,
-:root:not(.light) body.vc-form-skin .tw h4,
-:root:not(.light) body.vc-form-skin [data-slot='dialog-content'] h3,
-:root:not(.light) body.vc-form-skin [data-slot='dialog-content'] h4 {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin .tw h3,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin .tw h4,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-content'] h3,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-content'] h4 {
   font-family: var(--vc-font-mono);
   font-size: 12px;
   font-weight: 600;
@@ -96,7 +101,7 @@
 }
 
 /* ---------- Labels ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='label'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='label'] {
   font-family: var(--vc-font-mono);
   font-size: 11px;
   font-weight: 600;
@@ -107,9 +112,9 @@
 
 /* ---------- Text inputs / textareas / select triggers ---------- */
 /* Controls sit on the base surface so they read as wells inside a panel. */
-:root:not(.light) body.vc-form-skin [data-slot='input'],
-:root:not(.light) body.vc-form-skin [data-slot='textarea'],
-:root:not(.light) body.vc-form-skin [data-slot='select-trigger'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='input'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='textarea'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-trigger'] {
   min-height: 40px;
   background: var(--vc-bg-base);
   border-color: var(--vc-line-strong);
@@ -120,33 +125,33 @@
   font-size: 13.5px;
   letter-spacing: 0.03em;
 }
-:root:not(.light) body.vc-form-skin [data-slot='textarea'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='textarea'] {
   line-height: 1.5;
   padding-block: 0.55rem;
 }
-:root:not(.light) body.vc-form-skin [data-slot='input']::placeholder,
-:root:not(.light) body.vc-form-skin [data-slot='textarea']::placeholder {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='input']::placeholder,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='textarea']::placeholder {
   color: var(--vc-text-tertiary);
   letter-spacing: 0.06em;
 }
-:root:not(.light) body.vc-form-skin [data-slot='select-trigger'][data-placeholder] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-trigger'][data-placeholder] {
   color: var(--vc-text-tertiary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='input']:focus-visible,
-:root:not(.light) body.vc-form-skin [data-slot='textarea']:focus-visible,
-:root:not(.light) body.vc-form-skin [data-slot='select-trigger']:focus {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='input']:focus-visible,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='textarea']:focus-visible,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-trigger']:focus {
   outline: none;
   border-color: var(--vc-data-live);
   box-shadow: 0 0 0 1px var(--vc-data-live);
 }
-:root:not(.light) body.vc-form-skin [data-slot='input']:disabled,
-:root:not(.light) body.vc-form-skin [data-slot='textarea']:disabled,
-:root:not(.light) body.vc-form-skin [data-slot='select-trigger']:disabled {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='input']:disabled,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='textarea']:disabled,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-trigger']:disabled {
   background: var(--vc-bg-surface);
   color: var(--vc-text-tertiary);
 }
 /* File pickers (backup restore) keep the mono language on their button half. */
-:root:not(.light) body.vc-form-skin [data-slot='input']::file-selector-button {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='input']::file-selector-button {
   color: var(--vc-data-live);
   font-family: var(--vc-font-mono);
   font-size: 11px;
@@ -161,7 +166,7 @@
  * chrome (which paints its own light field over background-color); tapping
  * still opens the OS picker, and the option list stays OS-drawn. The chevron
  * is two gradient wedges rather than an SVG so it can ride on currentColor. */
-:root:not(.light) body.vc-form-skin .tw select {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin .tw select {
   appearance: none;
   -webkit-appearance: none;
   min-height: 40px;
@@ -180,20 +185,20 @@
   font-size: 13px;
   letter-spacing: 0.03em;
 }
-:root:not(.light) body.vc-form-skin .tw select:focus {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin .tw select:focus {
   outline: none;
   border-color: var(--vc-data-live);
   box-shadow: 0 0 0 1px var(--vc-data-live);
 }
 
 /* ---------- Select menu (portalled) ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='select-content'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-content'] {
   background: var(--vc-bg-raised);
   border-color: var(--vc-line-strong);
   border-radius: 10px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
 }
-:root:not(.light) body.vc-form-skin [data-slot='select-item'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-item'] {
   min-height: 38px;
   border-radius: 6px;
   color: var(--vc-text-primary);
@@ -203,17 +208,17 @@
 }
 /* --accent is bg-raised in the vc remap, i.e. the menu's own background, so
  * the stock focus style was invisible — highlight with the live accent. */
-:root:not(.light) body.vc-form-skin [data-slot='select-item']:focus,
-:root:not(.light) body.vc-form-skin [data-slot='select-item'][data-highlighted] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-item']:focus,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-item'][data-highlighted] {
   background: color-mix(in srgb, var(--vc-data-live) 18%, transparent);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='select-item'][data-state='checked'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='select-item'][data-state='checked'] {
   color: var(--vc-data-live);
 }
 
 /* ---------- Buttons ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='button'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'] {
   border-radius: 8px;
   font-family: var(--vc-font-mono);
   font-size: 11.5px;
@@ -221,57 +226,57 @@
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-size='default'] { min-height: 38px; }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-size='lg'] { min-height: 42px; }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-size='sm'] { font-size: 10.5px; }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='default'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-size='default'] { min-height: 38px; }
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-size='lg'] { min-height: 42px; }
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-size='sm'] { font-size: 10.5px; }
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='default'] {
   background: var(--vc-data-live);
   color: var(--vc-bg-base);
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='default']:hover {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='default']:hover {
   background: var(--vc-data-live);
   filter: brightness(1.08);
 }
 /* Secondary/outline read as quiet outlines rather than filled grey chips. */
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='secondary'],
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='outline'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='secondary'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='outline'] {
   background: transparent;
   border: 1px solid var(--vc-line-strong);
   color: var(--vc-text-secondary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='secondary']:hover,
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='outline']:hover {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='secondary']:hover,
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='outline']:hover {
   background: var(--vc-bg-raised);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='ghost'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='ghost'] {
   color: var(--vc-text-secondary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='ghost']:hover {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='ghost']:hover {
   background: var(--vc-bg-raised);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='button'][data-variant='link'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button'][data-variant='link'] {
   color: var(--vc-data-live);
   letter-spacing: 0.1em;
 }
-:root:not(.light) body.vc-form-skin [data-slot='button']:focus-visible {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='button']:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--vc-bg-base), 0 0 0 4px var(--vc-data-live);
 }
 
 /* ---------- Checkbox ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='checkbox'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='checkbox'] {
   border-radius: 4px;
   border-color: var(--vc-line-strong);
   background: var(--vc-bg-base);
 }
-:root:not(.light) body.vc-form-skin [data-slot='checkbox'][data-state='checked'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='checkbox'][data-state='checked'] {
   background: var(--vc-data-live);
   border-color: var(--vc-data-live);
   color: var(--vc-bg-base);
 }
-:root:not(.light) body.vc-form-skin [data-slot='checkbox']:focus-visible {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='checkbox']:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--vc-bg-base), 0 0 0 4px var(--vc-data-live);
 }
@@ -279,21 +284,21 @@
 /* ---------- Switch ---------- */
 /* The thumb is stock `bg-background`, which on the dark scale is nearly the
  * same value as the track — it reads as a hole rather than a knob. */
-:root:not(.light) body.vc-form-skin [data-slot='switch'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='switch'] {
   background: var(--vc-bg-base);
   border: 1px solid var(--vc-line-strong);
 }
-:root:not(.light) body.vc-form-skin [data-slot='switch'][data-state='checked'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='switch'][data-state='checked'] {
   background: var(--vc-data-live);
   border-color: var(--vc-data-live);
 }
-:root:not(.light) body.vc-form-skin [data-slot='switch-thumb'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='switch-thumb'] {
   background: var(--vc-text-secondary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='switch'][data-state='checked'] [data-slot='switch-thumb'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='switch'][data-state='checked'] [data-slot='switch-thumb'] {
   background: var(--vc-bg-base);
 }
-:root:not(.light) body.vc-form-skin [data-slot='switch']:focus-visible {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='switch']:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--vc-bg-base), 0 0 0 4px var(--vc-data-live);
 }
@@ -301,7 +306,7 @@
 /* ---------- Badges ---------- */
 /* The stock variants carry GitHub-palette hex; restate them on the vc scale
  * so a badge next to a skinned control belongs to the same system. */
-:root:not(.light) body.vc-form-skin [data-slot='badge'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'] {
   border-radius: 999px;
   font-family: var(--vc-font-mono);
   font-size: 9.5px;
@@ -309,69 +314,69 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='default'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='default'] {
   background: color-mix(in srgb, var(--vc-data-live) 18%, transparent);
   border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
   color: var(--vc-data-live);
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='success'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='success'] {
   background: color-mix(in srgb, var(--vc-state-complete) 15%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-complete) 55%, transparent);
   color: var(--vc-state-complete);
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='warning'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='warning'] {
   background: color-mix(in srgb, var(--vc-state-due) 15%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
   color: var(--vc-state-due);
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='danger'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='danger'] {
   background: color-mix(in srgb, var(--vc-state-alert) 15%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
   color: var(--vc-state-alert);
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='info'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='info'] {
   background: color-mix(in srgb, var(--vc-data-live) 15%, transparent);
   border-color: color-mix(in srgb, var(--vc-data-live) 55%, transparent);
   color: var(--vc-data-live);
 }
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='secondary'],
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='muted'],
-:root:not(.light) body.vc-form-skin [data-slot='badge'][data-variant='outline'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='secondary'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='muted'],
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='badge'][data-variant='outline'] {
   background: transparent;
   border-color: var(--vc-line-strong);
   color: var(--vc-text-secondary);
 }
 
 /* ---------- Alerts ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='alert'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='alert'] {
   border-radius: 8px;
   font-family: var(--vc-font-sans);
   font-size: 13.5px;
   line-height: 1.5;
 }
-:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='default'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='alert'][data-variant='default'] {
   background: var(--vc-bg-raised);
   border-color: var(--vc-line-hairline);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='destructive'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='alert'][data-variant='destructive'] {
   background: color-mix(in srgb, var(--vc-state-alert) 12%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-alert) 55%, transparent);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='success'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='alert'][data-variant='success'] {
   background: color-mix(in srgb, var(--vc-state-complete) 12%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-complete) 55%, transparent);
   color: var(--vc-text-primary);
 }
-:root:not(.light) body.vc-form-skin [data-slot='alert'][data-variant='warning'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='alert'][data-variant='warning'] {
   background: color-mix(in srgb, var(--vc-state-due) 12%, transparent);
   border-color: color-mix(in srgb, var(--vc-state-due) 55%, transparent);
   color: var(--vc-text-primary);
 }
 
 /* ---------- Dialogs ---------- */
-:root:not(.light) body.vc-form-skin [data-slot='dialog-content'] {
+:root:is(:not(.light), .dash-scheme-dark) body.vc-form-skin [data-slot='dialog-content'] {
   background: var(--vc-bg-sheet);
   border-color: var(--vc-line-strong);
   border-radius: 12px;

--- a/frontend/src/pages/admin-v2/vc-skin-gating.test.js
+++ b/frontend/src/pages/admin-v2/vc-skin-gating.test.js
@@ -1,0 +1,39 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The two vc skin sheets must stay reachable from the live board, which is
+// dark-only regardless of the user's saved theme. Every dark-gated rule is
+// therefore scoped `:root:is(:not(.light), .dash-scheme-dark)`; a bare
+// `:root:not(.light)` would silently drop the skin for a light-theme user on
+// /live (the board pins `dash-scheme-dark` on <html>, never removes `light`).
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const SHEETS = ['./vc-forms.css', './vc-content.css'];
+const GATE = ':root:is(:not(.light), .dash-scheme-dark)';
+
+describe('vc skin dark gating', () => {
+  for (const sheet of SHEETS) {
+    it(`${sheet} has no bare :root:not(.light) selectors`, () => {
+      const css = readFileSync(fileURLToPath(new URL(sheet, import.meta.url)), 'utf8');
+      const bare = css.split('\n').filter((l) => l.includes(':root:not(.light)'));
+      expect(bare).toEqual([]);
+      expect(css.includes(GATE)).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
Stacked on #154 (merge that first; this diff includes its commit until then).

## What

- `components/EquipmentModal.jsx` rewritten as a vc docked panel: `ModalBase` + `mp-modal-title`, `PanelViewSwitcher` (Supplies / History), `useModalDock()` decides narrow vs wide (no more resize listener), data via `equipmentService`, History is one `GET /api/equipment/history` call (was N+1 per item) with a per-supply filter.
- New `components/equipment/`: `EquipmentList` (tight hairline cards, status badge never a stripe, 4 flat facts, Receive / Change / Use), `EquipmentHistory` (one line per change), `StockActionSheet` (replaces `window.prompt`/`alert`), `equipmentStatus.js`, `equipment-panel.css` (density tokens at the top: 4px radii, half-rem padding).
- New `components/vc/ConfirmSheet.jsx` — reusable vc yes/no on `EntityModal` (+ `.em-submit.destructive`); the other panels' shadcn confirm Dialogs can move to it next.
- `PanelViewSwitcher` gains `supplies`/`history` icons. `Dashboard.jsx` stops passing the ignored `equipmentDueCount`.
- No `@/components/ui/*`, no raw hex, no left accent bars in the panel.

## Tests

`EquipmentModal.test.jsx` (7: badges + due sublabel, dock-driven layout, change → confirm → `logChange` + refetch, 409 → restock gate, receive via sheet with `window.prompt` never called, over-use refused inline, failed save shown inline not `alert`), `EquipmentHistory.test.jsx` (3), `ConfirmSheet.test.jsx` (3). `npm run lint` clean; full `npm test` green.

## Verified

Playwright on `/live` (patient 5, with two seeded scheduled items, removed afterwards) at 1440×900 narrow + expanded and 390×844: supplies, change confirm, receive sheet, history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vgpstiNy2SiLZt6ALkKYW