### PR TITLE
Give the caregiver PIN challenge the vitals keypad and a masked entry

### DIFF
--- a/frontend/src/components/auth/PinChallengeModal.jsx
+++ b/frontend/src/components/auth/PinChallengeModal.jsx
@@ -18,8 +18,12 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ModalBase from '../ModalBase';
+import Keypad from '../vc/Keypad';
 import { useAuth } from '../../contexts/AuthContext';
 import './pin-challenge.css';
+
+export const PIN_MIN = 4;
+export const PIN_MAX = 8;
 
 /**
  * Global PIN re-auth challenge. Two steps:
@@ -81,9 +85,12 @@ export default function PinChallengeModal({ open, onSuccess, onCancel }) {
     setError(null);
   };
 
+  const pinReady = pin.length >= PIN_MIN;
+  const canSubmit = !submitting && (requirePassword ? !!password : pinReady);
+
   const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!selected) return;
+    e?.preventDefault?.();
+    if (!selected || !canSubmit) return;
     setSubmitting(true);
     setError(null);
     try {
@@ -102,10 +109,35 @@ export default function PinChallengeModal({ open, onSuccess, onCancel }) {
       } else {
         setError(result.error || 'Authentication failed');
       }
+    } catch (err) {
+      // selectUser throws on a non-2xx (a wrong PIN is a 401): show it, and
+      // clear the PIN so the next attempt starts clean.
+      setError(err?.message || 'Authentication failed');
+      setPin('');
     } finally {
       setSubmitting(false);
     }
   };
+
+  const pinMode = !!selected && !requirePassword;
+  const typeDigit = (d) => setPin((p) => (p.length < PIN_MAX ? p + d : p));
+  const eraseDigit = () => setPin((p) => p.slice(0, -1));
+
+  // There is no text field in PIN mode (the pad + masked slots are the
+  // input), so a hardware keyboard is wired here: digits, Backspace, Enter.
+  useEffect(() => {
+    if (!open || !pinMode) return undefined;
+    const onKeyDown = (e) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (/^[0-9]$/.test(e.key)) { e.preventDefault(); typeDigit(e.key); }
+      else if (e.key === 'Backspace') { e.preventDefault(); eraseDigit(); }
+      else if (e.key === 'Enter') { e.preventDefault(); handleSubmit(); }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+    // handleSubmit closes over pin/selected/submitting via state; re-bind on change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, pinMode, pin, selected, submitting, requirePassword, password]);
 
   if (!open) return null;
 
@@ -167,19 +199,41 @@ export default function PinChallengeModal({ open, onSuccess, onCancel }) {
                 />
               </div>
             ) : (
-              <div>
-                <label className="pc-label" htmlFor="pc-pin">PIN</label>
-                <input
-                  id="pc-pin"
-                  type="password"
-                  className="pc-input pin"
-                  inputMode="numeric"
+              <div className="pc-pin">
+                <span className="pc-label" id="pc-pin-label">PIN</span>
+                {/* Masked slots: a dot per entered digit, the caret on the next,
+                    a hairline after the fourth for the minimum. The value is
+                    never in the DOM; the live region reads the count. */}
+                <div
+                  className="pc-pin-slots"
+                  role="status"
+                  aria-live="polite"
+                  aria-labelledby="pc-pin-label"
+                  aria-label={`PIN: ${pin.length} of ${PIN_MAX} digits entered`}
+                  data-testid="pc-pin-slots"
+                >
+                  {Array.from({ length: PIN_MAX }, (_, i) => {
+                    const filled = i < pin.length;
+                    const active = i === pin.length;
+                    return (
+                      <span
+                        key={i}
+                        className={`pc-pin-slot${filled ? ' filled' : ''}${active ? ' active' : ''}${i === PIN_MIN - 1 ? ' min' : ''}`}
+                        aria-hidden="true"
+                      >
+                        {filled ? '\u25CF' : ''}
+                        {active && <span className="vc-caret" />}
+                      </span>
+                    );
+                  })}
+                </div>
+                <span className="pc-pin-hint">{PIN_MIN}–{PIN_MAX} digits</span>
+                <Keypad
                   value={pin}
-                  onChange={(e) => setPin(e.target.value)}
-                  maxLength={8}
-                  pattern="\d*"
-                  autoFocus
-                  required
+                  onKey={typeDigit}
+                  onBackspace={eraseDigit}
+                  canAccept={() => pin.length < PIN_MAX}
+                  className="pc-keypad"
                 />
               </div>
             )}
@@ -195,7 +249,7 @@ export default function PinChallengeModal({ open, onSuccess, onCancel }) {
                 <button
                   type="submit"
                   className="pc-btn primary"
-                  disabled={submitting || (requirePassword ? !password : !pin)}
+                  disabled={!canSubmit}
                 >{submitting ? 'Verifying…' : 'Verify'}</button>
               </div>
             </div>

--- a/frontend/src/components/auth/PinChallengeModal.test.jsx
+++ b/frontend/src/components/auth/PinChallengeModal.test.jsx
@@ -42,7 +42,12 @@ beforeEach(() => {
   onCancel.mockReset();
 });
 
-const pinInput = () => document.querySelector('input[type="password"]');
+const passwordInput = () => document.querySelector('input[type="password"]');
+// PIN mode has no text field: digits come from the on-screen pad (or a
+// hardware keyboard, see below).
+const tapPin = (digits) => {
+  for (const d of digits) fireEvent.click(screen.getByRole('button', { name: d }));
+};
 
 describe('PinChallengeModal', () => {
   it('renders nothing when closed', () => {
@@ -66,11 +71,44 @@ describe('PinChallengeModal', () => {
   it('verifies with a PIN and fires onSuccess', async () => {
     renderModal();
     fireEvent.click(await screen.findByText('Claude'));
-    fireEvent.change(pinInput(), { target: { value: '1234' } });
+    expect(document.querySelector('input')).toBeNull(); // no typeable field, nothing to autofill
+    tapPin('1234');
+    expect(screen.getByTestId('pc-pin-slots')).toHaveAttribute('aria-label', 'PIN: 4 of 8 digits entered');
     await act(async () => { fireEvent.click(screen.getByText('Verify')); });
 
     expect(selectUser).toHaveBeenCalledWith(1, '1234', null);
     expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('takes digits, Backspace and Enter from a hardware keyboard', async () => {
+    renderModal();
+    fireEvent.click(await screen.findByText('Claude'));
+    for (const k of ['1', '2', '3', '5', 'Backspace', '4']) fireEvent.keyDown(document, { key: k });
+    expect(screen.getByTestId('pc-pin-slots')).toHaveAttribute('aria-label', 'PIN: 4 of 8 digits entered');
+    await act(async () => { fireEvent.keyDown(document, { key: 'Enter' }); });
+    expect(selectUser).toHaveBeenCalledWith(1, '1234', null);
+  });
+
+  it('will not verify fewer than 4 digits, and caps at 8', async () => {
+    renderModal();
+    fireEvent.click(await screen.findByText('Claude'));
+    tapPin('123');
+    expect(screen.getByText('Verify')).toBeDisabled();
+    tapPin('456789');
+    expect(screen.getByTestId('pc-pin-slots')).toHaveAttribute('aria-label', 'PIN: 8 of 8 digits entered');
+    expect(screen.getByRole('button', { name: '9' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Backspace' })).toBeEnabled();
+  });
+
+  it('shows a rejected PIN (selectUser throws on 401) and clears the entry', async () => {
+    selectUser.mockRejectedValue(new Error('Invalid PIN'));
+    renderModal();
+    fireEvent.click(await screen.findByText('Claude'));
+    tapPin('0000');
+    await act(async () => { fireEvent.click(screen.getByText('Verify')); });
+    expect(await screen.findByText('Invalid PIN')).toBeInTheDocument();
+    expect(screen.getByTestId('pc-pin-slots')).toHaveAttribute('aria-label', 'PIN: 0 of 8 digits entered');
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 
   it('requires a password for a user without a PIN', async () => {
@@ -78,7 +116,7 @@ describe('PinChallengeModal', () => {
     renderModal();
     fireEvent.click(await screen.findByText('NoPin'));
     expect(screen.getByText('Password')).toBeInTheDocument(); // password label, not PIN
-    fireEvent.change(pinInput(), { target: { value: 'secret' } });
+    fireEvent.change(passwordInput(), { target: { value: 'secret' } });
     await act(async () => { fireEvent.click(screen.getByText('Verify')); });
 
     expect(selectUser).toHaveBeenCalledWith(2, null, 'secret');
@@ -88,7 +126,7 @@ describe('PinChallengeModal', () => {
     selectUser.mockResolvedValue({ success: false, requiresPassword: true });
     renderModal();
     fireEvent.click(await screen.findByText('Claude'));
-    fireEvent.change(pinInput(), { target: { value: '1234' } });
+    tapPin('1234');
     await act(async () => { fireEvent.click(screen.getByText('Verify')); });
 
     expect(await screen.findByText('Password')).toBeInTheDocument();
@@ -100,7 +138,7 @@ describe('PinChallengeModal', () => {
     selectUser.mockResolvedValue({ success: false, error: 'Invalid PIN' });
     renderModal();
     fireEvent.click(await screen.findByText('Claude'));
-    fireEvent.change(pinInput(), { target: { value: '0000' } });
+    tapPin('0000');
     await act(async () => { fireEvent.click(screen.getByText('Verify')); });
 
     expect(await screen.findByText('Invalid PIN')).toBeInTheDocument();

--- a/frontend/src/components/auth/pin-challenge.css
+++ b/frontend/src/components/auth/pin-challenge.css
@@ -154,7 +154,56 @@
   border-color: var(--vc-data-live);
   box-shadow: 0 0 0 1px var(--vc-data-live);
 }
-.pc-input.pin { text-align: center; font-size: 20px; letter-spacing: 0.5em; }
+
+/* PIN entry: masked slots over the shared vc keypad (components/vc/keypad.css). */
+.pc-pin { display: flex; flex-direction: column; }
+.pc-pin-slots {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 52px;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--vc-line-strong);
+  border-radius: 8px;
+  background: var(--vc-bg-base);
+}
+.pc-pin-slot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 32px;
+  border-bottom: 2px solid var(--vc-line-hairline);
+  font-family: var(--vc-font-mono);
+  font-size: 18px;
+  line-height: 1;
+  color: var(--vc-text-primary);
+}
+.pc-pin-slot.filled { border-bottom-color: var(--vc-text-secondary); }
+.pc-pin-slot.active { border-bottom-color: var(--vc-data-live); }
+/* the minimum: a hairline after the fourth slot */
+.pc-pin-slot.min { margin-right: 0.35rem; position: relative; }
+.pc-pin-slot.min::after {
+  content: '';
+  position: absolute;
+  right: -0.35rem;
+  top: 4px;
+  bottom: 4px;
+  width: 1px;
+  background: var(--vc-line-hairline);
+}
+.pc-pin-hint {
+  margin-top: 0.35rem;
+  font-family: var(--vc-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vc-text-tertiary);
+  text-align: center;
+}
+.pc-pin .vc-keypad { margin: 0.6rem 0 0; }
+.pc-pin .vc-key { min-height: 48px; font-size: 20px; }
 
 .pc-actions {
   display: flex;

--- a/frontend/src/components/vc/Keypad.jsx
+++ b/frontend/src/components/vc/Keypad.jsx
@@ -1,0 +1,62 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// The vc on-screen number pad. Owns no state: the parent holds the string and
+// decides what a tap means (`onKey(char)` / `onBackspace()`); `canAccept(char)`
+// lets it grey out keys that would overflow the field. Used by the vitals
+// capture sheet (digits + optional decimal) and the caregiver PIN challenge
+// (digits only, 4–8).
+import { BackspaceIcon } from '../Icons';
+import './keypad.css';
+
+const KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+export default function Keypad({
+  value = '',
+  onKey,
+  onBackspace,
+  canAccept = () => true,
+  showDecimal = false,
+  className = '',
+}) {
+  return (
+    <div className={`vc-keypad${className ? ` ${className}` : ''}`} role="group" aria-label="Number pad">
+      {KEYS.map((k) => (
+        <button key={k} type="button" className="vc-key" aria-label={k}
+                disabled={!canAccept(k)} onClick={() => onKey(k)}>
+          {k}
+        </button>
+      ))}
+      {showDecimal ? (
+        <button type="button" className="vc-key" aria-label="Decimal point"
+                disabled={!canAccept('.')} onClick={() => onKey('.')}>
+          .
+        </button>
+      ) : (
+        <span className="vc-key" aria-hidden="true" />
+      )}
+      <button type="button" className="vc-key" aria-label="0"
+              disabled={!canAccept('0')} onClick={() => onKey('0')}>
+        0
+      </button>
+      <button type="button" className="vc-key" aria-label="Backspace"
+              disabled={!value} onClick={onBackspace}>
+        <BackspaceIcon size={22} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/vc/keypad.css
+++ b/frontend/src/components/vc/keypad.css
@@ -1,0 +1,63 @@
+/*
+ * Smart Home Health
+ * Copyright (C) 2026 John Carty
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/* vc number pad + the blinking entry caret that pairs with it. Moved out of
+ * capture.css so the PIN challenge can share them; rendered outside the .tw
+ * island, so the key resets its own button chrome. */
+@import '../../styles/vc-tokens.css';
+
+.vc-keypad {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--vc-line-hairline);
+  border: 1px solid var(--vc-line-hairline);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 0.4rem 0 0.8rem;
+}
+.vc-key {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--vc-bg-sheet);
+  border: none;
+  padding: 0;
+  color: var(--vc-text-primary);
+  font-family: var(--vc-font-mono);
+  font-size: 22px;
+  min-height: 52px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.vc-key:active { background: var(--vc-bg-raised); }
+.vc-key:disabled { color: var(--vc-text-tertiary); cursor: default; }
+
+.vc-caret {
+  display: inline-block;
+  width: 2px;
+  height: 0.85em;
+  background: var(--vc-data-live);
+  margin-left: 2px;
+  vertical-align: baseline;
+  animation: vc-caret-blink 1.1s steps(1) infinite;
+}
+@keyframes vc-caret-blink { 50% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .vc-caret { animation: none; }
+}

--- a/frontend/src/pages/capture/capture.css
+++ b/frontend/src/pages/capture/capture.css
@@ -476,17 +476,6 @@
 .vc-hero.bp .vc-hero-field { font-size: 32px; }
 .vc-hero.bp .vc-hero-field.vc-placeholder { letter-spacing: 0.04em; }
 
-/* Caret */
-.vc-caret {
-  display: inline-block;
-  width: 2px;
-  height: 0.85em;
-  background: var(--vc-data-live);
-  margin-left: 2px;
-  vertical-align: baseline;
-  animation: vc-caret-blink 1.1s steps(1) infinite;
-}
-@keyframes vc-caret-blink { 50% { opacity: 0; } }
 
 /* Warning / block banners */
 .vc-band {
@@ -518,32 +507,7 @@
 }
 .vc-band.block .vc-band-title, .vc-band.block svg { color: var(--vc-state-alert); }
 
-/* ---------- Keypad ---------- */
-.vc-keypad {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  background: var(--vc-line-hairline);
-  border: 1px solid var(--vc-line-hairline);
-  border-radius: 8px;
-  overflow: hidden;
-  margin: 0.4rem 0 0.8rem;
-}
-.vc-key {
-  background: var(--vc-bg-sheet);
-  border: none;
-  padding: 0;
-  color: var(--vc-text-primary);
-  font-family: var(--vc-font-mono);
-  font-size: 22px;
-  min-height: 52px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.vc-key:active { background: var(--vc-bg-raised); }
-.vc-key:disabled { color: var(--vc-text-tertiary); cursor: default; }
+/* Keypad + caret live in components/vc/keypad.css (shared with the PIN challenge). */
 
 /* Sheet actions */
 .vc-sheet-actions {
@@ -646,7 +610,6 @@
   .vc-sheet[data-state='open'],
   .vc-sheet-overlay[data-state='open'],
   .vc-toast { animation: vc-fade-in 1ms linear; }
-  .vc-caret { animation: none; }
 }
 
 /* ---- Docked in the live dashboard --------------------------------------

--- a/frontend/src/pages/capture/components/Keypad.jsx
+++ b/frontend/src/pages/capture/components/Keypad.jsx
@@ -15,61 +15,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-// Card-driven numeric keypad. The decimal key renders only when the active
-// field allows decimals (spec §4.1) and keypresses that would exceed the
-// field's digit budget are blocked at input time, not errored later.
-import { BackspaceIcon } from '../../../components/Icons';
+// Card-driven numeric keypad for the capture sheet: the shared vc Keypad with
+// the active field's digit budget applied (spec §4.1) — the decimal key shows
+// only when the field allows decimals, and keys that would overflow are
+// blocked at input time, not errored later.
+import Keypad from '../../../components/vc/Keypad';
 import { acceptKey } from '../vitalConfigs';
 
-const KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
-
-export default function Keypad({ value, field, onKey, onBackspace }) {
-  const showDecimal = field.maxDecimals > 0;
+export default function CaptureKeypad({ value, field, onKey, onBackspace }) {
   return (
-    <div className="vc-keypad" role="group" aria-label="Number pad">
-      {KEYS.map((k) => (
-        <button
-          key={k}
-          type="button"
-          className="vc-key"
-          aria-label={k}
-          disabled={!acceptKey(value, k, field)}
-          onClick={() => onKey(k)}
-        >
-          {k}
-        </button>
-      ))}
-      {showDecimal ? (
-        <button
-          type="button"
-          className="vc-key"
-          aria-label="Decimal point"
-          disabled={!acceptKey(value, '.', field)}
-          onClick={() => onKey('.')}
-        >
-          .
-        </button>
-      ) : (
-        <span className="vc-key" aria-hidden="true" />
-      )}
-      <button
-        type="button"
-        className="vc-key"
-        aria-label="0"
-        disabled={!acceptKey(value, '0', field)}
-        onClick={() => onKey('0')}
-      >
-        0
-      </button>
-      <button
-        type="button"
-        className="vc-key"
-        aria-label="Backspace"
-        disabled={!value}
-        onClick={onBackspace}
-      >
-        <BackspaceIcon size={22} />
-      </button>
-    </div>
+    <Keypad
+      value={value}
+      onKey={onKey}
+      onBackspace={onBackspace}
+      canAccept={(k) => acceptKey(value, k, field)}
+      showDecimal={field.maxDecimals > 0}
+    />
   );
 }


### PR DESCRIPTION
## What

- `components/vc/Keypad.jsx` + `keypad.css` — the capture sheet's number pad, lifted into a shared vc component (`value / onKey / onBackspace / canAccept / showDecimal`). `pages/capture/components/Keypad.jsx` is now a thin wrapper applying the field's digit budget; `.vc-keypad/.vc-key/.vc-caret` rules move out of `capture.css`.
- `components/auth/PinChallengeModal.jsx`: the PIN step is eight masked slots (dot per digit, caret on the next, hairline after the 4th for the minimum; value never in the DOM, `aria-live` announces the count) over the shared pad. Hardware keyboard still works (digits / Backspace / Enter). Verify enables at 4 digits, 9th digit blocked. Password mode unchanged.
- **Bug fix:** `selectUser` throws on a 401; `handleSubmit` had `finally` but no `catch`, so a wrong PIN showed nothing. Now surfaces the error and clears the entry.

## Tests

`PinChallengeModal.test.jsx` rewritten to drive the pad by its keys (+ keyboard path, 4–8 bounds, thrown-401 case) — 11 green; capture-sheet tests unchanged and green. Lint clean; full suite 103 files / 1,233 tests.

## Verified

Playwright `/live` with the freshness window fast-forwarded: challenge at the narrow dock (1440) and on a phone (390) — picker, empty pad, digits tapped, digits typed; `/capture` sheet keypad unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vgpstiNy2SiLZt6ALkKYW